### PR TITLE
fix(traefik) Fix null pointer error, move ingressClass quote

### DIFF
--- a/charts/core/traefik/Chart.yaml
+++ b/charts/core/traefik/Chart.yaml
@@ -22,7 +22,7 @@ sources:
 - https://github.com/traefik/traefik-helm-chart
 - https://traefik.io/
 type: application
-version: 11.3.1
+version: 11.3.2
 annotations:
   truecharts.org/catagories: |
     - network

--- a/charts/core/traefik/questions.yaml
+++ b/charts/core/traefik/questions.yaml
@@ -112,6 +112,7 @@ questions:
       attrs:
         - variable: enabled
           label: "Enable"
+          description: "When enabled, ingressClass will match the entered name of this app"
           schema:
             type: boolean
             default: false

--- a/charts/core/traefik/templates/_args.tpl
+++ b/charts/core/traefik/templates/_args.tpl
@@ -64,7 +64,7 @@ args:
   {{- end }}
   {{- end }}
   {{- if .Values.ingressClass.enabled }}
-  - "--providers.kubernetesingress.ingressclass="{{ .Release.Name }}
+  - "--providers.kubernetesingress.ingressclass={{ .Release.Name }}"
   {{- end }}
   {{- range $entrypoint, $config := $ports }}
   {{/* add args for forwardedHeaders support */}}


### PR DESCRIPTION
**Description**
Fix bad quote location on ingressClass arg, add description to ingressClass question relaying what the ingressClass name will be set to.
⚒️ Fixes  #2684

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I setup a user on my TrueNAS SCALE system running TrueNAS-SCALE-22.02.1, and I used the k3s cluster config at `/etc/rancher/k3s/k3s.yaml` to enable the built in helm command to execute lint, install and upgrade commands.  I developed this failing test:
```
disky% helm install -n ix-traefik traefik . --debug --dry-run --set ingressClass.enabled=true | grep ingress
install.go:178: [debug] Original chart version: ""
install.go:195: [debug] CHART PATH: /mnt/jobs/home/cullen/Projects/apps/charts/core/traefik

install.go:210: [debug] WARNING: This chart or one of its subcharts contains CRDs. Rendering may fail or contain inaccuracies.
Error: INSTALLATION FAILED: template: traefik/templates/common.yaml:14:19: executing "traefik/templates/common.yaml" at <concat .Values.args .Values.newArgs.args>: error calling concat: runtime error: invalid memory address or nil pointer dereference
helm.go:84: [debug] template: traefik/templates/common.yaml:14:19: executing "traefik/templates/common.yaml" at <concat .Values.args .Values.newArgs.args>: error calling concat: runtime error: invalid memory address or nil pointer dereference
INSTALLATION FAILED
main.newInstallCmd.func2
        helm.sh/helm/v3/cmd/helm/install.go:127
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.3.0/command.go:856
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.3.0/command.go:974
github.com/spf13/cobra.(*Command).Execute
        github.com/spf13/cobra@v1.3.0/command.go:902
main.main
        helm.sh/helm/v3/cmd/helm/helm.go:83
runtime.main
        runtime/proc.go:255
runtime.goexit
        runtime/asm_amd64.s:1581
disky% 
```

And with my fix applied this is the output instead: 
```
disky% helm install -n ix-traefik traefik . --debug --dry-run --set ingressClass.enabled=true | grep ingressclass
install.go:178: [debug] Original chart version: ""
install.go:195: [debug] CHART PATH: /mnt/jobs/home/cullen/Projects/apps/charts/core/traefik

install.go:210: [debug] WARNING: This chart or one of its subcharts contains CRDs. Rendering may fail or contain inaccuracies.
    - ingressclasses
      - ingressclasses
            - --providers.kubernetesingress.ingressclass=traefik
    ingressclass.kubernetes.io/is-default-class: "false"
disky% 
```

**📃 Notes:**
To make future deployments easier, I added a description that describes what the name of the ingressClass will be.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
