### PR TITLE
update/fix plex-meta-manager

### DIFF
--- a/charts/incubator/plex-meta-manager/Chart.yaml
+++ b/charts/incubator/plex-meta-manager/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: plex-meta-manager
 version: 0.0.4
 appVersion: "1.17.1"
-description: Python3 script run using YAML config files to update on a schedule the metadata of the movies, shows, and collections in your libraries as well as automatically build collections
+description: Python script to update metadata and automatically build collections.
 type: application
 deprecated: false
 home: https://github.com/truecharts/apps/tree/master/charts/incubator/plex-meta-manager

--- a/charts/incubator/plex-meta-manager/Chart.yaml
+++ b/charts/incubator/plex-meta-manager/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: plex-meta-manager
-version: 0.0.4
+version: 0.0.5
 appVersion: "1.17.1"
 description: Python script to update metadata and automatically build collections.
 type: application

--- a/charts/incubator/plex-meta-manager/questions.yaml
+++ b/charts/incubator/plex-meta-manager/questions.yaml
@@ -62,22 +62,30 @@ questions:
       attrs:
         - variable: PMM_CONFIG
           label: "PMM CONFIG"
-          description: "Specify a custom config.yaml"
+          description: "Specify a internal config.yaml"
           schema:
             type: string
             default: "/config/config.yaml"
-        - variable: PMM_TIME
-          label: "PMM TIME"
-          description: "Comma-separated list of times to update each day. Format: HH:MM"
-          schema:
-            type: string
-            default: "03:00"
         - variable: PMM_RUN
           label: "PMM RUN"
-          description: "Set to True to run without the scheduler."
+          description: "Set to false to run with a scheduler."
           schema:
             type: boolean
             default: true
+        - variable: customtime
+          label: "Set PMM Time"
+          schema:
+            show_if: [["PMM_RUN", "=", false]]
+            type: boolean
+            default: false
+            show_subquestions_if: true
+            subquestions:
+              - variable: PMM_TIME
+                label: "PMM TIME"
+                description: "Comma-separated list of times to update each day. Format: HH:MM"
+                schema:
+                  type: string
+                  default: ""
         - variable: PMM_TEST
           label: "PMM TEST"
           description: "Set to True to run in debug mode with only collections that have test: true"

--- a/charts/incubator/plex-meta-manager/questions.yaml
+++ b/charts/incubator/plex-meta-manager/questions.yaml
@@ -60,20 +60,12 @@ questions:
       additional_attrs: true
       type: dict
       attrs:
-        - variable: CUSTOM_CONFIG_FILE
-          label: "Set Custom config file"
-          description: "enable this and point the config.yaml to a dir"
+        - variable: PMM_CONFIG
+          label: "PMM CONFIG"
+          description: "Specify a custom config.yaml"
           schema:
-            type: boolean
-            default: false
-            show_subquestions_if: true
-            subquestions:
-              - variable: PMM_CONFIG
-                label: "PMM CONFIG"
-                description: "Specify a custom config file to use internally ex: /config/config.yaml"
-                schema:
-                  type: string
-                  default: ""
+            type: string
+            default: "/config/config.yaml"
         - variable: PMM_TIME
           label: "PMM TIME"
           description: "Comma-separated list of times to update each day. Format: HH:MM"
@@ -85,7 +77,7 @@ questions:
           description: "Set to True to run without the scheduler."
           schema:
             type: boolean
-            default: false
+            default: true
         - variable: PMM_TEST
           label: "PMM TEST"
           description: "Set to True to run in debug mode with only collections that have test: true"

--- a/charts/incubator/plex-meta-manager/values.yaml
+++ b/charts/incubator/plex-meta-manager/values.yaml
@@ -12,8 +12,9 @@ podSecurityContext:
   runAsGroup: 0
 
 env:
+  PMM_CONFIG: "/config/config.yaml"
   PMM_TIME: "03:00"
-  PMM_RUN: false
+  PMM_RUN: true
   PMM_TEST: false
   PMM_NO_MISSING: false
 


### PR DESCRIPTION
**Description**
update plex-meta-manager with quality of life improvements

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
tested the incubator app 0.0.3.

**📃 Notes:**

I updated the description, changed the format in questions.yaml and set custom config variable with a default path.
also enabled the PMM_RUN variable for the app to start right away as default. it can still be disabled  by the user if needed.

the only downside is users will need to set the config location from pvc(simple) to hostpath and point to their PMM config dir/dataset if they want to use all the custom config files...or create a custom location and have the PMM_CONFIG variable point to the new location to persist all the configs for the app to work.

ofc we can mount the pvc storage...but that isnt user friendly to most  users.

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
