### PR TITLE
fix(linkace): set fsGroup to www-data (82)

### DIFF
--- a/charts/stable/linkace/Chart.yaml
+++ b/charts/stable/linkace/Chart.yaml
@@ -27,7 +27,7 @@ sources:
 - https://www.linkace.org/docs/
 - https://github.com/linkace/linkace
 - https://hub.docker.com/r/linkace/linkace
-version: 4.0.12
+version: 4.0.13
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/linkace/questions.yaml
+++ b/charts/stable/linkace/questions.yaml
@@ -415,7 +415,7 @@ questions:
           description: "The group that should own ALL storage."
           schema:
             type: int
-            default: 568
+            default: 82
 # Include{podSecurityContextAdvanced}
 
 # Include{resources}

--- a/charts/stable/linkace/values.yaml
+++ b/charts/stable/linkace/values.yaml
@@ -10,6 +10,7 @@ securityContext:
 podSecurityContext:
   runAsUser: 0
   runAsGroup: 0
+  fsGroup: 82
 
 # secretEnv:
 #   CRON_TOKEN: ""


### PR DESCRIPTION
**Description**

Starting up Linkace currently causes 500 internal server errors because the web process is unable to write to the log directory.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

Setting fsGroup to 82 through Web GUI fixes 500 errors. See also: https://github.com/Kovah/LinkAce/issues/332

**📃 Notes:**

One issue still remaining is that `.env` is not writable during the setup process. The user has to use the container shell to `chmod 777 .env` to be able to finish the setup. I think this is an upstream issue, but is there maybe an easy fix we can implement?

![image](https://user-images.githubusercontent.com/3743342/177013170-ba7122e7-8325-4e30-b768-08fb313bf179.png)

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
