### PR TITLE
feat(traefik) add theme.park plugin support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,13 +2,15 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.154.0/containers/ruby
 {
     "name": "Ruby",
-    "image": "tccr.io/truecharts/devcontainer:v2.2.1"
-
+    "image": "tccr.io/truecharts/devcontainer:v2.2.1",
     // Set *default* container specific settings.json values on container create.
     "settings": {
-        "terminal.integrated.shell.linux": "/bin/bash"
+        "terminal.integrated.defaultProfile.linux": "zsh"
     },
-
+    "mounts": [
+        "source=home,target=/home/vscode,type=volume",
+        "source=${localEnv:HOME}/dotfiles,target=/home/vscode/dotfiles,type=bind"
+    ],
     // Add the IDs of extensions you want installed when the container is created.
     "extensions": [
         "ms-kubernetes-tools.vscode-kubernetes-tools",
@@ -26,13 +28,10 @@
         "spmeesseman.vscode-taskexplorer",
         "formulahendry.code-runner"
     ],
-
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
-
     // Use 'postCreateCommand' to run commands after the container is created.
     "postCreateCommand": "export RUBYJQ_USE_SYSTEM_LIBRARIES=1 && bundle install",
-
     // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,15 +2,13 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.154.0/containers/ruby
 {
     "name": "Ruby",
-    "image": "tccr.io/truecharts/devcontainer:v2.2.1",
+    "image": "tccr.io/truecharts/devcontainer:v2.2.1"
+
     // Set *default* container specific settings.json values on container create.
     "settings": {
-        "terminal.integrated.defaultProfile.linux": "zsh"
+        "terminal.integrated.shell.linux": "/bin/bash"
     },
-    "mounts": [
-        "source=home,target=/home/vscode,type=volume",
-        "source=${localEnv:HOME}/dotfiles,target=/home/vscode/dotfiles,type=bind"
-    ],
+
     // Add the IDs of extensions you want installed when the container is created.
     "extensions": [
         "ms-kubernetes-tools.vscode-kubernetes-tools",
@@ -28,10 +26,13 @@
         "spmeesseman.vscode-taskexplorer",
         "formulahendry.code-runner"
     ],
+
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
+
     // Use 'postCreateCommand' to run commands after the container is created.
     "postCreateCommand": "export RUBYJQ_USE_SYSTEM_LIBRARIES=1 && bundle install",
+
     // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode"
 }

--- a/charts/core/traefik/Chart.yaml
+++ b/charts/core/traefik/Chart.yaml
@@ -22,7 +22,7 @@ sources:
 - https://github.com/traefik/traefik-helm-chart
 - https://traefik.io/
 type: application
-version: 11.3.9
+version: 11.4.0
 annotations:
   truecharts.org/catagories: |
     - network

--- a/charts/core/traefik/crds/middlewares.yaml
+++ b/charts/core/traefik/crds/middlewares.yaml
@@ -548,6 +548,19 @@ spec:
                       type: string
                     type: array
                 type: object
+              themePark:
+                description: ThemePark middleware contains configuration for the
+                  traefik-themepark plugin. This is a 3rd party plugin that allows for
+                  adding references to `theme.park` (https://theme-park.dev/) themes for
+                  a growing number of appliations.
+                properties:
+                  appName:
+                    description: The name of the supported application to be themed. (ie `sonarr`)
+                    type: string
+                  themeName:
+                    description: The name of the supported theme to be themed. (ie `dark`)
+                    type: string
+                type: object
             type: object
         required:
         - metadata

--- a/charts/core/traefik/crds/middlewares.yaml
+++ b/charts/core/traefik/crds/middlewares.yaml
@@ -560,6 +560,9 @@ spec:
                   themeName:
                     description: The name of the supported theme to be themed. (ie `dark`)
                     type: string
+                  baseUrl:
+                    description: The base URL to use for loading theme CSS styles from.
+                    type: string
                 type: object
             type: object
         required:

--- a/charts/core/traefik/questions.yaml
+++ b/charts/core/traefik/questions.yaml
@@ -102,6 +102,14 @@ questions:
                 schema:
                   type: boolean
                   default: false
+              - variable: enableThemePark
+                label: "Enable theme.park"
+                description: Install plugin adding support for theme.park themes on supported apps.
+                  This is a 3rd party plugin!
+                  Please report any bugs to https://github.com/packruler/traefik-themepark
+                schema:
+                  type: boolean
+                  default: false
 
   - variable: ingressClass
     label: "ingressClass"
@@ -570,6 +578,39 @@ questions:
                                     type: string
                                     required: true
                                     default: ""
+
+        - variable: themePark
+          label: "theme.park"
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: themeParkEntry
+                label: ""
+                schema:
+                  additional_attrs: true
+                  type: dict
+                  attrs:
+                    - variable: name
+                      label: "Name"
+                      description: Requires enabling `theme.park` plugin in Traefik Pilot section.
+                      schema:
+                        type: string
+                        required: true
+                    - variable: appName
+                      label: App Name
+                      description: The name of the app to be themed.
+                        Go to https://docs.theme-park.dev/themes/ to see supported apps.
+                      schema:
+                        type: string
+                        required: true
+                    - variable: themeName
+                      label: Theme Name
+                      description: The name of the theme to be applied.
+                        Go to https://docs.theme-park.dev/theme-options/ to see supported themes.
+                      schema:
+                        type: string
+                        required: true
 
   - variable: service
     group: "Networking and Services"

--- a/charts/core/traefik/questions.yaml
+++ b/charts/core/traefik/questions.yaml
@@ -611,6 +611,19 @@ questions:
                       schema:
                         type: string
                         required: true
+                    - variable: enableBaseUrl
+                      label: Enable Custom Base URL
+                      description: Replace `https://theme-park.dev` URL for self-hosting reference.
+                      schema:
+                        type: boolean
+                        default: false
+                        show_subquestions_if: true
+                        subquestions:
+                          - variable: baseUrl
+                            label: Base URL
+                            schema:
+                              type: string
+                              required: true
 
   - variable: service
     group: "Networking and Services"

--- a/charts/core/traefik/templates/_args.tpl
+++ b/charts/core/traefik/templates/_args.tpl
@@ -145,7 +145,7 @@ args:
   - "--pilot.token={{ .Values.pilot.token }}"
   {{- if .Values.pilot.enableThemePark }}
   - "--experimental.plugins.themePark.modulename=github.com/packruler/traefik-themepark"
-  - "--experimental.plugins.themePark.version=v0.2.1"
+  - "--experimental.plugins.themePark.version=v1.0.0"
   {{- end }}
   {{- end }}
   {{- if hasKey .Values.pilot "dashboard" }}

--- a/charts/core/traefik/templates/_args.tpl
+++ b/charts/core/traefik/templates/_args.tpl
@@ -143,6 +143,10 @@ args:
   {{- end }}
   {{- if .Values.pilot.enabled }}
   - "--pilot.token={{ .Values.pilot.token }}"
+  {{- if .Values.pilot.enableThemePark }}
+  - "--experimental.plugins.themePark.modulename=github.com/packruler/traefik-themepark"
+  - "--experimental.plugins.themePark.version=v0.2.1"
+  {{- end }}
   {{- end }}
   {{- if hasKey .Values.pilot "dashboard" }}
   - "--pilot.dashboard={{ .Values.pilot.dashboard }}"

--- a/charts/core/traefik/templates/middlewares/themePark.yaml
+++ b/charts/core/traefik/templates/middlewares/themePark.yaml
@@ -1,0 +1,19 @@
+{{- $values := .Values }}
+{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
+{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
+{{- $namespace = "default" }}
+{{- end }}
+
+{{ range $index, $middlewareData := .Values.middlewares.themePark }}
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $middlewareData.name }}
+  namespace: {{ $namespace }}
+spec:
+  plugin:
+    themePark:
+      app: {{ $middlewareData.appName}}
+      theme: {{ $middlewareData.themeName}}
+{{ end }}

--- a/charts/core/traefik/templates/middlewares/themePark.yaml
+++ b/charts/core/traefik/templates/middlewares/themePark.yaml
@@ -14,6 +14,9 @@ metadata:
 spec:
   plugin:
     themePark:
-      app: {{ $middlewareData.appName}}
-      theme: {{ $middlewareData.themeName}}
+      app: {{ $middlewareData.appName }}
+      theme: {{ $middlewareData.themeName }}
+      {{- if $middlewareData.enableBaseUrl }}
+      baseUrl: {{ $middlewareData.baseUrl }}
+      {{- end -}}
 {{ end }}

--- a/charts/core/traefik/values.yaml
+++ b/charts/core/traefik/values.yaml
@@ -16,6 +16,7 @@ ingressClass:
 pilot:
   enabled: false
   token: ""
+  enableThemePark: false
   # Toggle Pilot Dashboard
   # dashboard: false
 
@@ -334,3 +335,9 @@ middlewares:
 
 portalhook:
   enabled: true
+
+persistence:
+  plugins:
+    enabled: true
+    mountPath: "/plugins-storage"
+    type: emptyDir


### PR DESCRIPTION
**Description**
This adds Traefik middleware config support for Traefik theme.park plugin.

⚒️ Fixes  #2778

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
This was tested locally via fork of `apps` and `catalog`

**📃 Notes:**
Getting used to not developing for dumb customers...

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
