### PR TITLE
fix(traefik) remove deprecated references from default headers

### DIFF
--- a/charts/stable/traefik/Chart.yaml
+++ b/charts/stable/traefik/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/traefik/traefik-helm-chart
   - https://traefik.io/
 type: application
-version: 13.2.2
+version: 13.2.3
 annotations:
   truecharts.org/catagories: |
     - network

--- a/charts/stable/traefik/templates/middlewares/basic-middleware.yaml
+++ b/charts/stable/traefik/templates/middlewares/basic-middleware.yaml
@@ -37,14 +37,12 @@ spec:
       - HEAD
       - PUT
     accessControlMaxAge: 100
-    sslRedirect: true
     stsSeconds: 63072000
     # stsIncludeSubdomains: false
     # stsPreload: false
     forceSTSHeader: true
     contentTypeNosniff: true
     browserXssFilter: true
-    sslForceHost: true
     referrerPolicy: same-origin
     customRequestHeaders:
       X-Forwarded-Proto: "https"


### PR DESCRIPTION
**Description**
This is to remove deprecated header middleware config references that fills the Traefik app logs. The preferred method for handling SSL redirects is already implemented in the system.
For reference: https://doc.traefik.io/traefik/middlewares/http/headers/#sslredirect
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Tested in local TrueNAS Scale system

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
