### PR TITLE
fix(tests): upgrade k3s version for tests

### DIFF
--- a/.github/workflows/charts-test.yaml
+++ b/.github/workflows/charts-test.yaml
@@ -162,7 +162,7 @@ jobs:
       - name: Create k3d cluster
         uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.23
+          version: v1.24
 
       - name: Remove node taints
         run: |
@@ -209,7 +209,7 @@ jobs:
       - name: Create k3d cluster
         uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.23
+          version: v1.24
 
       - name: Remove node taints
         run: |
@@ -257,7 +257,7 @@ jobs:
       - name: Create k3d cluster
         uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.23
+          version: v1.24
 
       - name: Remove node taints
         run: |
@@ -304,7 +304,7 @@ jobs:
       - name: Create k3d cluster
         uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.23
+          version: v1.24
 
       - name: Remove node taints
         run: |
@@ -351,7 +351,7 @@ jobs:
       - name: Create k3d cluster
         uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.23
+          version: v1.24
 
       - name: Remove node taints
         run: |
@@ -398,7 +398,7 @@ jobs:
       - name: Create k3d cluster
         uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.23
+          version: v1.24
 
       - name: Remove node taints
         run: |


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

Currently latest `k3s` version for `1.23`, is `1.23.7-k3s1`.
For this version their docker tags are in the format of  `1.23.7-k3s1-<ARCHITECTURE>`

But the action script tries to pull tries to pull image with tag `1.23.7-k3s1` because it's based on the github's release version.

Either we specify `with.version` to `1.23.6`, which has appropriate tag or we use `1.24` which also has appropriate tag

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
