### PR TITLE
fix variable value on lancache-monolithic

### DIFF
--- a/charts/incubator/lancache-monolithic/Chart.yaml
+++ b/charts/incubator/lancache-monolithic/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: lancache-monolithic
-version: 0.0.4
+version: 0.0.5
 appVersion: "latest"
 description: A monolithic lancache service capable of caching all cdn's in a single instance.
 type: application

--- a/charts/incubator/lancache-monolithic/questions.yaml
+++ b/charts/incubator/lancache-monolithic/questions.yaml
@@ -101,7 +101,7 @@ questions:
           description: "Amount of index memory for the nginx cache manager. We recommend 250m of index memory per 1TB"
           schema:
             type: string
-            default: "3560d"
+            default: "500m"
 # Include{containerConfig}
 
   - variable: service


### PR DESCRIPTION
**Description**
change a value in questions.yaml
⚒️ Fixes  # <!--(issue)-->

The variable "CACHE_INDEX_SIZE" value cant be"3560d" its suppose to be 500m or min "250m" NOT 3560d. I must have miss this value by accident.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
tested it when I installed the app on my server.

**📃 Notes:**
"UPSTREAM_DNS" variable does actually work with SPACES and the char ";"

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
