### PR TITLE
fix(nextcloud): change nginx redirect options to not add port to query

### DIFF
--- a/charts/stable/nextcloud/Chart.yaml
+++ b/charts/stable/nextcloud/Chart.yaml
@@ -33,7 +33,7 @@ sources:
 - https://github.com/nextcloud/docker
 - https://github.com/nextcloud/helm
 type: application
-version: 15.0.0
+version: 15.0.1
 annotations:
   truecharts.org/catagories: |
     - cloud

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -293,6 +293,10 @@ configmap:
                     location = /.well-known/carddav { return 301 /remote.php/dav/; }
                     location = /.well-known/caldav  { return 301 /remote.php/dav/; }
 
+                    # according to the documentation these two lines are not necessary, but some users are still recieving errors
+                    location = /.well-known/webfinger   { return 301 /index.php$uri; }
+                    location = /.well-known/nodeinfo   { return 301 /index.php$uri; }
+
                     location /.well-known/acme-challenge    { try_files $uri $uri/ =404; }
                     location /.well-known/pki-validation    { try_files $uri $uri/ =404; }
 

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -206,6 +206,7 @@ configmap:
 
             server {
                 listen 8080;
+                absolute_redirect off;
 
                 # Forward Notify_Push "High Performance Backend"  to it's own container
                 location ^~ /push/ {


### PR DESCRIPTION
**Description**
There are a few cases where redirect on nextcloud didn't grab the right port when using ingress...

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
