### PR TITLE
fix(Kitchenowl): Specify FRONT_URL env var

### DIFF
--- a/charts/incubator/kitchenowl/Chart.yaml
+++ b/charts/incubator/kitchenowl/Chart.yaml
@@ -21,7 +21,7 @@ name: kitchenowl
 sources:
   - https://tombursch.github.io/kitchenowl
 type: application
-version: 0.0.1
+version: 0.0.2
 annotations:
   truecharts.org/catagories: |
     - utilities

--- a/charts/incubator/kitchenowl/questions.yaml
+++ b/charts/incubator/kitchenowl/questions.yaml
@@ -83,11 +83,10 @@ questions:
       attrs:
         - variable: FRONT_URL
           label: "FRONT_URL"
-          description: "The url the instance will be access with ports:"
+          description: "The url the instance will be accessed. eg. http://192.168.1.100:10246 or https://kitchen.mydomain.com"
           schema:
             type: string
-            default: "http://localhost:10246"
-            private: true
+            required: true
 # Include{containerConfig}
   - variable: service
     group: "Networking and Services"

--- a/charts/incubator/kitchenowl/questions.yaml
+++ b/charts/incubator/kitchenowl/questions.yaml
@@ -74,6 +74,20 @@ questions:
                     - value: "OnDelete"
                       description: "(Legacy) OnDelete: ignore .spec.template changes"
 # Include{controllerExpert}
+  - variable: env
+    group: "Container Configuration"
+    label: "Image Environment"
+    schema:
+      additional_attrs: true
+      type: dict
+      attrs:
+        - variable: FRONT_URL
+          label: "FRONT_URL"
+          description: "The url the instance will be access with ports:"
+          schema:
+            type: string
+            default: "http://localhost:10246"
+            private: true
 # Include{containerConfig}
   - variable: service
     group: "Networking and Services"

--- a/charts/incubator/kitchenowl/questions.yaml
+++ b/charts/incubator/kitchenowl/questions.yaml
@@ -87,6 +87,7 @@ questions:
           schema:
             type: string
             required: true
+            default: ""
 # Include{containerConfig}
   - variable: service
     group: "Networking and Services"


### PR DESCRIPTION
**Description**

See thread [here](https://discord.com/channels/830763548678291466/1003684119521263646) but basically needs to have a specific IP for the FRONT_URL env var and not localhost for it to resolve

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [X] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
