### PR TITLE
fix(mosquitto): set password file when auth is enabled

### DIFF
--- a/charts/stable/mosquitto/Chart.yaml
+++ b/charts/stable/mosquitto/Chart.yaml
@@ -21,7 +21,7 @@ name: mosquitto
 sources:
 - https://github.com/eclipse/mosquitto
 type: application
-version: 6.0.18
+version: 6.0.19
 annotations:
   truecharts.org/catagories: |
     - homeautomation

--- a/charts/stable/mosquitto/values.yaml
+++ b/charts/stable/mosquitto/values.yaml
@@ -22,6 +22,7 @@ configmap:
         listener {{ .Values.service.main.ports.main.port }}
         {{- if .Values.auth.enabled }}
         allow_anonymous false
+        password_file /mosquitto/data/passwords.txt
         {{- else }}
         allow_anonymous true
         {{- end }}

--- a/templates/docs/README.md.gotmpl
+++ b/templates/docs/README.md.gotmpl
@@ -14,7 +14,7 @@ https://truecharts.org
 {{ template "custom.repository.organization" . }}/{{ template "chart.name" . }}
 {{- end -}}
 {{- define "custom.notes" -}}
-TrueCharts are designed to be installed as TrueNAS SCALE app only. We can not guarantee this charts works as a stand-alone helm installation.
+TrueCharts can be installed as both *normal* Helm Charts or as Apps on TrueNAS SCALE. Please refer to your specific platform for more detailed instructions.
 **This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/truecharts/apps/issues/new/choose)**
 {{- end -}}
 {{- define "custom.requirements" -}}
@@ -30,24 +30,48 @@ TrueCharts are designed to be installed as TrueNAS SCALE app only. We can not gu
 {{- define "custom.install" -}}
 ## Installing the Chart
 
+### TrueNAS SCALE
+
 To install this App on TrueNAS SCALE check our [Quick-Start Guide](https://truecharts.org/manual/Quick-Start%20Guides/02-Installing-an-App/).
+
+### Helm
+
+To install the chart with the release name `{{ template "chart.name" . }}`
+
+```console
+helm repo add {{ template "custom.repository.organization" . }} {{ template "custom.helm.url" . }}
+helm repo update
+helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }}
+```
 {{- end -}}
 {{- define "custom.uninstall" -}}
-## Upgrading, Rolling Back and Uninstalling the Chart
+## Uninstall
+### TrueNAS SCALE
+
+**Upgrading, Rolling Back and Uninstalling the Chart**
 
 To upgrade, rollback or delete this App from TrueNAS SCALE check our [Quick-Start Guide](https://truecharts.org/manual/Quick-Start%20Guides/04-Upgrade-rollback-delete-an-App/).
+
+## Helm
+
+To uninstall the `{{ template "chart.name" . }}` deployment
+
+```console
+helm uninstall {{ template "chart.name" . }}
+```
 {{- end -}}
 
 {{- define "custom.linking" -}}
 ##### Connecting to other apps
+
 If you need to connect this App to other Apps on TrueNAS SCALE, please refer to our [Linking Apps Internally](https://truecharts.org/manual/Quick-Start%20Guides/06-linking-apps/) quick-start guide.
 {{- end -}}
 
 {{- define "custom.support" -}}
 ## Support
 
-- Please check our [quick-start guides](https://truecharts.org/manual/Quick-Start%20Guides/01-Adding-TrueCharts/) first.
-- See the [Wiki](https://truecharts.org)
+- Please check our [quick-start guides for TrueNAS SCALE](https://truecharts.org/docs/manual/SCALE%20Apps/Quick-Start%20Guides/Important-MUST-READ).
+- See the [Website](https://truecharts.org)
 - Check our [Discord](https://discord.gg/tVsPTHWTtr)
 - Open a [issue](https://github.com/truecharts/apps/issues/new/choose)
 {{- end -}}


### PR DESCRIPTION
**Description**
When auth is enabled for Mosquitto, we need to also specify the password file.
Which is now set to `/mosquitto/data/passwords.txt`

⚒️ Fixes  #3159

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
