### PR TITLE
fix(metallb): indent issue with L2 advertisements

### DIFF
--- a/charts/enterprise/metallb/Chart.yaml
+++ b/charts/enterprise/metallb/Chart.yaml
@@ -25,7 +25,7 @@ sources:
   - https://github.com/metallb/metallb
   - https://metallb.universe.tf
 type: application
-version: 4.0.8
+version: 4.0.9
 annotations:
   truecharts.org/catagories: |
     - core

--- a/charts/enterprise/metallb/questions.yaml
+++ b/charts/enterprise/metallb/questions.yaml
@@ -88,21 +88,21 @@ questions:
                         type: string
                         default: ""
                         required: true
-        - variable: nodeSelectors
-          label: Node Selectors
-          description: NodeSelectors allows to limit the nodes to announce as
-              next hops for the LoadBalancer IP. When empty, all the nodes having  are
-              announced as next hops.
-          schema:
-            type: list
-            default: []
-            items:
-              - variable: nodeSelectorEntry
-                label: Node Selector Entry
+              - variable: nodeSelectors
+                label: Node Selectors
+                description: NodeSelectors allows to limit the nodes to announce as
+                    next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                    announced as next hops.
                 schema:
-                  type: string
-                  default: ""
-                  required: true
+                  type: list
+                  default: []
+                  items:
+                    - variable: nodeSelectorEntry
+                      label: Node Selector Entry
+                      schema:
+                        type: string
+                        default: ""
+                        required: true
   - variable: Communities
     group: App Configuration
     label: Communities


### PR DESCRIPTION
**Description**
The NodeSelectors was wrongly indented, causing the template to generate empty names. This in result causes an error during provisioning of metallb when L2 advertisements are used.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I tried to use L2 advertisements, but the system said no: `Unable to continue with update: could not get information about the resource L2Advertisement "" in namespace "ix-metallb": resource name may not be empty`. After this change, it no longer says no. And it even works, as the L2 advertisement is being done.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
