### PR TITLE
fix(apps): change some common references to tc.common

### DIFF
--- a/charts/dependency/promtail/Chart.yaml
+++ b/charts/dependency/promtail/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://grafana.com/oss/loki/
   - https://grafana.com/docs/loki/latest/
 type: application
-version: 3.0.13
+version: 3.0.14
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/dependency/promtail/templates/_servicemonitor.tpl
+++ b/charts/dependency/promtail/templates/_servicemonitor.tpl
@@ -4,13 +4,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "common.names.fullname" . -}}
+  name: {{ include "tc.common.names.fullname" . -}}
   {{- with .Values.serviceMonitor.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "tc.common.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -21,7 +21,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      {{- include "tc.common.labels.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: http-metrics
       {{- with .Values.serviceMonitor.interval }}

--- a/charts/stable/grafana/Chart.yaml
+++ b/charts/stable/grafana/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
 type: application
-version: 4.0.14
+version: 4.0.15
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/stable/grafana/templates/prometheusrules.yaml
+++ b/charts/stable/grafana/templates/prometheusrules.yaml
@@ -2,15 +2,15 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "tc.common.names.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "tc.common.labels" . | nindent 4 }}
     {{- with .Values.metrics.prometheusRule.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   groups:
-    - name: {{ include "common.names.fullname" . }}
+    - name: {{ include "tc.common.names.fullname" . }}
       rules:
         {{- with .Values.metrics.prometheusRule.rules }}
         {{- toYaml . | nindent 8 }}

--- a/charts/stable/grafana/templates/servicemonitor.yaml
+++ b/charts/stable/grafana/templates/servicemonitor.yaml
@@ -2,16 +2,16 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "tc.common.names.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "tc.common.labels" . | nindent 4 }}
     {{- with .Values.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   selector:
     matchLabels:
-      {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      {{- include "tc.common.labels.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: main
       {{- with .Values.metrics.serviceMonitor.interval }}

--- a/charts/stable/loki/Chart.yaml
+++ b/charts/stable/loki/Chart.yaml
@@ -23,7 +23,7 @@ name: loki
 sources:
   - https://github.com/grafana/loki
 type: application
-version: 5.0.8
+version: 5.0.9
 annotations:
   truecharts.org/catagories: |
     - logs

--- a/charts/stable/loki/values.yaml
+++ b/charts/stable/loki/values.yaml
@@ -32,7 +32,7 @@ args:
 #   alerting:
 #     enabled: true
 #     data:
-#       '{{ include "common.names.fullname" . }}-alerting-rules.yaml': |-
+#       '{{ include "tc.common.names.fullname" . }}-alerting-rules.yaml': |-
 #       {{- if gt (len .Values.alerting_groups) 0 }}
 #           groups:
 #           {{- toYaml .Values.alerting_groups | nindent 6 }}

--- a/charts/stable/promcord/Chart.yaml
+++ b/charts/stable/promcord/Chart.yaml
@@ -21,7 +21,7 @@ name: promcord
 sources:
   - https://github.com/nimarion/promcord
 type: application
-version: 4.0.8
+version: 4.0.9
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/stable/promcord/templates/prometheusrules.yaml
+++ b/charts/stable/promcord/templates/prometheusrules.yaml
@@ -2,22 +2,22 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "tc.common.names.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "tc.common.labels" . | nindent 4 }}
     {{- with .Values.metrics.prometheusRule.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   groups:
-    - name: {{ include "common.names.fullname" . }}
+    - name: {{ include "tc.common.names.fullname" . }}
       rules:
         - alert: PromcordAbsent
           annotations:
             description: Promcord has disappeared from Prometheus service discovery.
             summary: Promcord is down.
           expr: |
-            absent(up{job=~".*{{ include "common.names.fullname" . }}.*"} == 1)
+            absent(up{job=~".*{{ include "tc.common.names.fullname" . }}.*"} == 1)
           for: 5m
           labels:
             severity: critical

--- a/charts/stable/promcord/templates/servicemonitor.yaml
+++ b/charts/stable/promcord/templates/servicemonitor.yaml
@@ -2,16 +2,16 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "tc.common.names.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "tc.common.labels" . | nindent 4 }}
     {{- with .Values.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   selector:
     matchLabels:
-      {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      {{- include "tc.common.labels.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: metrics
       {{- with .Values.metrics.serviceMonitor.interval }}

--- a/charts/stable/speedtest-exporter/Chart.yaml
+++ b/charts/stable/speedtest-exporter/Chart.yaml
@@ -21,7 +21,7 @@ name: speedtest-exporter
 sources:
 - https://github.com/MiguelNdeCarvalho/speedtest-exporter/
 type: application
-version: 3.0.8
+version: 3.0.9
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/stable/speedtest-exporter/templates/prometheusrules.yaml
+++ b/charts/stable/speedtest-exporter/templates/prometheusrules.yaml
@@ -2,22 +2,22 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "tc.common.names.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "tc.common.labels" . | nindent 4 }}
     {{- with .Values.metrics.prometheusRule.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   groups:
-    - name: {{ include "common.names.fullname" . }}
+    - name: {{ include "tc.common.names.fullname" . }}
       rules:
         - alert: SpeedtestExporterAbsent
           annotations:
             description: Speedtest Exporter has disappeared from Prometheus target discovery.
             summary: Speedtest Exporter is down.
           expr: |
-            absent(up{job=~".*{{ include "common.names.fullname" . }}.*"} == 1)
+            absent(up{job=~".*{{ include "tc.common.names.fullname" . }}.*"} == 1)
           for: {{ trimAll "m" .Values.metrics.serviceMonitor.interval | add 15 }}m
           labels:
             severity: critical
@@ -26,7 +26,7 @@ spec:
             description: Internet download speed is averaging {{ "{{ humanize $value }}" }} Mbps.
             summary: SpeedTest slow internet download.
           expr: |
-            avg_over_time(speedtest_download_bits_per_second{job=~".*{{ include "common.names.fullname" . }}.*"}[4h])
+            avg_over_time(speedtest_download_bits_per_second{job=~".*{{ include "tc.common.names.fullname" . }}.*"}[4h])
               < {{ .Values.metrics.prometheusRule.downloadLimit }}
           for: 0m
           labels:
@@ -36,7 +36,7 @@ spec:
             description: Internet upload speed is averaging {{ "{{ humanize $value }}" }} Mbps.
             summary: SpeedTest slow internet upload.
           expr: |
-            avg_over_time(speedtest_upload_bits_per_second{job=~".*{{ include "common.names.fullname" . }}.*"}[4h])
+            avg_over_time(speedtest_upload_bits_per_second{job=~".*{{ include "tc.common.names.fullname" . }}.*"}[4h])
               < {{ .Values.metrics.prometheusRule.uploadLimit }}
           for: 0m
           labels:
@@ -46,7 +46,7 @@ spec:
             description: Internet ping latency is averaging {{ "{{ humanize $value }}" }} ms.
             summary: SpeedTest high ping latency.
           expr: |
-            avg_over_time(speedtest_ping_latency_milliseconds{job=~".*{{ include "common.names.fullname" . }}.*"}[4h])
+            avg_over_time(speedtest_ping_latency_milliseconds{job=~".*{{ include "tc.common.names.fullname" . }}.*"}[4h])
               > {{ .Values.metrics.prometheusRule.pingLimit }}
           for: 0m
           labels:
@@ -56,7 +56,7 @@ spec:
             description: Internet jitter latency is averaging {{ "{{ humanize $value }}" }} ms.
             summary: SpeedTest high jitter latency.
           expr: |
-            avg_over_time(speedtest_jitter_latency_milliseconds{job=~".*{{ include "common.names.fullname" . }}.*"}[4h])
+            avg_over_time(speedtest_jitter_latency_milliseconds{job=~".*{{ include "tc.common.names.fullname" . }}.*"}[4h])
               > {{ .Values.metrics.prometheusRule.jitterLimit }}
           for: 0m
           labels:

--- a/charts/stable/speedtest-exporter/templates/servicemonitor.yaml
+++ b/charts/stable/speedtest-exporter/templates/servicemonitor.yaml
@@ -2,16 +2,16 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "tc.common.names.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "tc.common.labels" . | nindent 4 }}
     {{- with .Values.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   selector:
     matchLabels:
-      {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      {{- include "tc.common.labels.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: metrics
       {{- with .Values.metrics.serviceMonitor.interval }}

--- a/charts/stable/unpoller/Chart.yaml
+++ b/charts/stable/unpoller/Chart.yaml
@@ -22,7 +22,7 @@ sources:
 - https://github.com/unifi-poller/unifi-poller
 - https://hub.docker.com/r/golift/unifi-poller
 type: application
-version: 3.0.8
+version: 3.0.9
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/stable/unpoller/templates/prometheusrules.yaml
+++ b/charts/stable/unpoller/templates/prometheusrules.yaml
@@ -2,22 +2,22 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "tc.common.names.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "tc.common.labels" . | nindent 4 }}
     {{- with .Values.metrics.prometheusRule.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   groups:
-    - name: {{ include "common.names.fullname" . }}
+    - name: {{ include "tc.common.names.fullname" . }}
       rules:
         - alert: UnifiPollerAbsent
           annotations:
             description: Unifi Poller has disappeared from Prometheus service discovery.
             summary: Unifi Poller is down.
           expr: |
-            absent(up{job=~".*{{ include "common.names.fullname" . }}.*"} == 1)
+            absent(up{job=~".*{{ include "tc.common.names.fullname" . }}.*"} == 1)
           for: 5m
           labels:
             severity: critical

--- a/charts/stable/unpoller/templates/servicemonitor.yaml
+++ b/charts/stable/unpoller/templates/servicemonitor.yaml
@@ -2,16 +2,16 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "tc.common.names.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "tc.common.labels" . | nindent 4 }}
     {{- with .Values.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   selector:
     matchLabels:
-      {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      {{- include "tc.common.labels.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: metrics
       {{- with .Values.metrics.serviceMonitor.interval }}

--- a/charts/stable/uptimerobot-prometheus/Chart.yaml
+++ b/charts/stable/uptimerobot-prometheus/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/lekpamartin/uptimerobot_exporter
   - https://github.com/k8s-at-home/charts/tree/master/charts/uptimerobot-prometheus
 type: application
-version: 4.0.8
+version: 4.0.9
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/stable/uptimerobot-prometheus/templates/prometheusrules.yaml
+++ b/charts/stable/uptimerobot-prometheus/templates/prometheusrules.yaml
@@ -2,22 +2,22 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "tc.common.names.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "tc.common.labels" . | nindent 4 }}
     {{- with .Values.metrics.prometheusRule.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   groups:
-    - name: {{ include "common.names.fullname" . }}
+    - name: {{ include "tc.common.names.fullname" . }}
       rules:
         - alert: UptimeRobotExporterAbsent
           annotations:
             description: Uptime Robot Exporter has disappeared from Prometheus service discovery.
             summary: Uptime Robot Exporter is down.
           expr: |
-            absent(up{job=~".*{{ include "common.names.fullname" . }}.*"} == 1)
+            absent(up{job=~".*{{ include "tc.common.names.fullname" . }}.*"} == 1)
           for: 5m
           labels:
             severity: critical

--- a/charts/stable/uptimerobot-prometheus/templates/servicemonitor.yaml
+++ b/charts/stable/uptimerobot-prometheus/templates/servicemonitor.yaml
@@ -2,16 +2,16 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "tc.common.names.fullname" . }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "tc.common.labels" . | nindent 4 }}
     {{- with .Values.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   selector:
     matchLabels:
-      {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      {{- include "tc.common.labels.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: metrics
       {{- with .Values.metrics.serviceMonitor.interval }}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Did a quick search for leftovers of common references and added a `tc.` in front of them.

Also I made sure that the new references eg (`tc.common.labels.selectorLabels`) was already exist by at least one other chart in the same format.

I'm not sure if there is more that needs to be done. If so, I'll have to look into it further.

⚒️ Fixes  #2969

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
