### PR TITLE
fix(nextcloud): increase nginx fpm forwarding timeouts

### DIFF
--- a/charts/stable/nextcloud/Chart.yaml
+++ b/charts/stable/nextcloud/Chart.yaml
@@ -37,7 +37,7 @@ sources:
 - https://github.com/nextcloud/docker
 - https://github.com/nextcloud/helm
 type: application
-version: 15.2.4
+version: 15.2.5
 annotations:
   truecharts.org/catagories: |
     - cloud

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -356,6 +356,11 @@ configmap:
 
                     fastcgi_intercept_errors on;
                     fastcgi_request_buffering off;
+
+                    proxy_send_timeout 300s;
+                    proxy_read_timeout 300s;
+                    fastcgi_send_timeout 300s;
+                    fastcgi_read_timeout 300s;
                 }
 
                 location ~ \.(?:css|js|svg|gif)$ {


### PR DESCRIPTION
**Description**
It looks like there are some cases where nginx cuts of the php-fpm connectivity, preventing uploads to finish.
This increases those limits considerablly.


**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have opened a PR on [truecharts/pub](https://github.com/truecharts/pub) adding the app icon.
- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
