### PR TITLE
[WIP] fix(etesync): unset PUID

### DIFF
--- a/charts/incubator/etesync/Chart.yaml
+++ b/charts/incubator/etesync/Chart.yaml
@@ -31,10 +31,10 @@ sources:
   - https://github.com/victor-rds/docker-etebase
   - https://hub.docker.com/r/victorrds/etesync
 type: application
-version: 0.0.1
+version: 0.0.2
 annotations:
   truecharts.org/catagories: |
-    - productivity
+    - etesync
     - sync
     - contacts
     - calendars

--- a/charts/incubator/etesync/values.yaml
+++ b/charts/incubator/etesync/values.yaml
@@ -10,7 +10,7 @@ image:
 # https://github.com/etesync/server#configuration
 
 security:
-  PUID: 0
+  PUID: ""
 
 podSecurityContext:
   runAsUser: 373

--- a/charts/incubator/etesync/values.yaml
+++ b/charts/incubator/etesync/values.yaml
@@ -3,16 +3,19 @@ image:
   pullPolicy: IfNotPresent
   tag: 0.9.1@sha256:a880ed256dd78f14fb8dc9ab2e72ca2acebd3b8a87db65ea038f30abed27d896
 
-podSecurityContext:
-  runAsUser: 373
-  runAsGroup: 373
-  fsGroup: 373
-
 # Docker image configuration docs:
 # https://github.com/victor-rds/docker-etebase#settings-and-customization
 
 # EteSync configuration docs:
 # https://github.com/etesync/server#configuration
+
+security:
+  PUID: 0
+
+podSecurityContext:
+  runAsUser: 373
+  runAsGroup: 373
+  fsGroup: 373
 
 env:
   # App


### PR DESCRIPTION
**Description**

Currently EteSync outputs the following warning:

```text
[Warn] [Entrypoint]: Setting PUID/PGID is no longer supported, change the user running the container
```

caused by [the following entrypoint.sh code](https://github.com/victor-rds/docker-etebase/blob/master/context/entrypoint.sh#L72-L74):

```bash
if [ -n "${PUID}" ] || [ -n "${PGID}" ]; then
  dckr_warn "Setting PUID/PGID is no longer supported, change the user running the container"
fi
```

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
