### PR TITLE
fix(nextcloud): fix wrong accessip reference

### DIFF
--- a/charts/stable/nextcloud/Chart.yaml
+++ b/charts/stable/nextcloud/Chart.yaml
@@ -33,7 +33,7 @@ sources:
 - https://github.com/nextcloud/docker
 - https://github.com/nextcloud/helm
 type: application
-version: 15.1.3
+version: 15.1.4
 annotations:
   truecharts.org/catagories: |
     - cloud

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -49,7 +49,7 @@ service:
         targetPort: 9090
 
 hostAliases:
-  - ip: '{{ .Values.AccessIP | default "127.0.0.1" }}'
+  - ip: '{{ .Values.env.AccessIP | default "127.0.0.1" }}'
     hostnames:
     - "{{ if .Values.ingress.main.enabled }}{{ with (first .Values.ingress.main.hosts) }}{{ .host }}{{ end }}{{ else }}placeholder.fakedomain.dns{{ end }}"
 


### PR DESCRIPTION
**Description**
A mistake has been made in a previous DNS patch for nextcloud, leading to the HPB not correctly resolving anymore.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have opened a PR on [truecharts/pub](https://github.com/truecharts/pub) adding the app icon.
- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
