### PR TITLE
fix(Openserver) - Change internal port 80

### DIFF
--- a/charts/incubator/openproject/Chart.yaml
+++ b/charts/incubator/openproject/Chart.yaml
@@ -26,7 +26,7 @@ sources:
   - http://openproject.org
   - https://hub.docker.com/u/openproject
 type: application
-version: 0.0.14
+version: 0.0.15
 annotations:
   truecharts.org/SCALE-support: "true"
   truecharts.org/catagories: |

--- a/charts/incubator/openproject/questions.yaml
+++ b/charts/incubator/openproject/questions.yaml
@@ -136,7 +136,7 @@ questions:
                                   description: "The internal(!) port on the container the Application runs on"
                                   schema:
                                     type: int
-                                    default: 8080
+                                    default: 80
   - variable: serviceexpert
     group: "Networking and Services"
     label: "Show Expert Config"

--- a/charts/incubator/openproject/values.yaml
+++ b/charts/incubator/openproject/values.yaml
@@ -31,7 +31,7 @@ service:
     ports:
       main:
         port: 10290
-        targetPort: 8080
+        targetPort: 80
 
 postgresql:
   enabled: true


### PR DESCRIPTION
**Description**

The upstream docker-compose uses port 80, so to run it I ran it on 80 with the existing chart, however this should fix it in the future for anyone else

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
