### PR TITLE
feat(mongodb): enable replicaset on single instance

### DIFF
--- a/charts/dependency/mongodb/Chart.yaml
+++ b/charts/dependency/mongodb/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://www.mongodb.com
 type: application
-version: 0.0.17
+version: 0.1.0
 annotations:
   truecharts.org/catagories: |
     - database

--- a/charts/dependency/mongodb/questions.yaml
+++ b/charts/dependency/mongodb/questions.yaml
@@ -124,12 +124,6 @@ questions:
     schema:
       type: string
       default: ""
-  - variable: mongodbAdvertisedHostname
-    group: "App Configuration"
-    label: "Advertised Hostname"
-    schema:
-      type: string
-      default: ""
 
   - variable: service
     group: "Networking and Services"

--- a/charts/dependency/mongodb/questions.yaml
+++ b/charts/dependency/mongodb/questions.yaml
@@ -97,6 +97,39 @@ questions:
       type: string
       default: ""
       required: true
+  - variable: mongodbReplicasetName
+    group: "App Configuration"
+    label: "Replicaset Name"
+    schema:
+      type: string
+      default: ""
+  - variable: mongodbReplicasetMode
+    group: "App Configuration"
+    label: "Replicaset Mode"
+    schema:
+      type: string
+      default: ""
+      enum:
+        - value: "primary"
+          description: "primary"
+        - value: "secondary"
+          description: "secondary"
+        - value: "arbiter"
+          description: "arbiter"
+        - value: "hidden"
+          description: "hidden"
+  - variable: mongodbReplicasetKey
+    group: "App Configuration"
+    label: "Replicaset Key"
+    schema:
+      type: string
+      default: ""
+  - variable: mongodbAdvertisedHostname
+    group: "App Configuration"
+    label: "Advertised Hostname"
+    schema:
+      type: string
+      default: ""
 
   - variable: service
     group: "Networking and Services"

--- a/charts/dependency/mongodb/templates/secret.yaml
+++ b/charts/dependency/mongodb/templates/secret.yaml
@@ -10,6 +10,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  mongodb-password: {{ printf "%v,%v" (( .Values.mongodbPassword | default "empty" ) | b64enc | quote ) (( .Values.mongodbPassword | default "empty" ) | b64enc | quote ) }}
+  mongodb-password: {{ ( .Values.mongodbPassword | default "empty" ) | b64enc | quote  }}
   mongodb-root-password: {{ ( .Values.mongodbRootPassword | default "empty" ) | b64enc | quote }}
   mongodb-replicaset-key: {{ ( .Values.mongodbReplicasetKey | default "empty" ) | b64enc | quote }}

--- a/charts/dependency/mongodb/templates/secret.yaml
+++ b/charts/dependency/mongodb/templates/secret.yaml
@@ -12,3 +12,4 @@ type: Opaque
 data:
   mongodb-password: {{ ( .Values.mongodbPassword | default "empty" ) | b64enc | quote }}
   mongodb-root-password: {{ ( .Values.mongodbRootPassword | default "empty" ) | b64enc | quote }}
+  mongodb-replicaset-key: {{ ( .Values.mongodbReplicasetKey | default "empty" ) | b64enc | quote }}

--- a/charts/dependency/mongodb/templates/secret.yaml
+++ b/charts/dependency/mongodb/templates/secret.yaml
@@ -10,6 +10,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  mongodb-password: {{ printf %v,%v (( .Values.mongodbPassword | default "empty" ) | b64enc | quote) (( .Values.mongodbPassword | default "empty" ) | b64enc | quote) }}
+  mongodb-password: {{ (( .Values.mongodbPassword | default "empty" ) | b64enc | quote)","(( .Values.mongodbPassword | default "empty" ) | b64enc | quote) }}
   mongodb-root-password: {{ ( .Values.mongodbRootPassword | default "empty" ) | b64enc | quote }}
   mongodb-replicaset-key: {{ ( .Values.mongodbReplicasetKey | default "empty" ) | b64enc | quote }}

--- a/charts/dependency/mongodb/templates/secret.yaml
+++ b/charts/dependency/mongodb/templates/secret.yaml
@@ -10,6 +10,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  mongodb-password: {{ ( .Values.mongodbPassword | default "empty" ) | b64enc | quote }}
+  mongodb-password: {{ printf %v,%v (( .Values.mongodbPassword | default "empty" ) | b64enc | quote) (( .Values.mongodbPassword | default "empty" ) | b64enc | quote) }}
   mongodb-root-password: {{ ( .Values.mongodbRootPassword | default "empty" ) | b64enc | quote }}
   mongodb-replicaset-key: {{ ( .Values.mongodbReplicasetKey | default "empty" ) | b64enc | quote }}

--- a/charts/dependency/mongodb/templates/secret.yaml
+++ b/charts/dependency/mongodb/templates/secret.yaml
@@ -10,6 +10,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  mongodb-password: {{ printf "%v,%v" (( .Values.mongodbPassword | default "empty" ) | b64enc | quote) (( .Values.mongodbPassword | default "empty" ) | b64enc | quote) }}
+  mongodb-password: {{ printf "%v,%v" (( .Values.mongodbPassword | default "empty" ) | b64enc | quote ) (( .Values.mongodbPassword | default "empty" ) | b64enc | quote ) }}
   mongodb-root-password: {{ ( .Values.mongodbRootPassword | default "empty" ) | b64enc | quote }}
   mongodb-replicaset-key: {{ ( .Values.mongodbReplicasetKey | default "empty" ) | b64enc | quote }}

--- a/charts/dependency/mongodb/templates/secret.yaml
+++ b/charts/dependency/mongodb/templates/secret.yaml
@@ -10,6 +10,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  mongodb-password: {{ (( .Values.mongodbPassword | default "empty" ) | b64enc | quote)","(( .Values.mongodbPassword | default "empty" ) | b64enc | quote) }}
+  mongodb-password: {{ printf "%v,%v" (( .Values.mongodbPassword | default "empty" ) | b64enc | quote) (( .Values.mongodbPassword | default "empty" ) | b64enc | quote) }}
   mongodb-root-password: {{ ( .Values.mongodbRootPassword | default "empty" ) | b64enc | quote }}
   mongodb-replicaset-key: {{ ( .Values.mongodbReplicasetKey | default "empty" ) | b64enc | quote }}

--- a/charts/dependency/mongodb/values.yaml
+++ b/charts/dependency/mongodb/values.yaml
@@ -102,7 +102,6 @@ mongodbRootPassword: "testroot"
 mongodbReplicasetName: "rs0"
 mongodbReplicasetMode: "primary"
 mongodbReplicasetKey: "replicakey"
-mongodbAdvertisedHostname: "rs0-primary"
 existingSecret: ""
 
 envValueFrom:
@@ -122,6 +121,5 @@ envValueFrom:
 env:
   MONGODB_USERNAME: "{{ .Values.mongodbUsername }}"
   MONGODB_DATABASE: "{{ .Values.mongodbDatabase }}"
-  MONGODB_ADVERTISED_HOSTNAME: "{{ .Values.mongodbAdvertisedHostname }}"
   MONGODB_REPLICA_SET_NAME: "{{ .Values.mongodbReplicasetName | default \"rs0\" }}"
   MONGODB_REPLICA_SET_MODE: "{{ .Values.mongodbReplicasetMode | default \"primary\" }}"

--- a/charts/dependency/mongodb/values.yaml
+++ b/charts/dependency/mongodb/values.yaml
@@ -107,7 +107,7 @@ existingSecret: ""
 envValueFrom:
   MONGODB_EXTRA_PASSWORDS:
     secretKeyRef:
-      name: '{{ ( tpl .Values.existingSecret $ ) | default ( include "common.names.fullname" . ) }},{{ ( tpl .Values.existingSecret $ ) | default ( include "common.names.fullname" . ) }}'
+      name: '{{ ( tpl .Values.existingSecret $ ) | default ( include "common.names.fullname" . ) }}'
       key: "mongodb-password"
   MONGODB_ROOT_PASSWORD:
     secretKeyRef:
@@ -119,7 +119,7 @@ envValueFrom:
       key: "mongodb-replicaset-key"
 
 env:
-  MONGODB_EXTRA_USERNAMES: "{{ .Values.mongodbUsername }},{{ .Values.mongodbUsername }}"
-  MONGODB_EXTRA_DATABASES: "{{ .Values.mongodbDatabase }},local"
+  MONGODB_EXTRA_USERNAMES: "{{ printf %v,%v .Values.mongodbUsername .Values.mongodbUsername }}"
+  MONGODB_EXTRA_DATABASES: "{{ printf %v,%v .Values.mongodbDatabase \"local\" }}"
   MONGODB_REPLICA_SET_NAME: "{{ .Values.mongodbReplicasetName | default \"rs0\" }}"
   MONGODB_REPLICA_SET_MODE: "{{ .Values.mongodbReplicasetMode | default \"primary\" }}"

--- a/charts/dependency/mongodb/values.yaml
+++ b/charts/dependency/mongodb/values.yaml
@@ -99,6 +99,10 @@ mongodbPassword: "testpass"
 mongodbUsername: "test"
 mongodbDatabase: "test"
 mongodbRootPassword: "testroot"
+mongodbReplicasetName: "rs0"
+mongodbReplicasetMode: "primary"
+mongodbReplicasetKey: "replicakey"
+mongodbAdvertisedHostname: "{{ printf \"%v-%v\" .Release.Name .Values.mongodbReplicasetMode }}"
 existingSecret: ""
 
 envValueFrom:
@@ -110,7 +114,14 @@ envValueFrom:
     secretKeyRef:
       name: '{{ ( tpl .Values.existingSecret $ ) | default ( include "common.names.fullname" . ) }}'
       key: "mongodb-root-password"
+  MONGODB_REPLICA_SET_KEY:
+    secretKeyRef:
+      name: '{{ ( tpl .Values.existingSecret $ ) | default ( include "common.names.fullname" . ) }}'
+      key: "mongodb-replicaset-key"
 
 env:
   MONGODB_USERNAME: "{{ .Values.mongodbUsername }}"
   MONGODB_DATABASE: "{{ .Values.mongodbDatabase }}"
+  MONGODB_ADVERTISED_HOSTNAME: "{{ .Values.mongodbAdvertisedHostname }}"
+  MONGODB_REPLICA_SET_NAME: "{{ .Values.mongodbReplicasetName | default \"rs0\" }}"
+  MONGODB_REPLICA_SET_MODE: "{{ .Values.mongodbReplicasetMode | default \"primary\" }}"

--- a/charts/dependency/mongodb/values.yaml
+++ b/charts/dependency/mongodb/values.yaml
@@ -35,7 +35,7 @@ securityContext:
   readOnlyRootFilesystem: false
 
 podSecurityContext:
-  runAsGroup: 0
+  runAsGroup: 1001
 
 volumeClaimTemplates:
   data:

--- a/charts/dependency/mongodb/values.yaml
+++ b/charts/dependency/mongodb/values.yaml
@@ -119,7 +119,7 @@ envValueFrom:
       key: "mongodb-replicaset-key"
 
 env:
-  MONGODB_EXTRA_USERNAMES: "{{ printf %v,%v .Values.mongodbUsername .Values.mongodbUsername }}"
-  MONGODB_EXTRA_DATABASES: "{{ printf %v,%v .Values.mongodbDatabase \"local\" }}"
+  MONGODB_EXTRA_USERNAMES: "{{ printf \"%v,%v\" .Values.mongodbUsername .Values.mongodbUsername }}"
+  MONGODB_EXTRA_DATABASES: "{{ printf \"%v,%v\" .Values.mongodbDatabase \"local\" }}"
   MONGODB_REPLICA_SET_NAME: "{{ .Values.mongodbReplicasetName | default \"rs0\" }}"
   MONGODB_REPLICA_SET_MODE: "{{ .Values.mongodbReplicasetMode | default \"primary\" }}"

--- a/charts/dependency/mongodb/values.yaml
+++ b/charts/dependency/mongodb/values.yaml
@@ -102,7 +102,7 @@ mongodbRootPassword: "testroot"
 mongodbReplicasetName: "rs0"
 mongodbReplicasetMode: "primary"
 mongodbReplicasetKey: "replicakey"
-mongodbAdvertisedHostname: "{{ printf \"%v-%v\" .Release.Name .Values.mongodbReplicasetMode }}"
+mongodbAdvertisedHostname: "rs0-primary"
 existingSecret: ""
 
 envValueFrom:

--- a/charts/dependency/mongodb/values.yaml
+++ b/charts/dependency/mongodb/values.yaml
@@ -105,9 +105,9 @@ mongodbReplicasetKey: "replicakey"
 existingSecret: ""
 
 envValueFrom:
-  MONGODB_PASSWORD:
+  MONGODB_EXTRA_PASSWORDS:
     secretKeyRef:
-      name: '{{ ( tpl .Values.existingSecret $ ) | default ( include "common.names.fullname" . ) }}'
+      name: '{{ ( tpl .Values.existingSecret $ ) | default ( include "common.names.fullname" . ) }},{{ ( tpl .Values.existingSecret $ ) | default ( include "common.names.fullname" . ) }}'
       key: "mongodb-password"
   MONGODB_ROOT_PASSWORD:
     secretKeyRef:
@@ -119,7 +119,7 @@ envValueFrom:
       key: "mongodb-replicaset-key"
 
 env:
-  MONGODB_USERNAME: "{{ .Values.mongodbUsername }}"
-  MONGODB_DATABASE: "{{ .Values.mongodbDatabase }}"
+  MONGODB_EXTRA_USERNAMES: "{{ .Values.mongodbUsername }},{{ .Values.mongodbUsername }}"
+  MONGODB_EXTRA_DATABASES: "{{ .Values.mongodbDatabase }},local"
   MONGODB_REPLICA_SET_NAME: "{{ .Values.mongodbReplicasetName | default \"rs0\" }}"
   MONGODB_REPLICA_SET_MODE: "{{ .Values.mongodbReplicasetMode | default \"primary\" }}"

--- a/charts/dependency/mongodb/values.yaml
+++ b/charts/dependency/mongodb/values.yaml
@@ -109,6 +109,10 @@ envValueFrom:
     secretKeyRef:
       name: '{{ ( tpl .Values.existingSecret $ ) | default ( include "common.names.fullname" . ) }}'
       key: "mongodb-password"
+  MONGODB_PASSWORD:
+    secretKeyRef:
+      name: '{{ ( tpl .Values.existingSecret $ ) | default ( include "common.names.fullname" . ) }}'
+      key: "mongodb-password"
   MONGODB_ROOT_PASSWORD:
     secretKeyRef:
       name: '{{ ( tpl .Values.existingSecret $ ) | default ( include "common.names.fullname" . ) }}'
@@ -119,7 +123,9 @@ envValueFrom:
       key: "mongodb-replicaset-key"
 
 env:
-  MONGODB_EXTRA_USERNAMES: "{{ printf \"%v,%v\" .Values.mongodbUsername .Values.mongodbUsername }}"
-  MONGODB_EXTRA_DATABASES: "{{ printf \"%v,%v\" .Values.mongodbDatabase \"local\" }}"
+  MONGODB_DATABASE: "{{ .Values.mongodbDatabase }}"
+  MONGODB_USERNAME: "{{ .Values.mongodbUsername }}"
+  MONGODB_EXTRA_USERNAMES: "{{ .Values.mongodbUsername }}"
+  MONGODB_EXTRA_DATABASES: "local"
   MONGODB_REPLICA_SET_NAME: "{{ .Values.mongodbReplicasetName | default \"rs0\" }}"
   MONGODB_REPLICA_SET_MODE: "{{ .Values.mongodbReplicasetMode | default \"primary\" }}"


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

Some apps require OPLOG access to mongodb (eg Rocket.Chat), which is only offered (AFAIK) when it's configured as replicaset.
While we don't have any support for scaling currently, we can enable a single instance replicaset which should give the needed access to OPLOG

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
