### PR TITLE
fix(nextcloud): prevent ownership init timeouts

### DIFF
--- a/charts/stable/nextcloud/Chart.yaml
+++ b/charts/stable/nextcloud/Chart.yaml
@@ -37,7 +37,7 @@ sources:
   - https://github.com/nextcloud/docker
   - https://github.com/nextcloud/helm
 type: application
-version: 15.3.0
+version: 15.3.1
 annotations:
   truecharts.org/catagories: |
     - cloud

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -109,7 +109,13 @@ initContainers:
           nfs4_setfacl -R -a A:g:33:RWX "/var/www/html/data"
         else
           echo "No NFSv4 ACLs detected, trying to override permissions using chown/chmod..."
-          chown -R :33 "/var/www/html/data"
+          echo "checking ownership..."
+          if [ $(stat -c %g .) -eq 33 ]; then
+            echo "Ownership already set to 33, skipping..."
+          else
+            echo "Changing ownership to group 33..."
+            chown -R :33 "/var/www/html/data"
+          fi
           chmod 770 /var/www/html/data
         fi
         EOF


### PR DESCRIPTION
**Description**
In some cases the init script (that cannot be disabled) might cause timeouts on very-large userdata sets.
To prevent this, we check the ownership of the userdata folder and don't override chown ownership recursively if it's correct.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
