### PR TITLE
fix(guac-client): booleans don't work the same with `with`

### DIFF
--- a/charts/stable/guacamole-client/Chart.yaml
+++ b/charts/stable/guacamole-client/Chart.yaml
@@ -26,7 +26,7 @@ sources:
   - https://hub.docker.com/r/guacamole/guacamole
   - http://guacamole.incubator.apache.org/doc/gug/introduction.html
 type: application
-version: 4.0.32
+version: 4.0.33
 annotations:
   truecharts.org/catagories: |
     - utilities

--- a/charts/stable/guacamole-client/templates/_configmap.tpl
+++ b/charts/stable/guacamole-client/templates/_configmap.tpl
@@ -15,8 +15,8 @@ data:
   API_SESSION_TIMEOUT: {{ . | quote }}
   {{- end }}
   {{/* TOTP */}}
-  {{- with .Values.totp.TOTP_ENABLED }}
-  TOTP_ENABLED: {{ . | quote }}
+  {{- if .Values.totp.TOTP_ENABLED }}
+  TOTP_ENABLED: {{ .Values.totp.TOTP_ENABLED | quote }}
   {{- with .Values.totp.TOTP_ISSUER }}
   TOTP_ISSUER: {{ . | quote }}
   {{- end }}
@@ -31,8 +31,8 @@ data:
   {{- end }}
   {{- end }}
   {{/* HEADER */}}
-  {{- with .Values.header.HEADER_ENABLED }}
-  HEADER_ENABLED: {{ . | quote }}
+  {{- if .Values.header.HEADER_ENABLED }}
+  HEADER_ENABLED: {{ .Values.header.HEADER_ENABLED | quote }}
   {{- with .Values.header.HTTP_AUTH_HEADER }}
   HTTP_AUTH_HEADER: {{ . | quote }}
   {{- end }}
@@ -118,8 +118,8 @@ data:
   {{- with .Values.radius.RADIUS_CA_PASSWORD }}
   RADIUS_CA_PASSWORD: {{ . | quote }}
   {{- end }}
-  {{- with .Values.radius.RADIUS_TRUST_ALL }}
-  RADIUS_TRUST_ALL: {{ . | quote }}
+  {{- if .Values.radius.RADIUS_TRUST_ALL }}
+  RADIUS_TRUST_ALL: {{ .Values.radius.RADIUS_TRUST_ALL | quote }}
   {{- end }}
   {{- with .Values.radius.RADIUS_RETRIES }}
   RADIUS_RETRIES: {{ . | quote }}
@@ -180,8 +180,8 @@ data:
   {{- with .Values.ldap.LDAP_DEREFERENCE_ALIASES }}
   LDAP_DEREFERENCE_ALIASES: {{ . | quote }}
   {{- end }}
-  {{- with .Values.ldap.LDAP_FOLLOW_REFERRALS }}
-  LDAP_FOLLOW_REFERRALS: {{ . | quote }}
+  {{- if .Values.ldap.LDAP_FOLLOW_REFERRALS }}
+  LDAP_FOLLOW_REFERRALS: {{ .Values.ldap.LDAP_FOLLOW_REFERRALS | quote }}
   {{- with .Values.ldap.LDAP_MAX_REFERRAL_HOPS }}
   LDAP_MAX_REFERRAL_HOPS: {{ . | quote }}
   {{- end }}
@@ -204,25 +204,25 @@ data:
   {{- with .Values.saml.SAML_IDP_URL }}
   SAML_IDP_URL: {{ . | quote }}
   {{- end }}
-  {{- with .Values.saml.SAML_STRICT }}
-  SAML_STRICT: {{ . | quote }}
+  {{- if .Values.saml.SAML_STRICT }}
+  SAML_STRICT: {{ .Values.saml.SAML_STRICT | quote }}
   {{- end }}
-  {{- with .Values.saml.SAML_DEBUG }}
-  SAML_DEBUG: {{ . | quote }}
+  {{- if .Values.saml.SAML_DEBUG }}
+  SAML_DEBUG: {{ .Values.saml.SAML_DEBUG | quote }}
   {{- end }}
-  {{- with .Values.saml.SAML_COMPRESS_REQUEST }}
-  SAML_COMPRESS_REQUEST: {{ . | quote }}
+  {{- if .Values.saml.SAML_COMPRESS_REQUEST }}
+  SAML_COMPRESS_REQUEST: {{ .Values.saml.SAML_COMPRESS_REQUEST | quote }}
   {{- end }}
-  {{- with .Values.saml.SAML_COMPRESS_RESPONSE }}
-  SAML_COMPRESS_RESPONSE: {{ . | quote }}
+  {{- if .Values.saml.SAML_COMPRESS_RESPONSE }}
+  SAML_COMPRESS_RESPONSE: {{ .alues.saml.SAML_COMPRESS_RESPONSE | quote }}
   {{- end }}
   {{- with .Values.saml.SAML_GROUP_ATTRIBUTE }}
   SAML_GROUP_ATTRIBUTE: {{ . | quote }}
   {{- end }}
   {{- end }}
   {{/* PROXY */}}
-  {{- with .Values.proxy.REMOTE_IP_VALVE_ENABLED }}
-  REMOTE_IP_VALVE_ENABLED: {{ . | quote }}
+  {{- if .Values.proxy.REMOTE_IP_VALVE_ENABLED }}
+  REMOTE_IP_VALVE_ENABLED: {{ .Values.proxy.REMOTE_IP_VALVE_ENABLED | quote }}
   {{- with .Values.proxy.PROXY_BY_HEADER }}
   PROXY_BY_HEADER: {{ . | quote }}
   {{- end }}

--- a/charts/stable/guacamole-client/values.yaml
+++ b/charts/stable/guacamole-client/values.yaml
@@ -50,7 +50,7 @@ envFrom:
       name: guacamole-client-env
 
 totp:
-  TOTP_ENABLED: true
+  TOTP_ENABLED: false
   # TOTP_ISSUER: "Apache Guacamole"
   # TOTP_DIGITS: "6"
   # TOTP_PERIOD: "30"

--- a/charts/stable/guacamole-client/values.yaml
+++ b/charts/stable/guacamole-client/values.yaml
@@ -50,7 +50,7 @@ envFrom:
       name: guacamole-client-env
 
 totp:
-  TOTP_ENABLED: false
+  TOTP_ENABLED: true
   # TOTP_ISSUER: "Apache Guacamole"
   # TOTP_DIGITS: "6"
   # TOTP_PERIOD: "30"


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
