### PR TITLE
feat(Traefik) add support for forwarded headers

### DIFF
--- a/charts/core/traefik/Chart.yaml
+++ b/charts/core/traefik/Chart.yaml
@@ -22,7 +22,7 @@ sources:
 - https://github.com/traefik/traefik-helm-chart
 - https://traefik.io/
 type: application
-version: 11.1.9
+version: 11.2.0
 annotations:
   truecharts.org/catagories: |
     - network

--- a/charts/core/traefik/Chart.yaml
+++ b/charts/core/traefik/Chart.yaml
@@ -22,7 +22,7 @@ sources:
 - https://github.com/traefik/traefik-helm-chart
 - https://traefik.io/
 type: application
-version: 11.1.8
+version: 11.1.9
 annotations:
   truecharts.org/catagories: |
     - network

--- a/charts/core/traefik/questions.yaml
+++ b/charts/core/traefik/questions.yaml
@@ -551,38 +551,6 @@ questions:
                                     required: true
                                     default: ""
 
-  - variable: forwardedHeaders
-    label: "Accept Forwarded Headers"
-    group: "App Configuration"
-    schema:
-      additional_attrs: true
-      type: dict
-      attrs:
-        - variable: enabled
-          label: "Enable"
-          schema:
-            type: boolean
-            default: false
-            show_subquestions_if: true
-            subquestions:
-              - variable: trustedIPs
-                label: "Trusted IPs"
-                schema:
-                  type: list
-                  default: []
-                  items:
-                    - variable: trustedIPsEntry
-                      label: ""
-                      schema:
-                        type: ipaddr
-                        required: true
-                        default: ""
-              - variable: insecureMode
-                label: "Insecure Mode"
-                schema:
-                  type: boolean
-                  default: false
-
   - variable: service
     group: "Networking and Services"
     label: "Configure Service Entrypoint"
@@ -638,6 +606,36 @@ questions:
                                   schema:
                                     type: int
                                     default: 9000
+                          - variable: forwardedHeaders
+                            label: "Accept Forwarded Headers"
+                            schema:
+                              additional_attrs: true
+                              type: dict
+                              attrs:
+                                - variable: enabled
+                                  label: "Enable"
+                                  schema:
+                                    type: boolean
+                                    default: false
+                                    show_subquestions_if: true
+                                    subquestions:
+                                      - variable: trustedIPs
+                                        label: "Trusted IPs"
+                                        schema:
+                                          type: list
+                                          default: []
+                                          items:
+                                            - variable: trustedIPsEntry
+                                              label: ""
+                                              schema:
+                                                type: ipaddr
+                                                required: true
+                                                default: ""
+                                      - variable: insecureMode
+                                        label: "Insecure Mode"
+                                        schema:
+                                          type: boolean
+                                          default: false
 
                           - variable: port
                             label: "Entrypoints Port"
@@ -707,6 +705,36 @@ questions:
                                   schema:
                                     type: string
                                     default: "websecure"
+                          - variable: forwardedHeaders
+                            label: "Accept Forwarded Headers"
+                            schema:
+                              additional_attrs: true
+                              type: dict
+                              attrs:
+                                - variable: enabled
+                                  label: "Enable"
+                                  schema:
+                                    type: boolean
+                                    default: false
+                                    show_subquestions_if: true
+                                    subquestions:
+                                      - variable: trustedIPs
+                                        label: "Trusted IPs"
+                                        schema:
+                                          type: list
+                                          default: []
+                                          items:
+                                            - variable: trustedIPsEntry
+                                              label: ""
+                                              schema:
+                                                type: ipaddr
+                                                required: true
+                                                default: ""
+                                      - variable: insecureMode
+                                        label: "Insecure Mode"
+                                        schema:
+                                          type: boolean
+                                          default: false
                     - variable: websecure
                       label: "websecure Entrypoints Configuration"
                       schema:
@@ -760,6 +788,36 @@ questions:
                                   label: "Redirect to Entrypoint"
                                   schema:
                                     type: string
+                          - variable: forwardedHeaders
+                            label: "Accept Forwarded Headers"
+                            schema:
+                              additional_attrs: true
+                              type: dict
+                              attrs:
+                                - variable: enabled
+                                  label: "Enable"
+                                  schema:
+                                    type: boolean
+                                    default: false
+                                    show_subquestions_if: true
+                                    subquestions:
+                                      - variable: trustedIPs
+                                        label: "Trusted IPs"
+                                        schema:
+                                          type: list
+                                          default: []
+                                          items:
+                                            - variable: trustedIPsEntry
+                                              label: ""
+                                              schema:
+                                                type: ipaddr
+                                                required: true
+                                                default: ""
+                                      - variable: insecureMode
+                                        label: "Insecure Mode"
+                                        schema:
+                                          type: boolean
+                                          default: false
                           - variable: tls
                             label: "websecure Entrypoints Configuration"
                             schema:
@@ -832,6 +890,36 @@ questions:
                                   label: "Redirect to Entrypoint"
                                   schema:
                                     type: string
+                          - variable: forwardedHeaders
+                            label: "Accept Forwarded Headers"
+                            schema:
+                              additional_attrs: true
+                              type: dict
+                              attrs:
+                                - variable: enabled
+                                  label: "Enable"
+                                  schema:
+                                    type: boolean
+                                    default: false
+                                    show_subquestions_if: true
+                                    subquestions:
+                                      - variable: trustedIPs
+                                        label: "Trusted IPs"
+                                        schema:
+                                          type: list
+                                          default: []
+                                          items:
+                                            - variable: trustedIPsEntry
+                                              label: ""
+                                              schema:
+                                                type: ipaddr
+                                                required: true
+                                                default: ""
+                                      - variable: insecureMode
+                                        label: "Insecure Mode"
+                                        schema:
+                                          type: boolean
+                                          default: false
   - variable: ingress
     label: ""
     group: "Ingress"

--- a/charts/core/traefik/questions.yaml
+++ b/charts/core/traefik/questions.yaml
@@ -606,36 +606,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 9000
-                          - variable: forwardedHeaders
-                            label: "Accept Forwarded Headers"
-                            schema:
-                              additional_attrs: true
-                              type: dict
-                              attrs:
-                                - variable: enabled
-                                  label: "Enable"
-                                  schema:
-                                    type: boolean
-                                    default: false
-                                    show_subquestions_if: true
-                                    subquestions:
-                                      - variable: trustedIPs
-                                        label: "Trusted IPs"
-                                        schema:
-                                          type: list
-                                          default: []
-                                          items:
-                                            - variable: trustedIPsEntry
-                                              label: ""
-                                              schema:
-                                                type: ipaddr
-                                                required: true
-                                                default: ""
-                                      - variable: insecureMode
-                                        label: "Insecure Mode"
-                                        schema:
-                                          type: boolean
-                                          default: false
 
                           - variable: port
                             label: "Entrypoints Port"

--- a/charts/core/traefik/questions.yaml
+++ b/charts/core/traefik/questions.yaml
@@ -551,6 +551,37 @@ questions:
                                     required: true
                                     default: ""
 
+  - variable: forwardedHeaders
+    label: "Accept Forwarded Headers"
+    group: "App Configuration"
+    schema:
+      additional_attrs: true
+      type: dict
+      attrs:
+        - variable: enabled
+          label: "Enable"
+          schema:
+            type: boolean
+            default: false
+            show_subquestions_if: true
+            subquestions:
+              - variable: trustedIPs
+                label: "Trusted IPs"
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: trustedIPsEntry
+                      label: ""
+                      schema:
+                        type: ipaddr
+                        required: true
+                        default: ""
+              - variable: insecureMode
+                label: "Insecure Mode"
+                schema:
+                  type: boolean
+                  default: false
 
   - variable: service
     group: "Networking and Services"

--- a/charts/core/traefik/templates/_args.tpl
+++ b/charts/core/traefik/templates/_args.tpl
@@ -63,14 +63,13 @@ args:
   - "--providers.kubernetesingress.namespaces={{ template "providers.kubernetesIngress.namespaces" . }}"
   {{- end }}
   {{- end }}
-  {{/* store reference to forwardedHeaders config for application on all entrypoints */}}
-  {{- $forwardedHeaders := .Values.forwardedHeaders }}
   {{- range $entrypoint, $config := $ports }}
-  {{- if $forwardedHeaders.enabled }}
-  {{- if not ( empty $forwardedHeaders.trustedIPs ) }}
-  - "--entrypoints.{{ $entrypoint }}.forwardedHeaders.trustedIPs={{ join "," $forwardedHeaders.trustedIPs }}"
+  {{/* add args for forwardedHeaders support */}}
+  {{- if $config.forwardedHeaders.enabled }}
+  {{- if not ( empty $config.forwardedHeaders.trustedIPs ) }}
+  - "--entrypoints.{{ $entrypoint }}.forwardedHeaders.trustedIPs={{ join "," $config.forwardedHeaders.trustedIPs }}"
   {{- end }}
-  {{- if $forwardedHeaders.insecureMode }}
+  {{- if $config.forwardedHeaders.insecureMode }}
   - "--entrypoints.{{ $entrypoint }}.forwardedHeaders.insecure"
   {{- end }}
   {{- end }}

--- a/charts/core/traefik/templates/_args.tpl
+++ b/charts/core/traefik/templates/_args.tpl
@@ -63,7 +63,18 @@ args:
   - "--providers.kubernetesingress.namespaces={{ template "providers.kubernetesIngress.namespaces" . }}"
   {{- end }}
   {{- end }}
+  {{/* store reference to forwardedHeaders config for application on all entrypoints */}}
+  {{- $forwardedHeaders := .Values.forwardedHeaders }}
   {{- range $entrypoint, $config := $ports }}
+  {{- if $forwardedHeaders.enabled }}
+  {{- if not ( empty $forwardedHeaders.trustedIPs ) }}
+  - "--entrypoints.{{ $entrypoint }}.forwardedHeaders.trustedIPs={{ join "," $forwardedHeaders.trustedIPs }}"
+  {{- end }}
+  {{- if $forwardedHeaders.insecureMode }}
+  - "--entrypoints.{{ $entrypoint }}.forwardedHeaders.insecure"
+  {{- end }}
+  {{- end }}
+  {{/* end forwardedHeaders configuration */}}
   {{- if $config.redirectTo }}
   {{- $toPort := index $ports $config.redirectTo }}
   - "--entrypoints.{{ $entrypoint }}.http.redirections.entryPoint.to=:{{ $toPort.port }}"

--- a/charts/core/traefik/values.yaml
+++ b/charts/core/traefik/values.yaml
@@ -52,6 +52,14 @@ providers:
       # By default this Traefik service
       # pathOverride: ""
 
+# -- Configure (Forwarded Headers)[https://doc.traefik.io/traefik/routing/entrypoints/#forwarded-headers] Support
+forwardedHeaders:
+  enabled: false
+  # -- List of trusted IP and CIDR references
+  trustedIPs: []
+  # -- Trust all forwarded headers
+  insecureMode: false
+
 # -- Logs
 # https://docs.traefik.io/observability/logs/
 logs:

--- a/charts/core/traefik/values.yaml
+++ b/charts/core/traefik/values.yaml
@@ -146,13 +146,9 @@ service:
         port: 9000
         targetPort: 9000
         protocol: HTTP
-        # -- Configure (Forwarded Headers)[https://doc.traefik.io/traefik/routing/entrypoints/#forwarded-headers] Support
+        # -- Forwarded Headers should never be enabled on Main entrypoint
         forwardedHeaders:
           enabled: false
-          # -- List of trusted IP and CIDR references
-          trustedIPs: []
-          # -- Trust all forwarded headers
-          insecureMode: false
   tcp:
     enabled: true
     type: LoadBalancer
@@ -205,13 +201,9 @@ service:
         port: 9180
         targetPort: 9180
         protocol: HTTP
-        # -- Configure (Forwarded Headers)[https://doc.traefik.io/traefik/routing/entrypoints/#forwarded-headers] Support
+        # -- Forwarded Headers should never be enabled on Metrics entrypoint
         forwardedHeaders:
           enabled: false
-          # -- List of trusted IP and CIDR references
-          trustedIPs: []
-          # -- Trust all forwarded headers
-          insecureMode: false
   udp:
     enabled: false
 

--- a/charts/core/traefik/values.yaml
+++ b/charts/core/traefik/values.yaml
@@ -52,14 +52,6 @@ providers:
       # By default this Traefik service
       # pathOverride: ""
 
-# -- Configure (Forwarded Headers)[https://doc.traefik.io/traefik/routing/entrypoints/#forwarded-headers] Support
-forwardedHeaders:
-  enabled: false
-  # -- List of trusted IP and CIDR references
-  trustedIPs: []
-  # -- Trust all forwarded headers
-  insecureMode: false
-
 # -- Logs
 # https://docs.traefik.io/observability/logs/
 logs:
@@ -154,6 +146,13 @@ service:
         port: 9000
         targetPort: 9000
         protocol: HTTP
+        # -- Configure (Forwarded Headers)[https://doc.traefik.io/traefik/routing/entrypoints/#forwarded-headers] Support
+        forwardedHeaders:
+          enabled: false
+          # -- List of trusted IP and CIDR references
+          trustedIPs: []
+          # -- Trust all forwarded headers
+          insecureMode: false
   tcp:
     enabled: true
     type: LoadBalancer
@@ -163,12 +162,26 @@ service:
         port: 9080
         protocol: HTTP
         redirectTo: websecure
+        # -- Configure (Forwarded Headers)[https://doc.traefik.io/traefik/routing/entrypoints/#forwarded-headers] Support
+        forwardedHeaders:
+          enabled: false
+          # -- List of trusted IP and CIDR references
+          trustedIPs: []
+          # -- Trust all forwarded headers
+          insecureMode: false
         # Options: Empty, 0 (ingore), or positive int
         # redirectPort:
       websecure:
         enabled: true
         port: 9443
         protocol: HTTPS
+        # -- Configure (Forwarded Headers)[https://doc.traefik.io/traefik/routing/entrypoints/#forwarded-headers] Support
+        forwardedHeaders:
+          enabled: false
+          # -- List of trusted IP and CIDR references
+          trustedIPs: []
+          # -- Trust all forwarded headers
+          insecureMode: false
 #      tcpexample:
 #        enabled: true
 #        targetPort: 9443
@@ -192,6 +205,13 @@ service:
         port: 9180
         targetPort: 9180
         protocol: HTTP
+        # -- Configure (Forwarded Headers)[https://doc.traefik.io/traefik/routing/entrypoints/#forwarded-headers] Support
+        forwardedHeaders:
+          enabled: false
+          # -- List of trusted IP and CIDR references
+          trustedIPs: []
+          # -- Trust all forwarded headers
+          insecureMode: false
   udp:
     enabled: false
 
@@ -311,7 +331,7 @@ middlewares:
   redirectRegex: []
   # - name: redirectRegexName
   #   regex: putregexhere
-  #   replacement: replacementurlhere
+  #   replacement: repslacementurlhere
   #   permanent: false
   stripPrefixRegex: []
   # - name: stripPrefixRegexName


### PR DESCRIPTION
**Description**
[Forwarded Headers](https://doc.traefik.io/traefik/routing/entrypoints/#forwarded-headers) enables support for getting proper client IP when Traefik is behind another instance of Traefik or other proxy.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I have successfully deployed changes via forked `catalog` version to my TrueNAS SCALE instance for development and testing.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [X] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
