### PR TITLE
chore(apps): remove protocol: http|https|tcp

### DIFF
--- a/charts/incubator/adguard-home/Chart.yaml
+++ b/charts/incubator/adguard-home/Chart.yaml
@@ -18,7 +18,7 @@ maintainers:
 name: adguard-home
 sources:
 - https://hub.docker.com/r/adguard/adguardhome
-version: 1.0.7
+version: 1.0.8
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/incubator/adguard-home/questions.yaml
+++ b/charts/incubator/adguard-home/questions.yaml
@@ -139,9 +139,9 @@ questions:
                                   schema:
                                     type: int
                                     default: 3000
-        - variable: dns-tcp
-          label: "dns-tcp Service"
-          description: "dns-tcp service"
+        - variable: dns
+          label: "dns Service"
+          description: "dns service"
           schema:
             additional_attrs: true
             type: dict
@@ -194,14 +194,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 53
-        - variable: dns-udp
-          label: "dns-udp Service"
-          description: "dns-udp service"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
                     - variable: dns-udp
                       label: "dns-udp Service Port Configuration"
                       schema:
@@ -312,8 +304,8 @@ questions:
             type: dict
             attrs:
 # Include{serviceSelector}
-                    - variable: dns-https
-                      label: "dns-https Service Port Configuration"
+                    - variable: dns-https-tcp
+                      label: "dns-https-tcp Service Port Configuration"
                       schema:
                         additional_attrs: true
                         type: dict
@@ -359,14 +351,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 443
-        - variable: dns-https-udp
-          label: "dns-https-udp Service"
-          description: "The dns-https-udp service."
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
                     - variable: dns-https-udp
                       label: "dns-https-udp Service Port Configuration"
                       schema:
@@ -422,8 +406,8 @@ questions:
             type: dict
             attrs:
 # Include{serviceSelector}
-                    - variable: dns-crypt
-                      label: "dns-crypt Service Port Configuration"
+                    - variable: dns-crypt-tcp
+                      label: "dns-crypt-tcp Service Port Configuration"
                       schema:
                         additional_attrs: true
                         type: dict
@@ -469,14 +453,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 5443
-        - variable: dns-crypt-udp
-          label: "dns-crypt-udp Service"
-          description: "The dns-crypt-udp service."
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
                     - variable: dns-crypt-udp
                       label: "dns-crypt-udp Service Port Configuration"
                       schema:
@@ -524,9 +500,9 @@ questions:
                                   schema:
                                     type: int
                                     default: 5443
-        - variable: dns-quic-udp-1
-          label: "dns-quic-udp-1 Service"
-          description: "The dns-quic-udp-1 service."
+        - variable: dns-quic
+          label: "dns-quic Service"
+          description: "The dns-quic service."
           schema:
             additional_attrs: true
             type: dict
@@ -579,14 +555,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 784
-        - variable: dns-quic-udp-2
-          label: "dns-quic-udp-2 Service"
-          description: "The dns-quic-udp-2 service."
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
                     - variable: dns-quic-udp-2
                       label: "dns-quic-udp-2 Service Port Configuration"
                       schema:
@@ -634,14 +602,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 853
-        - variable: dns-quic-udp-3
-          label: "dns-quic-udp-3 Service"
-          description: "The dns-quic-udp-3 service."
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
                     - variable: dns-quic-udp-3
                       label: "dns-quic-udp-3 Service Port Configuration"
                       schema:

--- a/charts/incubator/adguard-home/values.yaml
+++ b/charts/incubator/adguard-home/values.yaml
@@ -18,16 +18,13 @@ service:
       main:
         port: 10232
         targetPort: 3000
-  dns-tcp:
+  dns:
     enabled: true
     ports:
       dns-tcp:
         enabled: true
         port: 53
         targetPort: 53
-  dns-udp:
-    enabled: true
-    ports:
       dns-udp:
         enabled: true
         protocol: UDP
@@ -36,20 +33,17 @@ service:
   dns-http:
     enabled: true
     ports:
-      dns-http:
+      dns-http-tcp:
         enabled: true
         port: 10233
         targetPort: 80
   dns-https:
     enabled: true
     ports:
-      dns-https:
+      dns-https-tcp:
         enabled: true
         port: 10234
         targetPort: 443
-  dns-https-udp:
-    enabled: true
-    ports:
       dns-https-udp:
         enabled: true
         protocol: UDP
@@ -58,19 +52,16 @@ service:
   dns-crypt:
     enabled: true
     ports:
-      dns-crypt:
+      dns-crypt-tcp:
         enabled: true
         port: 5443
         targetPort: 5443
-  dns-crypt-udp:
-    enabled: true
-    ports:
       dns-crypt-udp:
         enabled: true
         protocol: UDP
         port: 5443
         targetPort: 5443
-  dns-quic-udp-1:
+  dns-quic:
     enabled: true
     ports:
       dns-quic-udp-1:
@@ -78,17 +69,11 @@ service:
         protocol: UDP
         port: 784
         targetPort: 784
-  dns-quic-udp-2:
-    enabled: true
-    ports:
       dns-quic-udp-2:
         enabled: true
         protocol: UDP
         port: 853
         targetPort: 853
-  dns-quic-udp-3:
-    enabled: true
-    ports:
       dns-quic-udp-3:
         enabled: true
         protocol: UDP

--- a/charts/incubator/authentik/Chart.yaml
+++ b/charts/incubator/authentik/Chart.yaml
@@ -26,7 +26,7 @@ name: authentik
 sources:
 - https://github.com/goauthentik/authentik
 - https://goauthentik.io/docs/
-version: 2.0.9
+version: 2.0.10
 annotations:
   truecharts.org/catagories: |
     - authentication

--- a/charts/incubator/authentik/values.yaml
+++ b/charts/incubator/authentik/values.yaml
@@ -96,7 +96,6 @@ service:
     ports:
       https:
         enabled: true
-        protocol: "HTTPS"
         port: 10229
         targetPort: 9443
 

--- a/charts/incubator/cloudflared/Chart.yaml
+++ b/charts/incubator/cloudflared/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: cloudflared
-version: 0.0.1
+version: 0.0.2
 appVersion: "2022.6.3"
 description: Client for Cloudflare Tunnel, a daemon that exposes private services through the Cloudflare edge.
 type: application

--- a/charts/incubator/cloudflared/values.yaml
+++ b/charts/incubator/cloudflared/values.yaml
@@ -17,7 +17,6 @@ podSecurityContext:
 
 service:
   main:
-    protocol: HTTP
     ports:
       main:
         targetPort: 6969

--- a/charts/incubator/etesync/Chart.yaml
+++ b/charts/incubator/etesync/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - https://github.com/victor-rds/docker-etebase
   - https://hub.docker.com/r/victorrds/etesync
 type: application
-version: 0.0.2
+version: 0.0.3
 annotations:
   truecharts.org/catagories: |
     - productivity

--- a/charts/incubator/etesync/values.yaml
+++ b/charts/incubator/etesync/values.yaml
@@ -50,7 +50,6 @@ secretEnv:
 
 service:
   main:
-    protocol: HTTP
     ports:
       main:
         targetPort: 3735

--- a/charts/incubator/frigate/Chart.yaml
+++ b/charts/incubator/frigate/Chart.yaml
@@ -23,7 +23,7 @@ sources:
 - https://github.com/blakeblackshear/frigate
 - https://hub.docker.com/r/blakeblackshear/frigate
 type: application
-version: 2.0.8
+version: 2.0.9
 annotations:
   truecharts.org/catagories: |
     - nvr

--- a/charts/incubator/frigate/values.yaml
+++ b/charts/incubator/frigate/values.yaml
@@ -416,7 +416,6 @@ service:
     enabled: true
     ports:
       rtmp:
-        protocol: TCP
         enabled: true
         port: 1935
         targetPort: 1935

--- a/charts/incubator/homebridge/Chart.yaml
+++ b/charts/incubator/homebridge/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 - https://homebridge.io/
 - https://github.com/oznu/docker-homebridge
 type: application
-version: 1.0.8
+version: 1.0.9
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/incubator/homebridge/values.yaml
+++ b/charts/incubator/homebridge/values.yaml
@@ -5,7 +5,6 @@ image:
 
 service:
   main:
-    protocol: HTTP
     ports:
       main:
         targetPort: 8581

--- a/charts/incubator/meshcentral/Chart.yaml
+++ b/charts/incubator/meshcentral/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: meshcentral
-version: 3.0.9
+version: 3.0.10
 appVersion: "1.0.41"
 description: MeshCentral is a full computer management web site
 type: application

--- a/charts/incubator/meshcentral/values.yaml
+++ b/charts/incubator/meshcentral/values.yaml
@@ -21,7 +21,6 @@ service:
   main:
     ports:
       main:
-        protocol: "HTTPS"
         port: 10205
 
 initContainers:

--- a/charts/incubator/privatebin/Chart.yaml
+++ b/charts/incubator/privatebin/Chart.yaml
@@ -26,7 +26,7 @@ sources:
   - https://github.com/PrivateBin/PrivateBin
   - https://hub.docker.com/r/privatebin/pdo
 type: application
-version: 0.0.5
+version: 0.0.6
 annotations:
   truecharts.org/catagories: |
     - productivity

--- a/charts/incubator/privatebin/values.yaml
+++ b/charts/incubator/privatebin/values.yaml
@@ -50,7 +50,6 @@ env:
 
 service:
   main:
-    protocol: HTTP
     ports:
       main:
         targetPort: 8080

--- a/charts/incubator/radicale/Chart.yaml
+++ b/charts/incubator/radicale/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/tomsquest/docker-radicale
   - https://hub.docker.com/r/tomsquest/docker-radicale
 type: application
-version: 0.0.3
+version: 0.0.4
 annotations:
   truecharts.org/catagories: |
     - radicale

--- a/charts/incubator/radicale/values.yaml
+++ b/charts/incubator/radicale/values.yaml
@@ -56,7 +56,6 @@ env:
 
 service:
   main:
-    protocol: HTTP
     ports:
       main:
         targetPort: 5232

--- a/charts/incubator/technitium/Chart.yaml
+++ b/charts/incubator/technitium/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 - https://technitium.com/
 - https://hub.docker.com/r/technitium/dns-server
 type: application
-version: 1.0.7
+version: 1.0.8
 annotations:
   truecharts.org/catagories: |
     - networking

--- a/charts/incubator/technitium/Chart.yaml
+++ b/charts/incubator/technitium/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 - https://technitium.com/
 - https://hub.docker.com/r/technitium/dns-server
 type: application
-version: 1.0.8
+version: 1.0.9
 annotations:
   truecharts.org/catagories: |
     - networking

--- a/charts/incubator/technitium/questions.yaml
+++ b/charts/incubator/technitium/questions.yaml
@@ -254,65 +254,9 @@ questions:
                                     type: int
                                     default: 5380
 
-        - variable: dns-udp
-          label: "DNS-UDP Service"
-          description: "DNS-UDP Service"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
-                    - variable: dns-udp
-                      label: "DNS-UDP Service Port Configuration"
-                      schema:
-                        additional_attrs: true
-                        type: dict
-                        attrs:
-                          - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
-                            schema:
-                              type: int
-                              default: 53
-                              required: true
-                          - variable: advanced
-                            label: "Show Advanced settings"
-                            schema:
-                              type: boolean
-                              default: false
-                              show_subquestions_if: true
-                              subquestions:
-                                - variable: protocol
-                                  label: "Port Type"
-                                  schema:
-                                    type: string
-                                    default: "UDP"
-                                    enum:
-                                      - value: HTTP
-                                        description: "HTTP"
-                                      - value: "HTTPS"
-                                        description: "HTTPS"
-                                      - value: TCP
-                                        description: "TCP"
-                                      - value: "UDP"
-                                        description: "UDP"
-                                - variable: nodePort
-                                  label: "Node Port (Optional)"
-                                  description: "This port gets exposed to the node. Only considered when service type is NodePort, Simple or LoadBalancer"
-                                  schema:
-                                    type: int
-                                    min: 9000
-                                    max: 65535
-                                - variable: targetPort
-                                  label: "Target Port"
-                                  description: "The internal(!) port on the container the Application runs on"
-                                  schema:
-                                    type: int
-                                    default: 53
-
-        - variable: dns-tcp
-          label: "DNS-TCP Service"
-          description: "DNS-TCP Service"
+        - variable: dns
+          label: "DNS Service"
+          description: "DNS Service"
           schema:
             additional_attrs: true
             type: dict
@@ -365,7 +309,53 @@ questions:
                                   schema:
                                     type: int
                                     default: 53
-
+                    - variable: dns-udp
+                      label: "DNS-UDP Service Port Configuration"
+                      schema:
+                        additional_attrs: true
+                        type: dict
+                        attrs:
+                          - variable: port
+                            label: "Port"
+                            description: "This port exposes the container port on the service"
+                            schema:
+                              type: int
+                              default: 53
+                              required: true
+                          - variable: advanced
+                            label: "Show Advanced settings"
+                            schema:
+                              type: boolean
+                              default: false
+                              show_subquestions_if: true
+                              subquestions:
+                                - variable: protocol
+                                  label: "Port Type"
+                                  schema:
+                                    type: string
+                                    default: "UDP"
+                                    enum:
+                                      - value: HTTP
+                                        description: "HTTP"
+                                      - value: "HTTPS"
+                                        description: "HTTPS"
+                                      - value: TCP
+                                        description: "TCP"
+                                      - value: "UDP"
+                                        description: "UDP"
+                                - variable: nodePort
+                                  label: "Node Port (Optional)"
+                                  description: "This port gets exposed to the node. Only considered when service type is NodePort, Simple or LoadBalancer"
+                                  schema:
+                                    type: int
+                                    min: 9000
+                                    max: 65535
+                                - variable: targetPort
+                                  label: "Target Port"
+                                  description: "The internal(!) port on the container the Application runs on"
+                                  schema:
+                                    type: int
+                                    default: 53
         - variable: dns-tls
           label: "DNS-TLS Service"
           description: "DNS-TLS Service"

--- a/charts/incubator/technitium/values.yaml
+++ b/charts/incubator/technitium/values.yaml
@@ -33,16 +33,13 @@ service:
       main:
         port: 5380
         targetPort: 5380
-  dns-tcp:
+  dns:
     enabled: true
     ports:
       dns-tcp:
         enabled: true
         port: 53
         targetPort: 53
-  dns-udp:
-    enabled: true
-    ports:
       dns-udp:
         enabled: true
         protocol: UDP

--- a/charts/incubator/technitium/values.yaml
+++ b/charts/incubator/technitium/values.yaml
@@ -53,7 +53,6 @@ service:
     ports:
       dns-tls:
         enabled: true
-        protocol: TCP
         port: 853
         targetPort: 853
   dns-cert:
@@ -61,7 +60,6 @@ service:
     ports:
       dns-cert:
         enabled: true
-        protocol: TCP
         port: 10202
         targetPort: 80
   dns-https:
@@ -69,7 +67,6 @@ service:
     ports:
       dns-https:
         enabled: true
-        protocol: TCP
         port: 10203
         targetPort: 443
   dns-https-proxy:
@@ -77,7 +74,6 @@ service:
     ports:
       dns-https-proxy:
         enabled: true
-        protocol: TCP
         port: 10204
         targetPort: 8053
 

--- a/charts/stable/deluge/Chart.yaml
+++ b/charts/stable/deluge/Chart.yaml
@@ -21,7 +21,7 @@ name: deluge
 sources:
 - https://github.com/deluge-torrent/deluge
 type: application
-version: 11.0.7
+version: 11.0.8
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/deluge/questions.yaml
+++ b/charts/stable/deluge/questions.yaml
@@ -197,14 +197,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 51413
-        - variable: torrent-udp
-          label: "UDP Torrent Service"
-          description: "UDP Torrent Service"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
                     - variable: udp
                       label: "UDP Service Port Configuration"
                       schema:

--- a/charts/stable/deluge/values.yaml
+++ b/charts/stable/deluge/values.yaml
@@ -24,9 +24,6 @@ service:
         enabled: true
         port: 51413
         targetPort: 51413
-  torrent-udp:
-    enabled: true
-    ports:
       udp:
         enabled: true
         port: 51413

--- a/charts/stable/grafana/Chart.yaml
+++ b/charts/stable/grafana/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
 type: application
-version: 4.0.16
+version: 4.0.17
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/stable/grafana/values.yaml
+++ b/charts/stable/grafana/values.yaml
@@ -8,7 +8,6 @@ securityContext:
 
 service:
   main:
-    protocol: HTTP
     ports:
       main:
         targetPort: 3000

--- a/charts/stable/ipfs/Chart.yaml
+++ b/charts/stable/ipfs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: ipfs
-version: 3.0.8
+version: 3.0.9
 appVersion: "0.13.0"
 description: IPFS is a global, versioned, peer-to-peer filesystem. It combines good ideas from previous systems such Git, BitTorrent, Kademlia, SFS, and the Web. It is like a single bittorrent swarm, exchanging git objects.
 type: application

--- a/charts/stable/ipfs/questions.yaml
+++ b/charts/stable/ipfs/questions.yaml
@@ -171,9 +171,9 @@ questions:
                                   schema:
                                     type: int
                                     default: 5001
-        - variable: peer-tcp
-          label: "Peer-TCP Service"
-          description: "The Peer-TCP service."
+        - variable: peer
+          label: "Peer Service"
+          description: "The Peer service."
           schema:
             additional_attrs: true
             type: dict
@@ -231,14 +231,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 4001
-        - variable: peer-udp
-          label: "Peer-UDP Service"
-          description: "The Peer-udp service."
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
                     - variable: peer-udp
                       label: "Peer-UDP Service Port Configuration"
                       schema:

--- a/charts/stable/ipfs/values.yaml
+++ b/charts/stable/ipfs/values.yaml
@@ -22,16 +22,13 @@ service:
       main:
         port: 10125
         targetPort: 5001
-  peer-tcp:
+  peer:
     enabled: true
     ports:
       peer-tcp:
         enabled: true
         targetPort: 4001
         port: 4001
-  peer-udp:
-    enabled: true
-    ports:
       peer-udp:
         protocol: UDP
         enabled: true

--- a/charts/stable/jackett/Chart.yaml
+++ b/charts/stable/jackett/Chart.yaml
@@ -21,7 +21,7 @@ name: jackett
 sources:
 - https://github.com/Jackett/Jackett
 type: application
-version: 11.0.18
+version: 11.0.19
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/jackett/values.yaml
+++ b/charts/stable/jackett/values.yaml
@@ -8,7 +8,6 @@ securityContext:
 
 service:
   main:
-    protocol: HTTP
     ports:
       main:
         targetPort: 9117

--- a/charts/stable/logitech-media-server/Chart.yaml
+++ b/charts/stable/logitech-media-server/Chart.yaml
@@ -23,7 +23,7 @@ sources:
 - https://github.com/Logitech/slimserver
 - https://hub.docker.com/r/lmscommunity/logitechmediaserver
 type: application
-version: 4.0.7
+version: 4.0.8
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/logitech-media-server/questions.yaml
+++ b/charts/stable/logitech-media-server/questions.yaml
@@ -176,9 +176,9 @@ questions:
                               default: 10059
                               required: true
 
-        - variable: playertcp
-          label: "Logitech Media Server Player TCP Communcation"
-          description: "Logitech Media Server Player Service for TCP communication"
+        - variable: player
+          label: "Logitech Media Server Player Communcation"
+          description: "Logitech Media Server Player Service for communication"
           schema:
             additional_attrs: true
             type: dict
@@ -211,15 +211,6 @@ questions:
                               type: int
                               default: 3483
                               required: true
-
-        - variable: playerudp
-          label: "Logitech Media Server Player Communcation"
-          description: "Logitech Media Server Player Service for UDP communication"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
                     - variable: slimprotoudp
                       label: "Player to server UDP communication"
                       schema:

--- a/charts/stable/logitech-media-server/values.yaml
+++ b/charts/stable/logitech-media-server/values.yaml
@@ -34,16 +34,13 @@ service:
         enabled: true
         targetPort: 9090
         port: 10059
-  playertcp:
+  player:
     enabled: true
     ports:
       slimprototcp:
         enabled: true
         targetPort: 3483
         port: 3483
-  playerudp:
-    enabled: true
-    ports:
       slimprotoudp:
         enabled: true
         targetPort: 3483

--- a/charts/stable/loki/Chart.yaml
+++ b/charts/stable/loki/Chart.yaml
@@ -23,7 +23,7 @@ name: loki
 sources:
   - https://github.com/grafana/loki
 type: application
-version: 5.0.9
+version: 5.0.10
 annotations:
   truecharts.org/catagories: |
     - logs

--- a/charts/stable/loki/values.yaml
+++ b/charts/stable/loki/values.yaml
@@ -49,7 +49,6 @@ service:
   main:
     ports:
       main:
-        protocol: HTTP
         targetPort: 3100
         port: 3100
 

--- a/charts/stable/matomo/Chart.yaml
+++ b/charts/stable/matomo/Chart.yaml
@@ -23,7 +23,7 @@ sources:
 - https://hub.docker.com/r/bitnami/matomo
 - https://github.com/bitnami/bitnami-docker-matomo
 - https://github.com/matomo-org/matomo
-version: 3.0.15
+version: 3.0.16
 annotations:
   truecharts.org/catagories: |
     - productivity

--- a/charts/stable/matomo/values.yaml
+++ b/charts/stable/matomo/values.yaml
@@ -72,7 +72,6 @@ service:
   main:
     ports:
       main:
-        protocol: HTTP
         port: 10172
         targetPort: 10172
   https:
@@ -80,7 +79,6 @@ service:
     ports:
       https:
         enabled: true
-        protocol: HTTPS
         port: 10173
         targetPort: 10173
 

--- a/charts/stable/omada-controller/Chart.yaml
+++ b/charts/stable/omada-controller/Chart.yaml
@@ -18,7 +18,7 @@ name: omada-controller
 sources:
 - https://github.com/mbentley/docker-omada-controller
 - https://github.com/truecharts/apps/tree/master/charts/omada-controller
-version: 6.0.18
+version: 6.0.19
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/omada-controller/Chart.yaml
+++ b/charts/stable/omada-controller/Chart.yaml
@@ -18,7 +18,7 @@ name: omada-controller
 sources:
 - https://github.com/mbentley/docker-omada-controller
 - https://github.com/truecharts/apps/tree/master/charts/omada-controller
-version: 6.0.17
+version: 6.0.18
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/omada-controller/questions.yaml
+++ b/charts/stable/omada-controller/questions.yaml
@@ -194,9 +194,9 @@ questions:
                                   schema:
                                     type: int
                                     default: 8843
-        - variable: omada-tcp
-          label: "Omada TCP"
-          description: "Omada TCP"
+        - variable: omada
+          label: "Omada"
+          description: "Omada"
           schema:
             additional_attrs: true
             type: dict
@@ -394,14 +394,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 29814
-        - variable: omada-udp
-          label: "Omada UDP"
-          description: "Omada UDP"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
                     - variable: omada-udp1
                       label: "Omada UDP 1"
                       description: "Omada Controller or EAP Discovery Utility discovers Omada devices."

--- a/charts/stable/omada-controller/values.yaml
+++ b/charts/stable/omada-controller/values.yaml
@@ -24,7 +24,7 @@ service:
         enabled: true
         port: 8843
         targetPort: 8843
-  omada-tcp:
+  omada:
     enabled: true
     ports:
       omada-tcp1:
@@ -43,9 +43,6 @@ service:
         enabled: true
         port: 29814
         targetPort: 29814
-  omada-udp:
-    enabled: true
-    ports:
       omada-udp1:
         enabled: true
         protocol: UDP

--- a/charts/stable/omada-controller/values.yaml
+++ b/charts/stable/omada-controller/values.yaml
@@ -15,14 +15,12 @@ service:
   main:
     ports:
       main:
-        protocol: HTTPS
         port: 8043
         targetPort: 8043
   comm:
     enabled: true
     ports:
       comm:
-        protocol: HTTPS
         enabled: true
         port: 8843
         targetPort: 8843

--- a/charts/stable/openhab/Chart.yaml
+++ b/charts/stable/openhab/Chart.yaml
@@ -19,7 +19,7 @@ name: openhab
 sources:
 - https://hub.docker.com/r/openhab/openhab
 type: application
-version: 2.0.8
+version: 2.0.9
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/openhab/values.yaml
+++ b/charts/stable/openhab/values.yaml
@@ -5,12 +5,10 @@ image:
 
 service:
   main:
-    protocol: HTTP
     ports:
       main:
         port: 10169
   https:
-    protocol: HTTPS
     enabled: true
     ports:
       https:

--- a/charts/stable/openspeedtest/Chart.yaml
+++ b/charts/stable/openspeedtest/Chart.yaml
@@ -21,7 +21,7 @@ name: openspeedtest
 sources:
 - https://github.com/openspeedtest/Speed-Test
 type: application
-version: 1.0.4
+version: 1.0.5
 annotations:
   truecharts.org/catagories: |
     - utilities

--- a/charts/stable/openspeedtest/values.yaml
+++ b/charts/stable/openspeedtest/values.yaml
@@ -13,7 +13,6 @@ podSecurityContext:
 
 service:
   main:
-    protocol: HTTP
     ports:
       main:
         targetPort: 3000

--- a/charts/stable/owncloud-ocis/Chart.yaml
+++ b/charts/stable/owncloud-ocis/Chart.yaml
@@ -25,7 +25,7 @@ name: owncloud-ocis
 sources:
 - https://hub.docker.com/r/owncloud/ocis
 - https://owncloud.dev/ocis/
-version: 7.0.7
+version: 7.0.8
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/owncloud-ocis/values.yaml
+++ b/charts/stable/owncloud-ocis/values.yaml
@@ -31,7 +31,6 @@ service:
   main:
     ports:
       main:
-        protocol: HTTPS
         port: 9200
         targetPort: 9200
 

--- a/charts/stable/pihole/Chart.yaml
+++ b/charts/stable/pihole/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 - https://github.com/pi-hole
 - https://github.com/pi-hole/docker-pi-hole
 type: application
-version: 6.0.7
+version: 6.0.8
 annotations:
   truecharts.org/catagories: |
     - networking

--- a/charts/stable/pihole/questions.yaml
+++ b/charts/stable/pihole/questions.yaml
@@ -175,74 +175,16 @@ questions:
                                   schema:
                                     type: int
                                     default: 80
-
-
         - variable: dns
           label: "DNS Service"
-          description: "The Primary service on which the healthcheck runs, often the webUI"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
-                    - variable: dns
-                      label: "DNS Service Port Configuration"
-                      schema:
-                        additional_attrs: true
-                        type: dict
-                        attrs:
-                          - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
-                            schema:
-                              type: int
-                              default: 53
-                              required: true
-                          - variable: advanced
-                            label: "Show Advanced settings"
-                            schema:
-                              type: boolean
-                              default: false
-                              show_subquestions_if: true
-                              subquestions:
-                                - variable: protocol
-                                  label: "Port Type"
-                                  schema:
-                                    type: string
-                                    default: "UDP"
-                                    enum:
-                                      - value: HTTP
-                                        description: "HTTP"
-                                      - value: "HTTPS"
-                                        description: "HTTPS"
-                                      - value: TCP
-                                        description: "TCP"
-                                      - value: "UDP"
-                                        description: "UDP"
-                                - variable: nodePort
-                                  label: "Node Port (Optional)"
-                                  description: "This port gets exposed to the node. Only considered when service type is NodePort, Simple or LoadBalancer"
-                                  schema:
-                                    type: int
-                                    min: 9000
-                                    max: 65535
-                                - variable: targetPort
-                                  label: "Target Port"
-                                  description: "The internal(!) port on the container the Application runs on"
-                                  schema:
-                                    type: int
-                                    default: 53
-
-        - variable: dns-tcp
-          label: "DNS-TCP Service"
-          description: "The Primary service on which the healthcheck runs, often the webUI"
+          description: "DNS Service"
           schema:
             additional_attrs: true
             type: dict
             attrs:
 # Include{serviceSelector}
                     - variable: dns-tcp
-                      label: "DNS-TCP Service Port Configuration"
+                      label: "DNS-TCP Service"
                       schema:
                         additional_attrs: true
                         type: dict
@@ -266,6 +208,53 @@ questions:
                                   schema:
                                     type: string
                                     default: "TCP"
+                                    enum:
+                                      - value: HTTP
+                                        description: "HTTP"
+                                      - value: "HTTPS"
+                                        description: "HTTPS"
+                                      - value: TCP
+                                        description: "TCP"
+                                      - value: "UDP"
+                                        description: "UDP"
+                                - variable: nodePort
+                                  label: "Node Port (Optional)"
+                                  description: "This port gets exposed to the node. Only considered when service type is NodePort, Simple or LoadBalancer"
+                                  schema:
+                                    type: int
+                                    min: 9000
+                                    max: 65535
+                                - variable: targetPort
+                                  label: "Target Port"
+                                  description: "The internal(!) port on the container the Application runs on"
+                                  schema:
+                                    type: int
+                                    default: 53
+                    - variable: dns-udp
+                      label: "DNS-TCP Service Port Configuration"
+                      schema:
+                        additional_attrs: true
+                        type: dict
+                        attrs:
+                          - variable: port
+                            label: "Port"
+                            description: "This port exposes the container port on the service"
+                            schema:
+                              type: int
+                              default: 53
+                              required: true
+                          - variable: advanced
+                            label: "Show Advanced settings"
+                            schema:
+                              type: boolean
+                              default: false
+                              show_subquestions_if: true
+                              subquestions:
+                                - variable: protocol
+                                  label: "Port Type"
+                                  schema:
+                                    type: string
+                                    default: "UDP"
                                     enum:
                                       - value: HTTP
                                         description: "HTTP"

--- a/charts/stable/pihole/values.yaml
+++ b/charts/stable/pihole/values.yaml
@@ -22,17 +22,14 @@ service:
       main:
         port: 9089
         targetPort: 80
-  dns-tcp:
+  dns:
     enabled: true
     ports:
       dns-tcp:
         enabled: true
         port: 53
         targetPort: 53
-  dns:
-    enabled: true
-    ports:
-      dns:
+      dns-udp:
         enabled: true
         protocol: UDP
         port: 53

--- a/charts/stable/prometheus/Chart.yaml
+++ b/charts/stable/prometheus/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
 type: application
-version: 4.0.18
+version: 4.0.19
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/stable/prometheus/values.yaml
+++ b/charts/stable/prometheus/values.yaml
@@ -26,7 +26,6 @@ service:
       main:
         port: 10086
         targetPort: 9090
-        protocol: HTTP
   promop:
     enabled: true
     ports:
@@ -34,7 +33,6 @@ service:
         enabled: true
         port: 10089
         targetPort: 8080
-        protocol: HTTP
   alertmanager:
     enabled: true
     selector:
@@ -45,7 +43,6 @@ service:
         enabled: true
         port: 10087
         targetPort: 9093
-        protocol: HTTP
   thanos:
     enabled: true
     selector:
@@ -56,7 +53,6 @@ service:
         enabled: true
         port: 10901
         targetPort: 10901
-        protocol: HTTP
 
 ingress:
   main:

--- a/charts/stable/pydio-cells/Chart.yaml
+++ b/charts/stable/pydio-cells/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: pydio-cells
-version: 4.0.7
+version: 4.0.8
 appVersion: "3.0.7"
 description: Pydio-cells is the nextgen file sharing platform for organizations.
 type: application

--- a/charts/stable/pydio-cells/values.yaml
+++ b/charts/stable/pydio-cells/values.yaml
@@ -70,7 +70,6 @@ service:
   main:
     ports:
       main:
-        protocol: HTTPS
         port: 10150
   gprc:
     enabled: true

--- a/charts/stable/qbittorrent/Chart.yaml
+++ b/charts/stable/qbittorrent/Chart.yaml
@@ -20,7 +20,7 @@ name: qbittorrent
 sources:
 - https://github.com/qbittorrent/qBittorrent
 type: application
-version: 11.0.8
+version: 11.0.9
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/qbittorrent/questions.yaml
+++ b/charts/stable/qbittorrent/questions.yaml
@@ -141,14 +141,14 @@ questions:
 
 
         - variable: torrent
-          label: "TCP Torrent Service"
+          label: "Torrent Service"
           description: "Torrent service"
           schema:
             additional_attrs: true
             type: dict
             attrs:
 # Include{serviceSelector}
-                    - variable: torrent
+                    - variable: torrent-tcp
                       label: "TCP Service Port Configuration"
                       schema:
                         additional_attrs: true
@@ -195,16 +195,7 @@ questions:
                                   schema:
                                     type: int
                                     default: 6881
-
-        - variable: torrentudp
-          label: "UDP Torrent Service"
-          description: "Torrent service"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
-                    - variable: torrentudp
+                    - variable: torrent-udp
                       label: "UDP Service Port Configuration"
                       schema:
                         additional_attrs: true

--- a/charts/stable/qbittorrent/questions.yaml
+++ b/charts/stable/qbittorrent/questions.yaml
@@ -148,7 +148,7 @@ questions:
             type: dict
             attrs:
 # Include{serviceSelector}
-                    - variable: torrent-tcp
+                    - variable: torrenttcp
                       label: "TCP Service Port Configuration"
                       schema:
                         additional_attrs: true
@@ -195,7 +195,7 @@ questions:
                                   schema:
                                     type: int
                                     default: 6881
-                    - variable: torrent-udp
+                    - variable: torrentudp
                       label: "UDP Service Port Configuration"
                       schema:
                         additional_attrs: true

--- a/charts/stable/qbittorrent/templates/_configmap.tpl
+++ b/charts/stable/qbittorrent/templates/_configmap.tpl
@@ -10,7 +10,7 @@ metadata:
     {{- include "tc.common.labels" . | nindent 4 }}
 data:
   {{- $bittorrentPort := "" -}}
-  {{- $bittorrentPort = .Values.service.torrent.ports.torrent.port -}}
+  {{- $bittorrentPort = .Values.service.torrent.ports.torrent-tcp.port -}}
   {{- if $bittorrentPort }}
   31-update-port: |-
     #!/bin/bash

--- a/charts/stable/qbittorrent/templates/_configmap.tpl
+++ b/charts/stable/qbittorrent/templates/_configmap.tpl
@@ -10,7 +10,7 @@ metadata:
     {{- include "tc.common.labels" . | nindent 4 }}
 data:
   {{- $bittorrentPort := "" -}}
-  {{- $bittorrentPort = .Values.service.torrent.ports.torrent-tcp.port -}}
+  {{- $bittorrentPort = .Values.service.torrent.ports.torrenttcp.port -}}
   {{- if $bittorrentPort }}
   31-update-port: |-
     #!/bin/bash

--- a/charts/stable/qbittorrent/values.yaml
+++ b/charts/stable/qbittorrent/values.yaml
@@ -15,14 +15,11 @@ service:
   torrent:
     enabled: true
     ports:
-      torrent:
+      torrent-tcp:
         enabled: true
         port: 6881
         targetPort: 6881
-  torrentudp:
-    enabled: true
-    ports:
-      torrentudp:
+      torrent-udp:
         enabled: true
         port: 6881
         targetPort: 6881

--- a/charts/stable/qbittorrent/values.yaml
+++ b/charts/stable/qbittorrent/values.yaml
@@ -15,11 +15,11 @@ service:
   torrent:
     enabled: true
     ports:
-      torrent-tcp:
+      torrenttcp:
         enabled: true
         port: 6881
         targetPort: 6881
-      torrent-udp:
+      torrentudp:
         enabled: true
         port: 6881
         targetPort: 6881

--- a/charts/stable/resilio-sync/Chart.yaml
+++ b/charts/stable/resilio-sync/Chart.yaml
@@ -21,7 +21,7 @@ maintainers:
 name: resilio-sync
 sources:
 - https://github.com/orgs/linuxserver/packages/container/package/resilio-sync
-version: 6.0.7
+version: 6.0.8
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/resilio-sync/questions.yaml
+++ b/charts/stable/resilio-sync/questions.yaml
@@ -140,66 +140,9 @@ questions:
                                     default: 8888
 
 
-        - variable: bt-udp
-          label: "bt-udp Service"
-          description: "The bt-udp service"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
-                    - variable: bt-udp
-                      label: "bt-udp Service Port Configuration"
-                      schema:
-                        additional_attrs: true
-                        type: dict
-                        attrs:
-                          - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
-                            schema:
-                              type: int
-                              default: 55555
-                              required: true
-                          - variable: advanced
-                            label: "Show Advanced settings"
-                            schema:
-                              type: boolean
-                              default: false
-                              show_subquestions_if: true
-                              subquestions:
-                                - variable: protocol
-                                  label: "Port Type"
-                                  schema:
-                                    type: string
-                                    default: "UDP"
-                                    enum:
-                                      - value: HTTP
-                                        description: "HTTP"
-                                      - value: "HTTPS"
-                                        description: "HTTPS"
-                                      - value: TCP
-                                        description: "TCP"
-                                      - value: "UDP"
-                                        description: "UDP"
-                                - variable: nodePort
-                                  label: "Node Port (Optional)"
-                                  description: "This port gets exposed to the node. Only considered when service type is NodePort, Simple or LoadBalancer"
-                                  schema:
-                                    type: int
-                                    min: 9000
-                                    max: 65535
-                                - variable: targetPort
-                                  label: "Target Port"
-                                  description: "The internal(!) port on the container the Application runs on"
-                                  schema:
-                                    type: int
-                                    default: 55555
-
-
-        - variable: bt-tcp
-          label: "bt-tcp Service"
-          description: "The bt-tcp service"
+        - variable: bt
+          label: "bt Service"
+          description: "The bt service"
           schema:
             additional_attrs: true
             type: dict
@@ -230,6 +173,53 @@ questions:
                                   schema:
                                     type: string
                                     default: "TCP"
+                                    enum:
+                                      - value: HTTP
+                                        description: "HTTP"
+                                      - value: "HTTPS"
+                                        description: "HTTPS"
+                                      - value: TCP
+                                        description: "TCP"
+                                      - value: "UDP"
+                                        description: "UDP"
+                                - variable: nodePort
+                                  label: "Node Port (Optional)"
+                                  description: "This port gets exposed to the node. Only considered when service type is NodePort, Simple or LoadBalancer"
+                                  schema:
+                                    type: int
+                                    min: 9000
+                                    max: 65535
+                                - variable: targetPort
+                                  label: "Target Port"
+                                  description: "The internal(!) port on the container the Application runs on"
+                                  schema:
+                                    type: int
+                                    default: 55555
+                    - variable: bt-udp
+                      label: "bt-udp Service Port Configuration"
+                      schema:
+                        additional_attrs: true
+                        type: dict
+                        attrs:
+                          - variable: port
+                            label: "Port"
+                            description: "This port exposes the container port on the service"
+                            schema:
+                              type: int
+                              default: 55555
+                              required: true
+                          - variable: advanced
+                            label: "Show Advanced settings"
+                            schema:
+                              type: boolean
+                              default: false
+                              show_subquestions_if: true
+                              subquestions:
+                                - variable: protocol
+                                  label: "Port Type"
+                                  schema:
+                                    type: string
+                                    default: "UDP"
                                     enum:
                                       - value: HTTP
                                         description: "HTTP"

--- a/charts/stable/resilio-sync/values.yaml
+++ b/charts/stable/resilio-sync/values.yaml
@@ -17,16 +17,13 @@ service:
       main:
         port: 8888
         targetPort: 8888
-  bt-tcp:
+  bt:
     enabled: true
     ports:
       bt-tcp:
         enabled: true
         port: 55555
         targetPort: 55555
-  bt-udp:
-    enabled: true
-    ports:
       bt-udp:
         enabled: true
         port: 55555

--- a/charts/stable/shlink-web-client/Chart.yaml
+++ b/charts/stable/shlink-web-client/Chart.yaml
@@ -20,7 +20,7 @@ name: shlink-web-client
 sources:
 - https://github.com/shlinkio/shlink-web-client
 type: application
-version: 3.0.8
+version: 3.0.9
 annotations:
   truecharts.org/catagories: |
     - utilities

--- a/charts/stable/shlink-web-client/values.yaml
+++ b/charts/stable/shlink-web-client/values.yaml
@@ -22,4 +22,3 @@ service:
       main:
         targetPort: 80
         port: 10154
-        protocol: HTTP

--- a/charts/stable/speedtest-exporter/Chart.yaml
+++ b/charts/stable/speedtest-exporter/Chart.yaml
@@ -21,7 +21,7 @@ name: speedtest-exporter
 sources:
 - https://github.com/MiguelNdeCarvalho/speedtest-exporter/
 type: application
-version: 3.0.9
+version: 3.0.10
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/stable/speedtest-exporter/values.yaml
+++ b/charts/stable/speedtest-exporter/values.yaml
@@ -13,7 +13,6 @@ service:
         enabled: false
       metrics:
         enabled: true
-        protocol: TCP
         port: 9798
 
 metrics:

--- a/charts/stable/storj-node/Chart.yaml
+++ b/charts/stable/storj-node/Chart.yaml
@@ -20,7 +20,7 @@ sources:
 - https://github.com/storj/storj
 - https://docs.storj.io/node/
 - https://hub.docker.com/r/storjlabs/storagenode
-version: 2.0.14
+version: 2.0.15
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/storj-node/Chart.yaml
+++ b/charts/stable/storj-node/Chart.yaml
@@ -20,7 +20,7 @@ sources:
 - https://github.com/storj/storj
 - https://docs.storj.io/node/
 - https://hub.docker.com/r/storjlabs/storagenode
-version: 2.0.15
+version: 2.0.16
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/storj-node/questions.yaml
+++ b/charts/stable/storj-node/questions.yaml
@@ -187,9 +187,9 @@ questions:
                                   schema:
                                     type: int
                                     default: 14002
-        - variable: coretcp
-          label: "Core TCP Service"
-          description: "Core TCP Service"
+        - variable: core
+          label: "Core Service"
+          description: "Core Service"
           schema:
             additional_attrs: true
             type: dict
@@ -219,7 +219,7 @@ questions:
                                   label: "Port Type"
                                   schema:
                                     type: string
-                                    default: "HTTP"
+                                    default: "TCP"
                                     enum:
                                       - value: HTTP
                                         description: "HTTP"
@@ -242,14 +242,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 28967
-        - variable: coreudp
-          label: "Core UDP Service"
-          description: "Core UDP Service"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
                     - variable: coreudp
                       label: "Core UDP Service Port Configuration"
                       schema:
@@ -274,7 +266,7 @@ questions:
                                   label: "Port Type"
                                   schema:
                                     type: string
-                                    default: "HTTP"
+                                    default: "UDP"
                                     enum:
                                       - value: HTTP
                                         description: "HTTP"

--- a/charts/stable/storj-node/values.yaml
+++ b/charts/stable/storj-node/values.yaml
@@ -31,7 +31,6 @@ service:
     ports:
       coretcp:
         enabled: true
-        protocol: TCP
         port: 28967
         targetPort: 28967
   coreudp:

--- a/charts/stable/storj-node/values.yaml
+++ b/charts/stable/storj-node/values.yaml
@@ -26,16 +26,13 @@ service:
       main:
         port: 14002
         targetPort: 14002
-  coretcp:
+  core:
     enabled: true
     ports:
       coretcp:
         enabled: true
         port: 28967
         targetPort: 28967
-  coreudp:
-    enabled: true
-    ports:
       coreudp:
         enabled: true
         protocol: UDP

--- a/charts/stable/syncthing/Chart.yaml
+++ b/charts/stable/syncthing/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 - https://github.com/syncthing/syncthing
 - https://hub.docker.com/r/syncthing/syncthing
 type: application
-version: 11.0.7
+version: 11.0.8
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/syncthing/questions.yaml
+++ b/charts/stable/syncthing/questions.yaml
@@ -139,8 +139,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 8384
-
-
         - variable: listeners
           label: "Syncthing Listening Service"
           description: "This service is used to process incoming connections directly to this Syncthing instance"
@@ -196,14 +194,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 22000
-        - variable: listeners-udp
-          label: "Syncthing Listening Service"
-          description: "This service is used to process incoming connections directly to this Syncthing instance"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
                     - variable: udp
                       label: "UDP Service Port Configuration"
                       schema:

--- a/charts/stable/syncthing/values.yaml
+++ b/charts/stable/syncthing/values.yaml
@@ -16,9 +16,6 @@ service:
         enabled: true
         port: 22000
         targetPort: 22000
-  listeners-udp:
-    enabled: true
-    ports:
       udp:
         enabled: true
         port: 22000

--- a/charts/stable/transmission/Chart.yaml
+++ b/charts/stable/transmission/Chart.yaml
@@ -22,7 +22,7 @@ sources:
 - https://github.com/transmission/transmission
 - https://hub.docker.com/r/linuxserver/transmission
 type: application
-version: 12.0.7
+version: 12.0.8
 annotations:
   truecharts.org/catagories: |
     - download-tools

--- a/charts/stable/transmission/questions.yaml
+++ b/charts/stable/transmission/questions.yaml
@@ -464,8 +464,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 10109
-
-
         - variable: torrent
           label: "TCP Torrent Service"
           description: "Torrent service"
@@ -474,7 +472,7 @@ questions:
             type: dict
             attrs:
 # Include{serviceSelector}
-                    - variable: torrent
+                    - variable: torrent-tcp
                       label: "TCP Service Port Configuration"
                       schema:
                         additional_attrs: true
@@ -521,15 +519,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 51414
-
-        - variable: torrentudp
-          label: "UDP Torrent Service"
-          description: "Torrent service"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
                     - variable: torrentudp
                       label: "UDP Service Port Configuration"
                       schema:

--- a/charts/stable/transmission/questions.yaml
+++ b/charts/stable/transmission/questions.yaml
@@ -472,7 +472,7 @@ questions:
             type: dict
             attrs:
 # Include{serviceSelector}
-                    - variable: torrent-tcp
+                    - variable: torrenttcp
                       label: "TCP Service Port Configuration"
                       schema:
                         additional_attrs: true
@@ -519,7 +519,7 @@ questions:
                                   schema:
                                     type: int
                                     default: 51414
-                    - variable: torrent-udp
+                    - variable: torrentudp
                       label: "UDP Service Port Configuration"
                       schema:
                         additional_attrs: true

--- a/charts/stable/transmission/questions.yaml
+++ b/charts/stable/transmission/questions.yaml
@@ -519,7 +519,7 @@ questions:
                                   schema:
                                     type: int
                                     default: 51414
-                    - variable: torrentudp
+                    - variable: torrent-udp
                       label: "UDP Service Port Configuration"
                       schema:
                         additional_attrs: true

--- a/charts/stable/transmission/values.yaml
+++ b/charts/stable/transmission/values.yaml
@@ -12,18 +12,16 @@ service:
   torrent:
     enabled: true
     ports:
-      torrent:
+      torrent-tcp:
         enabled: true
         port: 51414
         targetPort: 51414
-  torrentudp:
-    enabled: true
-    ports:
       torrentudp:
         enabled: true
         port: 51414
         targetPort: 51414
         protocol: UDP
+
 secretEnv: {}
   # TRANSMISSION_RPC_USERNAME: ""
   # TRANSMISSION_RPC_PASSWORD: ""

--- a/charts/stable/transmission/values.yaml
+++ b/charts/stable/transmission/values.yaml
@@ -12,11 +12,11 @@ service:
   torrent:
     enabled: true
     ports:
-      torrent-tcp:
+      torrenttcp:
         enabled: true
         port: 51414
         targetPort: 51414
-      torrent-udp:
+      torrentudp:
         enabled: true
         port: 51414
         targetPort: 51414
@@ -54,7 +54,7 @@ env:
   # TRANSMISSION_PEER_ID_TTL_HOURS: 6
   # TRANSMISSION_PEER_LIMIT_GLOBAL: 200
   # TRANSMISSION_PEER_LIMIT_PER_TORRENT: 50
-  TRANSMISSION_PEER_PORT: "{{ .Values.service.torrent.ports.torrent-tcp.targetPort }}"
+  TRANSMISSION_PEER_PORT: "{{ .Values.service.torrent.ports.torrenttcp.targetPort }}"
   # TRANSMISSION_PEER_PORT_RANDOM_HIGH: 65535
   # TRANSMISSION_PEER_PORT_RANDOM_LOW: 49152
   # TRANSMISSION_PEER_PORT_RANDOM_ON_START: false

--- a/charts/stable/transmission/values.yaml
+++ b/charts/stable/transmission/values.yaml
@@ -16,7 +16,7 @@ service:
         enabled: true
         port: 51414
         targetPort: 51414
-      torrentudp:
+      torrent-udp:
         enabled: true
         port: 51414
         targetPort: 51414
@@ -54,7 +54,7 @@ env:
   # TRANSMISSION_PEER_ID_TTL_HOURS: 6
   # TRANSMISSION_PEER_LIMIT_GLOBAL: 200
   # TRANSMISSION_PEER_LIMIT_PER_TORRENT: 50
-  TRANSMISSION_PEER_PORT: "{{ .Values.service.torrent.ports.torrent.targetPort }}"
+  TRANSMISSION_PEER_PORT: "{{ .Values.service.torrent.ports.torrent-tcp.targetPort }}"
   # TRANSMISSION_PEER_PORT_RANDOM_HIGH: 65535
   # TRANSMISSION_PEER_PORT_RANDOM_LOW: 49152
   # TRANSMISSION_PEER_PORT_RANDOM_ON_START: false

--- a/charts/stable/trilium-notes/Chart.yaml
+++ b/charts/stable/trilium-notes/Chart.yaml
@@ -23,7 +23,7 @@ sources:
 - https://hub.docker.com/r/zadam/trilium
 - https://github.com/zadam/trilium
 type: application
-version: 5.0.7
+version: 5.0.8
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/trilium-notes/values.yaml
+++ b/charts/stable/trilium-notes/values.yaml
@@ -15,7 +15,6 @@ service:
   main:
     ports:
       main:
-        protocol: HTTP
         targetPort: 8080
         port: 10156
 

--- a/charts/stable/unifi/Chart.yaml
+++ b/charts/stable/unifi/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 - https://github.com/jacobalberty/unifi-docker
 - https://unifi-network.ui.com
 type: application
-version: 11.0.7
+version: 11.0.8
 annotations:
   truecharts.org/catagories: |
     - Networking

--- a/charts/stable/unifi/values.yaml
+++ b/charts/stable/unifi/values.yaml
@@ -7,7 +7,6 @@ service:
   main:
     ports:
       main:
-        protocol: HTTPS
         port: 8443
         targetPort: 8443
   comm:
@@ -39,12 +38,10 @@ service:
         enabled: true
         port: 8880
         targetPort: 8880
-        protocol: HTTP
       websecure:
         enabled: true
         port: 8843
         targetPort: 8843
-        protocol: HTTPS
 
 securityContext:
   readOnlyRootFilesystem: false

--- a/charts/stable/verysync/Chart.yaml
+++ b/charts/stable/verysync/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
 name: verysync
 sources:
 - https://hub.docker.com/r/jonnyan404/verysync
-version: 2.0.7
+version: 2.0.8
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/verysync/questions.yaml
+++ b/charts/stable/verysync/questions.yaml
@@ -138,11 +138,9 @@ questions:
                                   schema:
                                     type: int
                                     default: 10193
-
-
-        - variable: bt-udp1
-          label: "bt-udp1 Service"
-          description: "The bt-udp service"
+        - variable: bt
+          label: "bt Service"
+          description: "The bt service"
           schema:
             additional_attrs: true
             type: dict
@@ -195,16 +193,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 22037
-
-
-        - variable: bt-udp2
-          label: "bt-udp2 Service"
-          description: "The bt-udp service"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
                     - variable: bt-udp2
                       label: "bt-udp2 Service Port Configuration"
                       schema:

--- a/charts/stable/verysync/values.yaml
+++ b/charts/stable/verysync/values.yaml
@@ -8,7 +8,7 @@ service:
     ports:
       main:
         port: 10193
-  bt-udp1:
+  bt:
     enabled: true
     ports:
       bt-udp1:
@@ -16,9 +16,6 @@ service:
         port: 22037
         targetPort: 22037
         protocol: UDP
-  bt-udp2:
-    enabled: true
-    ports:
       bt-udp2:
         enabled: true
         port: 22027


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->
Based on 
https://github.com/truecharts/library-charts/blob/f267828efef0c2e1fc0f22f7be0de114c5bc3387/charts/common/templates/lib/controller/_ports.tpl#L25-L32
protocol should only be needed when it's `UDP` On all other types is set to `TCP` from common


- [x] Removed any `protocol: HTTP|HTTPS|TCP` from all apps, EXCEPT traefik.
- [x] Combined TCP and UDP ports under the same service. This now should be okay, as the `MixedProtocolLBService` flag is merged

https://github.com/truenas/middleware/pull/8340

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
