### PR TITLE
fix(traefik): don't set xrobots header on default middleware

### DIFF
--- a/charts/stable/traefik/Chart.yaml
+++ b/charts/stable/traefik/Chart.yaml
@@ -22,7 +22,7 @@ sources:
 - https://github.com/traefik/traefik-helm-chart
 - https://traefik.io/
 type: application
-version: 12.0.22
+version: 12.0.23
 annotations:
   truecharts.org/catagories: |
     - network

--- a/charts/stable/traefik/templates/middlewares/basic-middleware.yaml
+++ b/charts/stable/traefik/templates/middlewares/basic-middleware.yaml
@@ -49,7 +49,6 @@ spec:
     customRequestHeaders:
       X-Forwarded-Proto: "https"
     customResponseHeaders:
-      X-Robots-Tag: 'none'
       server: ''
 ---
 apiVersion: traefik.containo.us/v1alpha1


### PR DESCRIPTION
**Description**
As stated in #3208 #3183 didn't (potentially) change the header in the right location (wrong middleware) this PR fixes that.
⚒️ Fixes  #3208 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I edited the file locally on my TrueNAS Scale machine and redeployed, now the header is gone from the default middleware.

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
