### PR TITLE
Fix broken home links in Chart.yaml files

### DIFF
--- a/charts/core/amd-gpu-plugin/Chart.yaml
+++ b/charts/core/amd-gpu-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "upstream"
 deprecated: false
 description: A kubernetes plugin to add AMD GPU's to Pods
-home: https://github.com/truecharts/apps/tree/master/charts/stable/amd-gpu-plugin
+home: https://github.com/truecharts/apps/tree/master/charts/core/amd-gpu-plugin
 icon: https://truecharts.org/_static/img/appicons/amd-gpu-plugin.png
 keywords:
 - amd

--- a/charts/core/docker-compose/Chart.yaml
+++ b/charts/core/docker-compose/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: Dedicated App for using Docker-Compose on TrueNAS SCALE
-home: https://github.com/truecharts/apps/tree/master/charts/dev/docker-compose
+home: https://github.com/truecharts/apps/tree/master/charts/core/docker-compose
 icon: https://truecharts.org/_static/img/appicons/docker-compose.png
 keywords:
 - docker-compose

--- a/charts/core/external-service/Chart.yaml
+++ b/charts/core/external-service/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: Allow external services to be used like Apps.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/external-service
+home: https://github.com/truecharts/apps/tree/master/charts/core/external-service
 icon: https://truecharts.org/_static/img/appicons/external-service.png
 keywords:
 - external-service

--- a/charts/core/k8s-gateway/Chart.yaml
+++ b/charts/core/k8s-gateway/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: A Helm chart for the k8s_gateway CoreDNS plugin
-home: https://github.com/truecharts/apps/tree/master/charts/stable/k8s-gateway
+home: https://github.com/truecharts/apps/tree/master/charts/core/k8s-gateway
 icon: https://truecharts.org/_static/img/appicons/k8s-gateway.png
 keywords:
 - DNS

--- a/charts/core/metallb/Chart.yaml
+++ b/charts/core/metallb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "upstream"
 deprecated: false
 description: A network load-balancer implementation for Kubernetes using standard routing protocols
-home: https://github.com/truecharts/apps/tree/master/charts/stable/metallb
+home: https://github.com/truecharts/apps/tree/master/charts/core/metallb
 icon: https://truecharts.org/_static/img/appicons/metallb.png
 keywords:
 - metallb

--- a/charts/core/prometheus/Chart.yaml
+++ b/charts/core/prometheus/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 deprecated: false
 description: kube-prometheus-stack collects Kubernetes manifests, Grafana dashboards, and Prometheus rules combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
 icon: https://truecharts.org/_static/img/appicons/prometheus.png
-home: https://github.com/truecharts/apps/tree/master/charts/stable/prometheus
+home: https://github.com/truecharts/apps/tree/master/charts/core/prometheus
 keywords:
 - metrics
 kubeVersion: '>=1.16.0-0'

--- a/charts/core/traefik/Chart.yaml
+++ b/charts/core/traefik/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: Traefik is a flexible reverse proxy and Ingress Provider.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/traefik
+home: https://github.com/truecharts/apps/tree/master/charts/core/traefik
 icon: https://truecharts.org/_static/img/appicons/traefik.png
 keywords:
 - traefik

--- a/charts/dependency/mariadb/Chart.yaml
+++ b/charts/dependency/mariadb/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.8
 deprecated: false
 description: Fast, reliable, scalable, and easy to use open-source relational database system.
-home: https://github.com/truecharts/apps/tree/master/stable/mariadb
+home: https://github.com/truecharts/apps/tree/master/charts/dependency/mariadb
 icon: https://truecharts.org/_static/img/appicons/mariadb.png
 keywords:
   - mariadb

--- a/charts/dependency/memcached/Chart.yaml
+++ b/charts/dependency/memcached/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.8
 deprecated: false
 description: Memcached is a memory-backed database caching solution
-home: https://github.com/truecharts/apps/tree/master/stable/memcached
+home: https://github.com/truecharts/apps/tree/master/charts/dependency/memcached
 icon: https://bitnami.com/assets/stacks/memcached/img/memcached-stack-220x234.png
 keywords:
 - memcached

--- a/charts/dependency/mongodb/Chart.yaml
+++ b/charts/dependency/mongodb/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.8
 deprecated: false
 description: Fast, reliable, scalable, and easy to use open-source no-sql database system.
-home: https://github.com/truecharts/apps/tree/master/stable/mongodb
+home: https://github.com/truecharts/apps/tree/master/charts/dependency/mongodb
 icon: https://truecharts.org/_static/img/appicons/mongodb.png
 keywords:
   - mongodb

--- a/charts/dependency/postgresql/Chart.yaml
+++ b/charts/dependency/postgresql/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.8
 deprecated: false
 description: PostgresSQL
-home: https://github.com/truecharts/apps/tree/master/stable/postgres
+home: https://github.com/truecharts/apps/tree/master/charts/dependency/postgresql
 icon: https://d1q6f0aelx0por.cloudfront.net/product-logos/library-postgres-logo.png
 keywords:
 - postgres

--- a/charts/dependency/promtail/Chart.yaml
+++ b/charts/dependency/promtail/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
 deprecated: false
 description: Promtail is an agent which ships the contents of local logs to a Loki instance
 icon: https://raw.githubusercontent.com/grafana/loki/master/docs/sources/logo.png
-home: https://github.com/truecharts/apps/tree/master/charts/stable/prometheus
+home: https://github.com/truecharts/apps/tree/master/charts/dependency/promtail
 keywords:
 - metrics
 - logs

--- a/charts/dependency/redis/Chart.yaml
+++ b/charts/dependency/redis/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.8
 deprecated: false
 description: Open source, advanced key-value store.
-home: https://github.com/truecharts/apps/tree/master/stable/redis
+home: https://github.com/truecharts/apps/tree/master/charts/dependency/redis
 icon: https://bitnami.com/assets/stacks/redis/img/redis-stack-220x234.png
 keywords:
   - redis

--- a/charts/dev/acestream/Chart.yaml
+++ b/charts/dev/acestream/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: "Acestream-engine\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/acestream
+home: https://github.com/truecharts/apps/tree/master/charts/dev/acestream
 icon: https://truecharts.org/_static/img/appicons/acestream.png
 keywords:
 - acestream

--- a/charts/dev/adguard-home/Chart.yaml
+++ b/charts/dev/adguard-home/Chart.yaml
@@ -16,7 +16,7 @@ description: "AdGuard Home is a network-wide software for blocking ads & trackin
   t need any client-side software for that. With the rise of Internet-Of-Things and\
   \ connected devices, it becomes more and more important to be able to control your\
   \ whole network."
-home: https://github.com/truecharts/apps/tree/master/charts/stable/adguard-home
+home: https://github.com/truecharts/apps/tree/master/charts/dev/adguard-home
 icon: https://truecharts.org/_static/img/appicons/adguard-home.png
 keywords:
 - adguard-home

--- a/charts/dev/adguardhome-sync/Chart.yaml
+++ b/charts/dev/adguardhome-sync/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 deprecated: false
 description: Adguardhome-sync(https://github.com/bakito/adguardhome-sync/) is a tool
   to synchronize AdGuardHome config to replica instances.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/adguardhome-sync
+home: https://github.com/truecharts/apps/tree/master/charts/dev/adguardhome-sync
 icon: https://truecharts.org/_static/img/appicons/adguardhome-sync.png
 keywords:
 - adguardhome-sync

--- a/charts/dev/adminer/Chart.yaml
+++ b/charts/dev/adminer/Chart.yaml
@@ -14,7 +14,7 @@ description: "Adminer (formerly phpMinAdmin) is a full-featured database managem
   \ tool written in PHP. Conversely to phpMyAdmin, it consist of a single file ready\
   \ to deploy to the target server. Adminer is available for MySQL, PostgreSQL, SQLite,\
   \ MS SQL, Oracle, Firebird, SimpleDB, Elasticsearch and MongoDB.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/adminer
+home: https://github.com/truecharts/apps/tree/master/charts/dev/adminer
 icon: https://truecharts.org/_static/img/appicons/adminer.png
 keywords:
 - adminer

--- a/charts/dev/alienswarm-reactivedrop/Chart.yaml
+++ b/charts/dev/alienswarm-reactivedrop/Chart.yaml
@@ -13,7 +13,7 @@ deprecated: false
 description: "This Docker will download and install SteamCMD. It will also install\
   \ Alien Swarm: Reactive Drop and run it. (!!!This container will only run on systems\
   \ with less than 32 CPU cores!!!) \r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/alienswarm-reactivedrop
+home: https://github.com/truecharts/apps/tree/master/charts/dev/alienswarm-reactivedrop
 icon: https://truecharts.org/_static/img/appicons/alienswarm-reactivedrop.png
 keywords:
 - alienswarm-reactivedrop

--- a/charts/dev/alienswarm/Chart.yaml
+++ b/charts/dev/alienswarm/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 deprecated: false
 description: "This Docker will download and install SteamCMD. It will also install\
   \ Alien Swarm and run it.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/alienswarm
+home: https://github.com/truecharts/apps/tree/master/charts/dev/alienswarm
 icon: https://truecharts.org/_static/img/appicons/alienswarm.png
 keywords:
 - alienswarm

--- a/charts/dev/altitude/Chart.yaml
+++ b/charts/dev/altitude/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: "This Docker will download and install Altitude and run it.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/altitude
+home: https://github.com/truecharts/apps/tree/master/charts/dev/altitude
 icon: https://truecharts.org/_static/img/appicons/altitude.png
 keywords:
 - altitude

--- a/charts/dev/ama/Chart.yaml
+++ b/charts/dev/ama/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 deprecated: false
 description: 'Automated Music Archiver :: This script will automatically archive music
   using a popular online DL Client'
-home: https://github.com/truecharts/apps/tree/master/charts/stable/ama
+home: https://github.com/truecharts/apps/tree/master/charts/dev/ama
 icon: https://truecharts.org/_static/img/appicons/ama.png
 keywords:
 - ama

--- a/charts/dev/ambd/Chart.yaml
+++ b/charts/dev/ambd/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 deprecated: false
 description: 'Automated MusicBrainz Downloader :: This script will automatically archive
   music using a popular online DL Client'
-home: https://github.com/truecharts/apps/tree/master/charts/stable/ambd
+home: https://github.com/truecharts/apps/tree/master/charts/dev/ambd
 icon: https://truecharts.org/_static/img/appicons/ambd.png
 keywords:
 - ambd

--- a/charts/dev/americasarmy-pg/Chart.yaml
+++ b/charts/dev/americasarmy-pg/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 deprecated: false
 description: "This Docker will download and install SteamCMD. It will also install\
   \ America's Army: Proving Grounds and run it.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/americasarmy-pg
+home: https://github.com/truecharts/apps/tree/master/charts/dev/americasarmy-pg
 icon: https://truecharts.org/_static/img/appicons/americasarmy-pg.png
 keywords:
 - americasarmy-pg

--- a/charts/dev/amtd/Chart.yaml
+++ b/charts/dev/amtd/Chart.yaml
@@ -15,7 +15,7 @@ description: 'Automated Movie Trailer Downloader :: AMTD is a Radarr Companion s
   to automatically download movie trailers for use in media applications
 
   '
-home: https://github.com/truecharts/apps/tree/master/charts/stable/amtd
+home: https://github.com/truecharts/apps/tree/master/charts/dev/amtd
 icon: https://truecharts.org/_static/img/appicons/amtd.png
 keywords:
 - amtd

--- a/charts/dev/amule/Chart.yaml
+++ b/charts/dev/amule/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: "DESCRIPTION\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/amule
+home: https://github.com/truecharts/apps/tree/master/charts/dev/amule
 icon: https://truecharts.org/_static/img/appicons/amule.png
 keywords:
 - amule

--- a/charts/dev/amvd/Chart.yaml
+++ b/charts/dev/amvd/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 deprecated: false
 description: 'Automated Music Video Downloader :: AMVD is a Lidarr Companion script
   to automatically download and tag Music Videos for use in various media applications'
-home: https://github.com/truecharts/apps/tree/master/charts/stable/amvd
+home: https://github.com/truecharts/apps/tree/master/charts/dev/amvd
 icon: https://truecharts.org/_static/img/appicons/amvd.png
 keywords:
 - amvd

--- a/charts/dev/android-8-0/Chart.yaml
+++ b/charts/dev/android-8-0/Chart.yaml
@@ -13,7 +13,7 @@ deprecated: false
 description: Android in docker solution with noVNC supported and video recording.
   Work way better with Intel CPUs because AMD doesn't an cpu graphics card. So with
   amd cpus can be unusable.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/android-8-0
+home: https://github.com/truecharts/apps/tree/master/charts/dev/android-8-0
 icon: https://truecharts.org/_static/img/appicons/android-8-0.png
 keywords:
 - android-8-0

--- a/charts/dev/androiddebugbridge/Chart.yaml
+++ b/charts/dev/androiddebugbridge/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 deprecated: false
 description: "Control AndroidTV/FireTV devices through ADB from the Home Assistant\
   \ Core docker image.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/androiddebugbridge
+home: https://github.com/truecharts/apps/tree/master/charts/dev/androiddebugbridge
 icon: https://truecharts.org/_static/img/appicons/androiddebugbridge.png
 keywords:
 - androiddebugbridge

--- a/charts/dev/anope/Chart.yaml
+++ b/charts/dev/anope/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 deprecated: false
 description: "Anope is a set of IRC Services designed for flexibility and ease of\
   \ use.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/anope
+home: https://github.com/truecharts/apps/tree/master/charts/dev/anope
 icon: https://truecharts.org/_static/img/appicons/anope.png
 keywords:
 - anope

--- a/charts/dev/apache-webdav/Chart.yaml
+++ b/charts/dev/apache-webdav/Chart.yaml
@@ -13,7 +13,7 @@ deprecated: false
 description: "Very simple WebDAV server based on Apache. You need a WebDAV client\
   \ to transfer files. It does not include a WebUI to upload files through your browser.\r\
   \n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/apache-webdav
+home: https://github.com/truecharts/apps/tree/master/charts/dev/apache-webdav
 icon: https://truecharts.org/_static/img/appicons/apache-webdav.png
 keywords:
 - apache-webdav

--- a/charts/dev/apprise-api/Chart.yaml
+++ b/charts/dev/apprise-api/Chart.yaml
@@ -15,7 +15,7 @@ description: 'Apprise-api(https://github.com/caronc/apprise-api) Takes advantage
   API.
 
   '
-home: https://github.com/truecharts/apps/tree/master/charts/stable/apprise-api
+home: https://github.com/truecharts/apps/tree/master/charts/dev/apprise-api
 icon: https://truecharts.org/_static/img/appicons/apprise-api.png
 keywords:
 - apprise-api

--- a/charts/dev/apt-cacher-ng/Chart.yaml
+++ b/charts/dev/apt-cacher-ng/Chart.yaml
@@ -15,7 +15,7 @@ deprecated: false
 description: Apt-Cacher NG is a caching proxy, specialized for package files from
   Linux distributors, primarily for Debian (and Debian based) distributions but not
   limited to those.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/apt-cacher-ng
+home: https://github.com/truecharts/apps/tree/master/charts/dev/apt-cacher-ng
 icon: https://truecharts.org/_static/img/appicons/apt-cacher-ng.png
 keywords:
 - apt-cacher-ng

--- a/charts/dev/archiveteam-warrior/Chart.yaml
+++ b/charts/dev/archiveteam-warrior/Chart.yaml
@@ -15,7 +15,7 @@ deprecated: false
 description: "The Archive Team Warrior is a virtual archiving appliance. You can run\
   \ it to help with the Archive Team archiving efforts. It will download sites and\
   \ upload them to our archive\u2014and it\u2019s really easy to do!\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/archiveteam-warrior
+home: https://github.com/truecharts/apps/tree/master/charts/dev/archiveteam-warrior
 icon: https://truecharts.org/_static/img/appicons/archiveteam-warrior.png
 keywords:
 - archiveteam-warrior

--- a/charts/dev/arksurvivalevolved/Chart.yaml
+++ b/charts/dev/arksurvivalevolved/Chart.yaml
@@ -13,7 +13,7 @@ deprecated: false
 description: "This Docker will download and install SteamCMD. It will also install\
   \ ARK:SurvivalEvolved and run it (Normal server startup of ARK can take a long time!).\r\
   \n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/arksurvivalevolved
+home: https://github.com/truecharts/apps/tree/master/charts/dev/arksurvivalevolved
 icon: https://truecharts.org/_static/img/appicons/arksurvivalevolved.png
 keywords:
 - arksurvivalevolved

--- a/charts/dev/arma3/Chart.yaml
+++ b/charts/dev/arma3/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 deprecated: false
 description: "This Docker will download and install SteamCMD. It will also install\
   \ ArmA III and run it.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/arma3
+home: https://github.com/truecharts/apps/tree/master/charts/dev/arma3
 icon: https://truecharts.org/_static/img/appicons/arma3.png
 keywords:
 - arma3

--- a/charts/dev/arma3exilemod/Chart.yaml
+++ b/charts/dev/arma3exilemod/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 deprecated: false
 description: "This Docker will download and install SteamCMD. It will also install\
   \ ArmA III including ExileMod and run it.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/arma3exilemod
+home: https://github.com/truecharts/apps/tree/master/charts/dev/arma3exilemod
 icon: https://truecharts.org/_static/img/appicons/arma3exilemod.png
 keywords:
 - arma3exilemod

--- a/charts/dev/artifactory-oss/Chart.yaml
+++ b/charts/dev/artifactory-oss/Chart.yaml
@@ -15,7 +15,7 @@ description: "JFrog\u2019s Artifactory open source project was created to speed 
   \ development cycles using binary repositories. It\u2019s the world\u2019s most\
   \ advanced repository manager, creating a single place for teams to manage all their\
   \ binary artifacts efficiently."
-home: https://github.com/truecharts/apps/tree/master/charts/stable/artifactory-oss
+home: https://github.com/truecharts/apps/tree/master/charts/dev/artifactory-oss
 icon: https://truecharts.org/_static/img/appicons/artifactory-oss.png
 keywords:
 - artifactory-oss

--- a/charts/dev/assettocorsa/Chart.yaml
+++ b/charts/dev/assettocorsa/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 deprecated: false
 description: "This Docker will download and install SteamCMD. It will also install\
   \ AssettoCorsa and run it.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/assettocorsa
+home: https://github.com/truecharts/apps/tree/master/charts/dev/assettocorsa
 icon: https://truecharts.org/_static/img/appicons/assettocorsa.png
 keywords:
 - assettocorsa

--- a/charts/dev/atd/Chart.yaml
+++ b/charts/dev/atd/Chart.yaml
@@ -14,7 +14,7 @@ deprecated: false
 description: '[b][u][span style=''color: #E80000;'']NOT FOR PUBLIC USE YET...[/span][/u][/b][br][br]Automated
   Tidal Downloader :: This script will automatically archive music using a popular
   online DL Client'
-home: https://github.com/truecharts/apps/tree/master/charts/stable/atd
+home: https://github.com/truecharts/apps/tree/master/charts/dev/atd
 icon: https://truecharts.org/_static/img/appicons/atd.png
 keywords:
 - atd

--- a/charts/dev/aurora-files/Chart.yaml
+++ b/charts/dev/aurora-files/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: "DESCRIPTION\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/aurora-files
+home: https://github.com/truecharts/apps/tree/master/charts/dev/aurora-files
 icon: https://truecharts.org/_static/img/appicons/aurora-files.png
 keywords:
 - aurora-files

--- a/charts/dev/auto-yt-dl/Chart.yaml
+++ b/charts/dev/auto-yt-dl/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 deprecated: false
 description: auto-yt-dl is used to automatically download new Videos of specific YouTube
   Channels. It features a Web Gui to add and remove Channels from your watch list.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/auto-yt-dl
+home: https://github.com/truecharts/apps/tree/master/charts/dev/auto-yt-dl
 icon: https://truecharts.org/_static/img/appicons/auto-yt-dl.png
 keywords:
 - auto-yt-dl

--- a/charts/dev/autoscan/Chart.yaml
+++ b/charts/dev/autoscan/Chart.yaml
@@ -13,7 +13,7 @@ deprecated: false
 description: Autoscan replaces the default Plex and Emby behaviour for picking up
   file changes on the file system. Autoscan integrates with Sonarr, Radarr and Lidarr
   to fetch changes in near real-time without relying on the file system.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/autoscan
+home: https://github.com/truecharts/apps/tree/master/charts/dev/autoscan
 icon: https://truecharts.org/_static/img/appicons/autoscan.png
 keywords:
 - autoscan

--- a/charts/dev/avorion/Chart.yaml
+++ b/charts/dev/avorion/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 deprecated: false
 description: "This Docker will download and install SteamCMD. It will also install\
   \ Avorion and run it.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/avorion
+home: https://github.com/truecharts/apps/tree/master/charts/dev/avorion
 icon: https://truecharts.org/_static/img/appicons/avorion.png
 keywords:
 - avorion

--- a/charts/dev/backuppc/Chart.yaml
+++ b/charts/dev/backuppc/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 deprecated: false
 description: BackupPC is a high-performance, enterprise-grade system for backing up
   Linux, Windows and macOS PCs and laptops to a server's disk.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/backuppc
+home: https://github.com/truecharts/apps/tree/master/charts/dev/backuppc
 icon: https://truecharts.org/_static/img/appicons/backuppc.png
 keywords:
 - backuppc

--- a/charts/dev/baikal/Chart.yaml
+++ b/charts/dev/baikal/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: "Ba\xEFkal is a lightweight CalDAV+CardDAV server"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/baikal
+home: https://github.com/truecharts/apps/tree/master/charts/dev/baikal
 icon: https://truecharts.org/_static/img/appicons/baikal.png
 keywords:
 - baikal

--- a/charts/dev/barcodebuddy/Chart.yaml
+++ b/charts/dev/barcodebuddy/Chart.yaml
@@ -14,7 +14,7 @@ deprecated: false
 description: "&lt;b&gt;Barcode Buddy is a Grocy companion app/plugin, which allows\
   \ you to install the Barcode Buddy app and scan products directly to your Grocy\
   \ library.&lt;/b&gt;\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/barcodebuddy
+home: https://github.com/truecharts/apps/tree/master/charts/dev/barcodebuddy
 icon: https://truecharts.org/_static/img/appicons/barcodebuddy.png
 keywords:
 - barcodebuddy

--- a/charts/dev/barotrauma/Chart.yaml
+++ b/charts/dev/barotrauma/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 deprecated: false
 description: "This Docker will download and install SteamCMD. It will also install\
   \ Barotrauma and run it.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/barotrauma
+home: https://github.com/truecharts/apps/tree/master/charts/dev/barotrauma
 icon: https://truecharts.org/_static/img/appicons/barotrauma.png
 keywords:
 - barotrauma

--- a/charts/dev/bitcoin-node/Chart.yaml
+++ b/charts/dev/bitcoin-node/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: "DESCRIPTION\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/bitcoin-node
+home: https://github.com/truecharts/apps/tree/master/charts/dev/bitcoin-node
 icon: https://truecharts.org/_static/img/appicons/bitcoin-node.png
 keywords:
 - bitcoin-node

--- a/charts/dev/bitcoind/Chart.yaml
+++ b/charts/dev/bitcoind/Chart.yaml
@@ -16,7 +16,7 @@ description: 'Support the Bitcoin network by hosting your own node! This templat
   provides a full Bitcoin Core node, built in a verifiably trustless way.
 
   '
-home: https://github.com/truecharts/apps/tree/master/charts/stable/bitcoind
+home: https://github.com/truecharts/apps/tree/master/charts/dev/bitcoind
 icon: https://truecharts.org/_static/img/appicons/bitcoind.png
 keywords:
 - bitcoind

--- a/charts/dev/bitcoinunlimited/Chart.yaml
+++ b/charts/dev/bitcoinunlimited/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 deprecated: false
 description: "The Bitcoin Unlimited project seeks to provide a voice to all stakeholders\
   \ in the Bitcoin ecosystem.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/bitcoinunlimited
+home: https://github.com/truecharts/apps/tree/master/charts/dev/bitcoinunlimited
 icon: https://truecharts.org/_static/img/appicons/bitcoinunlimited.png
 keywords:
 - bitcoinunlimited

--- a/charts/dev/bitcoinwalletgui/Chart.yaml
+++ b/charts/dev/bitcoinwalletgui/Chart.yaml
@@ -13,7 +13,7 @@ deprecated: false
 description: 'Bitcoin wallet with GUI over VNC and NoVNC.&#xD;
 
   '
-home: https://github.com/truecharts/apps/tree/master/charts/stable/bitcoinwalletgui
+home: https://github.com/truecharts/apps/tree/master/charts/dev/bitcoinwalletgui
 icon: https://truecharts.org/_static/img/appicons/bitcoinwalletgui.png
 keywords:
 - bitcoinwalletgui

--- a/charts/dev/blender-desktop-g3/Chart.yaml
+++ b/charts/dev/blender-desktop-g3/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: "DESCRIPTION\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/blender-desktop-g3
+home: https://github.com/truecharts/apps/tree/master/charts/dev/blender-desktop-g3
 icon: https://truecharts.org/_static/img/appicons/blender-desktop-g3.png
 keywords:
 - blender-desktop-g3

--- a/charts/dev/blender/Chart.yaml
+++ b/charts/dev/blender/Chart.yaml
@@ -15,7 +15,7 @@ description: Blender(https://www.blender.org/) is a free and open-source 3D comp
   3D printed models, motion graphics, interactive 3D applications, virtual reality,
   and computer games. **This image does not support GPU rendering out of the box only
   accelerated workspace experience**
-home: https://github.com/truecharts/apps/tree/master/charts/stable/blender
+home: https://github.com/truecharts/apps/tree/master/charts/dev/blender
 icon: https://truecharts.org/_static/img/appicons/blender.png
 keywords:
 - blender

--- a/charts/dev/breitbandmessung-de/Chart.yaml
+++ b/charts/dev/breitbandmessung-de/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 deprecated: false
 description: "A script to enable customers of lazy ISPs to perform measurement campaigns\
   \ of the connection speed as described here in an automated way.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/breitbandmessung-de
+home: https://github.com/truecharts/apps/tree/master/charts/dev/breitbandmessung-de
 icon: https://truecharts.org/_static/img/appicons/breitbandmessung-de.png
 keywords:
 - breitbandmessung-de

--- a/charts/dev/btdex/Chart.yaml
+++ b/charts/dev/btdex/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 deprecated: false
 description: This is a Docker container for BTDEX based on jlesage/docker-baseimage-gui
   Docker image.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/btdex
+home: https://github.com/truecharts/apps/tree/master/charts/dev/btdex
 icon: https://truecharts.org/_static/img/appicons/btdex.png
 keywords:
 - btdex

--- a/charts/dev/bwapp/Chart.yaml
+++ b/charts/dev/bwapp/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 deprecated: false
 description: "bWAPP, or a buggy web application, is a free and open source deliberately\
   \ insecure web application.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/bwapp
+home: https://github.com/truecharts/apps/tree/master/charts/dev/bwapp
 icon: https://truecharts.org/_static/img/appicons/bwapp.png
 keywords:
 - bwapp

--- a/charts/dev/server-7daystodie/Chart.yaml
+++ b/charts/dev/server-7daystodie/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
 deprecated: false
 description: "This Docker will download and install SteamCMD. It will also install\
   \ 7 Days to Die and run it.\r\n"
-home: https://github.com/truecharts/apps/tree/master/charts/stable/7daystodie
+home: https://github.com/truecharts/apps/tree/master/charts/dev/server-7daystodie
 icon: https://truecharts.org/_static/img/appicons/7daystodie.png
 keywords:
 - 7daystodie

--- a/charts/games/minetest/Chart.yaml
+++ b/charts/games/minetest/Chart.yaml
@@ -6,7 +6,7 @@ appVersion: "5.5.0"
 description: Minetest (server) is a near-infinite-world block sandbox game and a game engine.
 type: application
 deprecated: false
-home: https://github.com/truecharts/apps/tree/master/charts/stable/minetest
+home: https://github.com/truecharts/apps/tree/master/charts/games/minetest
 icon: https://truecharts.org/_static/img/appicons/minetest.png
 keywords:
   - minetest

--- a/charts/games/valheim/Chart.yaml
+++ b/charts/games/valheim/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   repository: https://library-charts.truecharts.org
   version: 9.3.6
 description: Valheim dedicated gameserver with automatic update and world backup support
-home: https://github.com/truecharts/apps/tree/master/charts/stable/valheim
+home: https://github.com/truecharts/apps/tree/master/charts/games/valheim
 icon: https://truecharts.org/_static/img/appicons/valheim.png
 keywords:
 - valheim

--- a/charts/incubator/adguard-home/Chart.yaml
+++ b/charts/incubator/adguard-home/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   repository: https://library-charts.truecharts.org
   version: 9.3.6
 description: Free and open source, powerful network-wide ads & trackers blocking DNS server.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/adguard-home
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/adguard-home
 icon: https://truecharts.org/_static/img/appicons/adguard-home.png
 keywords:
 - adblock

--- a/charts/incubator/appsmith/Chart.yaml
+++ b/charts/incubator/appsmith/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 #   repository: https://charts.truecharts.org
 #   version: 0.0.25
 description: Turn any datasource into an internal app in minutes. Appsmith lets you drag-and-drop UI components to build pages, connect to any API, database or GraphQL source and write logic with JavaScript objects.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/appsmith
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/appsmith
 icon: https://truecharts.org/_static/img/appicons/appsmith.png
 keywords:
 - appsmith

--- a/charts/incubator/authentik/Chart.yaml
+++ b/charts/incubator/authentik/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
   repository: https://charts.truecharts.org
   version: 2.0.52
 description: authentik is an open-source Identity Provider focused on flexibility and versatility.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/authentik
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/authentik
 icon: https://truecharts.org/_static/img/appicons/authentik.png
 keywords:
 - authentik

--- a/charts/incubator/baserow/Chart.yaml
+++ b/charts/incubator/baserow/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
   repository: https://charts.truecharts.org
   version: 2.0.52
 description: Baserow is an open source no-code database tool and Airtable alternative.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/baserow
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/baserow
 icon: https://truecharts.org/_static/img/appicons/baserow.png
 keywords:
 - baserow

--- a/charts/incubator/cups-server/Chart.yaml
+++ b/charts/incubator/cups-server/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   repository: https://library-charts.truecharts.org
   version: 9.3.6
 description: CUPS printing server
-home: https://github.com/truecharts/apps/tree/master/charts/stable/cups-server
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/cups-server
 icon: https://truecharts.org/_static/img/appicons/cups-server.png
 keywords:
 - print

--- a/charts/incubator/filerun/Chart.yaml
+++ b/charts/incubator/filerun/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   repository: https://charts.truecharts.org/
   version: 2.0.58
 description: FileRun is a full featured web based file manager with an easy to use user interface
-home: https://github.com/truecharts/apps/tree/master/charts/stable/filerun
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/filerun
 icon: https://truecharts.org/_static/img/appicons/filerun.png
 keywords:
 - filerun

--- a/charts/incubator/ghost/Chart.yaml
+++ b/charts/incubator/ghost/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   repository: https://charts.truecharts.org/
   version: 2.0.58
 description: Ghost is an open source, professional publishing platform built on a modern Node.js technology stack — designed for teams who need power, flexibility and performance.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/ghost
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/ghost
 icon: https://truecharts.org/_static/img/appicons/ghost.png
 keywords:
 - ghost

--- a/charts/incubator/inventree/Chart.yaml
+++ b/charts/incubator/inventree/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   repository: https://charts.truecharts.org/
   version: 7.0.61
 description: InvenTree is an open-source Inventory Management System which provides powerful low-level stock control and part tracking.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/inventree
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/inventree
 icon: https://truecharts.org/_static/img/appicons/inventree.png
 keywords:
 - inventory

--- a/charts/incubator/kopia/Chart.yaml
+++ b/charts/incubator/kopia/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   repository: https://library-charts.truecharts.org
   version: 9.3.6
 description: Kopia is a simple, cross-platform tool for managing encrypted backups in the cloud. It provides fast, incremental backups, secure, client-side end-to-end encryption, compression and data deduplication.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/kopia
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/kopia
 icon: https://truecharts.org/_static/img/appicons/kopia.png
 keywords:
 - backup

--- a/charts/incubator/meshcentral/Chart.yaml
+++ b/charts/incubator/meshcentral/Chart.yaml
@@ -6,7 +6,7 @@ appVersion: "1.0.18"
 description: MeshCentral is a full computer management web site
 type: application
 deprecated: false
-home: https://github.com/truecharts/apps/tree/master/charts/stable/meshcentral
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/meshcentral
 icon: https://truecharts.org/_static/img/appicons/meshcentral.png
 keywords:
   - meshcentral

--- a/charts/incubator/netdata/Chart.yaml
+++ b/charts/incubator/netdata/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   repository: https://library-charts.truecharts.org
   version: 9.3.6
 description: Netdata is high-fidelity infrastructure monitoring and troubleshooting.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/netdata
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/netdata
 icon: https://truecharts.org/_static/img/appicons/netdata.png
 keywords:
 - netdata

--- a/charts/incubator/piwigo/Chart.yaml
+++ b/charts/incubator/piwigo/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 description: A is photo gallery software for the web, built by an active community
   of users and developers.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/piwigo
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/piwigo
 icon: https://truecharts.org/_static/img/appicons/piwigo.png
 keywords:
 - piwigo

--- a/charts/incubator/self-service-password/Chart.yaml
+++ b/charts/incubator/self-service-password/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: Self Service Password is a PHP application that allows users to change their password in an LDAP directory.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/self-service-password
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/self-service-password
 icon: https://truecharts.org/_static/img/appicons/self-service-password.png
 keywords:
 - password

--- a/charts/incubator/technitium/Chart.yaml
+++ b/charts/incubator/technitium/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: Technitium DNS Server is an open source authoritative as well as recursive DNS server that can be used for self hosting a DNS server for privacy & security.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/technitium
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/technitium
 icon: https://truecharts.org/_static/img/appicons/technitium.png
 keywords:
 - DNS

--- a/charts/incubator/zabbix-server/Chart.yaml
+++ b/charts/incubator/zabbix-server/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   repository: https://charts.truecharts.org/
   version: 7.0.61
 description: Zabbix is an enterprise-class open source distributed monitoring solution.
-home: https://github.com/truecharts/apps/tree/master/charts/stable/zabbix-server
+home: https://github.com/truecharts/apps/tree/master/charts/incubator/zabbix-server
 icon: https://truecharts.org/_static/img/appicons/zabbix-server.png
 keywords:
 - zabbix

--- a/charts/stable/aria2/Chart.yaml
+++ b/charts/stable/aria2/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   repository: https://library-charts.truecharts.org
   version: 9.3.6
 description: aria server for downloading web content
-home: https://github.com/truecharts/apps/tree/master/charts/stable/aira2
+home: https://github.com/truecharts/apps/tree/master/charts/stable/aria2
 icon: https://truecharts.org/_static/img/appicons/aria2.png
 keywords:
 - aria2

--- a/charts/stable/automatic-music-downloader/Chart.yaml
+++ b/charts/stable/automatic-music-downloader/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: A Lidarr companion script to automatically download music for Lidarr.
-home: https://github.com/truecharts/apps/tree/master/charts/incubator/automatic-music-downloader
+home: https://github.com/truecharts/apps/tree/master/charts/stable/automatic-music-downloader
 icon: https://truecharts.org/_static/img/appicons/automatic-music-downloader.png
 keywords:
 - automatic

--- a/charts/stable/babybuddy/Chart.yaml
+++ b/charts/stable/babybuddy/Chart.yaml
@@ -5,7 +5,7 @@ version: 6.0.28
 name: babybuddy
 description: Helps caregivers track sleep, feedings, diaper changes, tummy time and more to learn about and predict baby's needs without (as much) guess work.
 type: application
-home: https://github.com/truecharts/apps/tree/stable/charts/babybuddy
+home: https://github.com/truecharts/apps/tree/master/charts/stable/babybuddy
 icon: https://truecharts.org/_static/img/appicons/babybuddy.png
 keywords:
   - baby

--- a/charts/stable/deemix/Chart.yaml
+++ b/charts/stable/deemix/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: deemix is a deezer downloader built from the ashes of Deezloader Remix.
-home: https://github.com/truecharts/apps/tree/master/charts/incubator/deemix
+home: https://github.com/truecharts/apps/tree/master/charts/stable/deemix
 icon: https://truecharts.org/_static/img/appicons/deemix.png
 keywords:
 - music

--- a/charts/stable/emby/Chart.yaml
+++ b/charts/stable/emby/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: Emby Server is a home media server
-home: https://github.com/truecharts/apps/master/stable/emby
+home: https://github.com/truecharts/apps/tree/master/charts/stable/emby
 icon: https://truecharts.org/_static/img/appicons/emby.png
 keywords:
 - jellyfin

--- a/charts/stable/etherpad/Chart.yaml
+++ b/charts/stable/etherpad/Chart.yaml
@@ -5,7 +5,7 @@ kubeVersion: '>=1.16.0-0'
 name: etherpad
 description: A real-time collaborative editor scalable to thousands of simultaneous real time users.
 type: application
-home: https://github.com/truecharts/apps/tree/main/charts/etherpad
+home: https://github.com/truecharts/apps/tree/master/charts/stable/etherpad
 icon: https://truecharts.org/_static/img/appicons/etherpad.png
 keywords:
   - etherpad

--- a/charts/stable/fireflyiii/Chart.yaml
+++ b/charts/stable/fireflyiii/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   version: 2.0.52
 deprecated: false
 description: A free and open source personal finance manager
-home: https://github.com/firefly-iii/firefly-iii/
+home: https://github.com/truecharts/apps/tree/master/charts/stable/fireflyiii
 icon: https://truecharts.org/_static/img/appicons/fireflyiii.png
 keywords:
 - fireflyiii

--- a/charts/stable/firefox-syncserver/Chart.yaml
+++ b/charts/stable/firefox-syncserver/Chart.yaml
@@ -5,7 +5,7 @@ kubeVersion: '>=1.16.0-0'
 name: firefox-syncserver
 description: This is an all-in-one package for running a self-hosted Firefox Sync server.
 type: application
-home: "https://github.com/truecharts/apps/tree/main/charts/firefox-syncserver"
+home: https://github.com/truecharts/apps/tree/master/charts/stable/firefox-syncserver
 icon: https://truecharts.org/_static/img/appicons/firefox-syncserver.png
 keywords:
   - server

--- a/charts/stable/freeradius/Chart.yaml
+++ b/charts/stable/freeradius/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: OpenSource Radius implementation
-home: https://www.openldap.org
+home: https://github.com/truecharts/apps/tree/master/charts/stable/freeradius
 icon: https://truecharts.org/_static/img/appicons/freeradius.png
 keywords:
 - radius

--- a/charts/stable/gotify/Chart.yaml
+++ b/charts/stable/gotify/Chart.yaml
@@ -5,7 +5,7 @@ kubeVersion: '>=1.16.0-0'
 name: gotify
 description: a simple server for sending and receiving messages
 type: application
-home: "https://github.com/truecharts/apps/tree/main/charts/gotify"
+home: https://github.com/truecharts/apps/tree/master/charts/stable/gotify
 keywords:
   - server
   - gotify

--- a/charts/stable/haste-server/Chart.yaml
+++ b/charts/stable/haste-server/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
   repository: https://library-charts.truecharts.org
   version: 9.3.6
 description: Simple text sharing
-home: https://github.com/truecharts/apps/tree/master/charts/stable/haste
+home: https://github.com/truecharts/apps/tree/master/charts/stable/haste-server
 icon: https://truecharts.org/_static/img/appicons/haste-server.png
 keywords:
 - haste

--- a/charts/stable/joplin-server/Chart.yaml
+++ b/charts/stable/joplin-server/Chart.yaml
@@ -7,7 +7,7 @@ kubeVersion: '>=1.16.0-0'
 keywords:
   - joplin
   - notes
-home: https://github.com/truecharts/apps/tree/master/charts/stable/jopplin-server
+home: https://github.com/truecharts/apps/tree/master/charts/stable/joplin-server
 icon: https://truecharts.org/_static/img/appicons/joplin-server.png
 sources:
   - https://github.com/laurent22/joplin/tree/dev/packages/server

--- a/charts/stable/logitech-media-server/Chart.yaml
+++ b/charts/stable/logitech-media-server/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: Logitech Media Server is a platform for home/office audio streaming.
-home: https://github.com/truecharts/apps/master/charts/incubator/logitech-media-server
+home: https://github.com/truecharts/apps/tree/master/charts/stable/logitech-media-server
 icon: https://truecharts.org/_static/img/appicons/logitech-media-server.png
 keywords:
 - logitech-media-server

--- a/charts/stable/miniflux/Chart.yaml
+++ b/charts/stable/miniflux/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - miniflux
 - rss
 - news
-home: https://github.com/truecharts/apps/tree/master/charts/miniflux
+home: https://github.com/truecharts/apps/tree/master/charts/stable/miniflux
 icon: https://truecharts.org/_static/img/appicons/miniflux.png
 sources:
 - https://github.com/miniflux/v2

--- a/charts/stable/nextcloud/Chart.yaml
+++ b/charts/stable/nextcloud/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 deprecated: false
 description: A private cloud server that puts the control and security of your own
   data back into your hands.
-home: https://nextcloud.com/
+home: https://github.com/truecharts/apps/tree/master/charts/stable/nextcloud
 icon: https://truecharts.org/_static/img/appicons/nextcloud.png
 keywords:
 - nextcloud

--- a/charts/stable/odoo/Chart.yaml
+++ b/charts/stable/odoo/Chart.yaml
@@ -5,7 +5,7 @@ kubeVersion: '>=1.16.0-0'
 name: odoo
 description: All-in-one business software. Beautiful. Easy-to-use. CRM, Accounting, PM, HR, Procurement, Point of Sale, MRP, Marketing, etc.
 type: application
-home: "https://github.com/truecharts/apps/tree/main/charts/odoo"
+home: https://github.com/truecharts/apps/tree/master/charts/stable/odoo
 icon: https://truecharts.org/_static/img/appicons/odoo.png
 keywords:
   - odoo

--- a/charts/stable/openldap/Chart.yaml
+++ b/charts/stable/openldap/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: Community developed LDAP software
-home: https://www.openldap.org
+home: https://github.com/truecharts/apps/tree/master/charts/stable/openldap
 icon: https://truecharts.org/_static/img/appicons/openldap.png
 keywords:
 - ldap

--- a/charts/stable/promcord/Chart.yaml
+++ b/charts/stable/promcord/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
 deprecated: false
 description: Discord bot that provides metrics from a Discord server
 icon: https://truecharts.org/_static/img/appicons/promcord.png
-home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/promcord
+home: https://github.com/truecharts/apps/tree/master/charts/stable/promcord
 keywords:
 - promcord
 - discord

--- a/charts/stable/redmine/Chart.yaml
+++ b/charts/stable/redmine/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.26
 name: redmine
 description: Redmine is a flexible project management web application written using Ruby on Rails framework.
 type: application
-home: "https://github.com/truecharts/apps/tree/main/charts/redmine"
+home: https://github.com/truecharts/apps/tree/master/charts/stable/redmine
 icon: https://truecharts.org/_static/img/appicons/redmine.png
 keywords:
   - project

--- a/charts/stable/resilio-sync/Chart.yaml
+++ b/charts/stable/resilio-sync/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 description: Resilio Sync is a fast, reliable, and simple file sync and share solution,
   powered by P2P technology
-home: https://github.com/truecharts/apps/tree/master/charts/stable/resio-sync
+home: https://github.com/truecharts/apps/tree/master/charts/stable/resilio-sync
 icon: https://truecharts.org/_static/img/appicons/resilio-sync.png
 keywords:
 - resilio

--- a/charts/stable/shiori/Chart.yaml
+++ b/charts/stable/shiori/Chart.yaml
@@ -5,7 +5,7 @@ kubeVersion: '>=1.16.0-0'
 name: shiori
 description: A simple bookmark manager built with Go
 type: application
-home: "https://github.com/truecharts/apps/tree/main/charts/shiori"
+home: https://github.com/truecharts/apps/tree/master/charts/stable/shiori
 icon: https://truecharts.org/_static/img/appicons/shiori.png
 keywords:
   - shiori

--- a/charts/stable/speedtest-exporter/Chart.yaml
+++ b/charts/stable/speedtest-exporter/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
 deprecated: false
 description: Speedtest Exporter made in python using the official speedtest bin
 icon: https://truecharts.org/_static/img/appicons/speedtest-exporter.png
-home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/speedtest-exporter
+home: https://github.com/truecharts/apps/tree/master/charts/stable/speedtest-exporter
 keywords:
 - speedtest-exporter
 - speedtest

--- a/charts/stable/spotweb/Chart.yaml
+++ b/charts/stable/spotweb/Chart.yaml
@@ -5,7 +5,7 @@ version: 2.0.10
 name: spotweb
 description: Spotweb is a decentralized usenet community based on the Spotnet protocol.
 type: application
-home: https://github.com/truecharts/apps/master/charts/incubator/spotweb
+home: https://github.com/truecharts/apps/tree/master/charts/stable/spotweb
 icon: https://raw.githubusercontent.com/spotweb/spotweb/9af0ade0f618675206dcf1f744dbb3c1eae70e5a/images/spotnet.gif
 keywords:
 - usenet

--- a/charts/stable/synapse/Chart.yaml
+++ b/charts/stable/synapse/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 7.0.61
 deprecated: false
 description: A Helm chart to deploy a Matrix homeserver stack into Kubernetes
-home: https://github.com/truecharts/apps/charts/stable/synapse
+home: https://github.com/truecharts/apps/tree/master/charts/stable/synapse
 icon: https://truecharts.org/_static/img/appicons/synapse.png
 keywords:
 - chat

--- a/charts/stable/unpackerr/Chart.yaml
+++ b/charts/stable/unpackerr/Chart.yaml
@@ -8,7 +8,7 @@ deprecated: false
 description: This application runs as a daemon on your download host. It checks for
   completed downloads and extracts them so Radarr, Lidarr, Sonarr, and Readarr may
   import them
-home: https://github.com/truecharts/apps/tree/master/charts/stable/unpackrr
+home: https://github.com/truecharts/apps/tree/master/charts/stable/unpackerr
 icon: https://truecharts.org/_static/img/appicons/unpackerr.png
 keywords:
 - unpackerr

--- a/charts/stable/unpoller/Chart.yaml
+++ b/charts/stable/unpoller/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
 deprecated: false
 description: Collect ALL UniFi Controller, Site, Device & Client Data - Export to InfluxDB or Prometheus
 icon: https://truecharts.org/_static/img/appicons/unpoller.png
-home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/unifi-poller
+home: https://github.com/truecharts/apps/tree/master/charts/stable/unpoller
 keywords:
 - unifi
 - unifi-poller

--- a/charts/stable/uptime-kuma/Chart.yaml
+++ b/charts/stable/uptime-kuma/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   version: 9.3.6
 deprecated: false
 description: A fancy self-hosted monitoring tool
-home: https://github.com/louislam/uptime-kuma
+home: https://github.com/truecharts/apps/tree/master/charts/stable/uptime-kuma
 icon: https://truecharts.org/_static/img/appicons/uptime-kuma.png
 keywords:
 - monitoring

--- a/charts/stable/uptimerobot-prometheus/Chart.yaml
+++ b/charts/stable/uptimerobot-prometheus/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
 deprecated: false
 description: Prometheus Exporter for the official uptimerobot CLI
 icon: https://truecharts.org/_static/img/appicons/uptimerobot-prometheus.png
-home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/uptimerobot-prometheus
+home: https://github.com/truecharts/apps/tree/master/charts/stable/uptimerobot-prometheus
 keywords:
 - uptimerobot
 - prometheus


### PR DESCRIPTION
**Description**
Many of home links are broken. Most seem to be due to movement into different trains, but some are plain typos.

⚒️ Fixes  #2662 

**⚙️ Type of change**

Fixing broken links. No functional change.

**🧪 How Has This Been Tested?**
Checked the new links work.

**📃 Notes:**

The command I used to automate this:
```zsh
zsh -c 'repo_url=$(yq -r .repo_url < mkdocs.yml); for c ( charts/**/Chart.yaml(.) ) sed -i "s|^home: .*|home: $repo_url/tree/master/${c%/Chart.yaml}|" $c'
```

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
