### PR TITLE
fix(firefox-syncserver): fix to use PostgreSQL instead of SQLite

### DIFF
--- a/charts/stable/firefox-syncserver/Chart.yaml
+++ b/charts/stable/firefox-syncserver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "1.8.0"
-version: 6.0.19
+version: 7.0.0
 kubeVersion: '>=1.16.0-0'
 name: firefox-syncserver
 description: This is an all-in-one package for running a self-hosted Firefox Sync server.

--- a/charts/stable/firefox-syncserver/Chart.yaml
+++ b/charts/stable/firefox-syncserver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "1.8.0"
-version: 6.0.18
+version: 6.0.19
 kubeVersion: '>=1.16.0-0'
 name: firefox-syncserver
 description: This is an all-in-one package for running a self-hosted Firefox Sync server.

--- a/charts/stable/firefox-syncserver/helm-values.md
+++ b/charts/stable/firefox-syncserver/helm-values.md
@@ -17,8 +17,8 @@ You will, however, be able to use all values referenced in the common chart here
 | env.FF_SYNCSERVER_FORWARDED_ALLOW_IPS | string | `"*"` |  |
 | env.FF_SYNCSERVER_LOGLEVEL | string | `"info"` |  |
 | env.FF_SYNCSERVER_PUBLIC_URL | string | `"firefox-syncserver.192.168.1.189.nip.io"` |  |
-| envValueFrom.DB_HOST.secretKeyRef.key | string | `"url"` |  |
-| envValueFrom.DB_HOST.secretKeyRef.name | string | `"dbcreds"` |  |
+| envValueFrom.FF_SYNCSERVER_SQLURI.secretKeyRef.key | string | `"url"` |  |
+| envValueFrom.FF_SYNCSERVER_SQLURI.secretKeyRef.name | string | `"dbcreds"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"tccr.io/truecharts/firefox-syncserver"` |  |
 | image.tag | string | `"v1.8.0@sha256:d0fbf65c8c7a99ad4ba7ffcfdad2e7b2555e0d829867c21cefc9314ace94f747"` |  |

--- a/charts/stable/firefox-syncserver/helm-values.md
+++ b/charts/stable/firefox-syncserver/helm-values.md
@@ -17,8 +17,8 @@ You will, however, be able to use all values referenced in the common chart here
 | env.FF_SYNCSERVER_FORWARDED_ALLOW_IPS | string | `"*"` |  |
 | env.FF_SYNCSERVER_LOGLEVEL | string | `"info"` |  |
 | env.FF_SYNCSERVER_PUBLIC_URL | string | `"firefox-syncserver.192.168.1.189.nip.io"` |  |
-| envValueFrom.FF_SYNCSERVER_SQLURI.secretKeyRef.key | string | `"url"` |  |
-| envValueFrom.FF_SYNCSERVER_SQLURI.secretKeyRef.name | string | `"dbcreds"` |  |
+| envValueFrom.DB_HOST.secretKeyRef.key | string | `"url"` |  |
+| envValueFrom.DB_HOST.secretKeyRef.name | string | `"dbcreds"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"tccr.io/truecharts/firefox-syncserver"` |  |
 | image.tag | string | `"v1.8.0@sha256:d0fbf65c8c7a99ad4ba7ffcfdad2e7b2555e0d829867c21cefc9314ace94f747"` |  |

--- a/charts/stable/firefox-syncserver/values.yaml
+++ b/charts/stable/firefox-syncserver/values.yaml
@@ -25,7 +25,7 @@ env:
   FF_SYNCSERVER_FORWARDED_ALLOW_IPS: "*"
 
 envValueFrom:
-  DB_HOST:
+  FF_SYNCSERVER_SQLURI:
     secretKeyRef:
       name: dbcreds
       key: url


### PR DESCRIPTION
This enables [PostgreSQL as intended](https://github.com/truecharts/apps/blob/master/charts/stable/firefox-syncserver/values.yaml#L43-L48), instead of the [upstream SQLite default](https://github.com/crazy-max/docker-firefox-syncserver#volumes).

**Description**

⚒️ Fixes #2668

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
To reproduce, log in to the container shell and observe the sqlite database `/data/syncserver.db`. This data should be in postgres (which is not populated).

<img width="1329" alt="firefox-syncserver-no-data" src="https://user-images.githubusercontent.com/1931222/168204681-b663feb5-c7f6-401b-be04-a9a4a4a6f481.png">

```shell
/ # ls -l /data/
total 4321
-rw-------    1 syncserv syncserv   8323072 May 13 13:12 syncserver.db
/ # 
```

I pushed my own catalog with the fix and tested it still syncs with Firefox. I then logged into the created `firefox-syncserver` postgres database with pgAdmin and verified the tables are actually being populated.

<img width="1319" alt="firefox-syncserver-data" src="https://user-images.githubusercontent.com/1931222/168198256-b698d237-e3bb-4d67-8d14-28766e1dab73.png">

In addition, `/data/syncserver.db` is not created, as expected.


**📃 Notes:**
It's not strictly necessary to sync with firefox to observe this, as the tables don't even get created in postgres.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning