### PR TITLE
fix(openspeedtest): fix port conflict

### DIFF
--- a/charts/incubator/openspeedtest/Chart.yaml
+++ b/charts/incubator/openspeedtest/Chart.yaml
@@ -21,7 +21,7 @@ name: openspeedtest
 sources:
 - https://github.com/openspeedtest/Speed-Test
 type: application
-version: 0.0.1
+version: 0.0.2
 annotations:
   truecharts.org/catagories: |
     - utilities

--- a/charts/incubator/openspeedtest/questions.yaml
+++ b/charts/incubator/openspeedtest/questions.yaml
@@ -104,7 +104,7 @@ questions:
                             description: "This port exposes the container port on the service"
                             schema:
                               type: int
-                              default: 10250
+                              default: 10246
                               required: true
                           - variable: advanced
                             label: "Show Advanced settings"

--- a/charts/incubator/openspeedtest/questions.yaml
+++ b/charts/incubator/openspeedtest/questions.yaml
@@ -104,7 +104,7 @@ questions:
                             description: "This port exposes the container port on the service"
                             schema:
                               type: int
-                              default: 10246
+                              default: 10251
                               required: true
                           - variable: advanced
                             label: "Show Advanced settings"

--- a/charts/incubator/openspeedtest/values.yaml
+++ b/charts/incubator/openspeedtest/values.yaml
@@ -17,7 +17,7 @@ service:
     ports:
       main:
         targetPort: 3000
-        port: 10246
+        port: 10251
 
 probes:
   liveness:

--- a/charts/incubator/openspeedtest/values.yaml
+++ b/charts/incubator/openspeedtest/values.yaml
@@ -17,7 +17,7 @@ service:
     ports:
       main:
         targetPort: 3000
-        port: 10250
+        port: 10246
 
 probes:
   liveness:


### PR DESCRIPTION
**Description**
when installing OpenSpeedTest i was getting this error
`[EFAULT] Failed to install chart release: Error: INSTALLATION FAILED: Service "openspeedtest" is invalid: spec.ports[0]: Invalid value: 10250: may not expose port 10250 externally since it is used by kubele`

@zasx from Discord told me to change it to 1246.

i did that with this PR.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
