### PR TITLE
feat(mosquitto): Add optional websockets support

### DIFF
--- a/charts/stable/mosquitto/Chart.yaml
+++ b/charts/stable/mosquitto/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/mosquitto
   - https://github.com/eclipse/mosquitto
 type: application
-version: 6.0.38
+version: 6.1.0
 annotations:
   truecharts.org/catagories: |
     - homeautomation

--- a/charts/stable/mosquitto/questions.yaml
+++ b/charts/stable/mosquitto/questions.yaml
@@ -23,6 +23,19 @@ questions:
           schema:
             type: boolean
             default: false
+  - variable: websockets
+    group: "App Configuration"
+    label: "Web Sockets"
+    schema:
+      additional_attrs: true
+      type: dict
+      attrs:
+        - variable: enabled
+          label: "enabled"
+          description: "By enabling this, an additional listener with protocol websockets is added in the mosquitto config."
+          schema:
+            type: boolean
+            default: false
 # Include{containerConfig}
 # Include{serviceRoot}
         - variable: main
@@ -54,6 +67,35 @@ questions:
                                   schema:
                                     type: int
                                     default: 1883
+        - variable: websockets
+          label: "WebSockets Service"
+          description: "WebSockets Service"
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{serviceSelectorClusterIP}
+# Include{serviceSelectorExtras}
+                    - variable: websockets
+                      label: "WebSockets Service Port Configuration"
+                      schema:
+                        additional_attrs: true
+                        type: dict
+                        attrs:
+                          - variable: port
+                            label: "Port"
+                            description: "This port exposes the container port on the service"
+                            schema:
+                              type: int
+                              default: 9001
+                              required: true
+# Include{advancedPortHTTP}
+                                - variable: targetPort
+                                  label: "Target Port"
+                                  description: "The internal(!) port on the container the Application runs on"
+                                  schema:
+                                    type: int
+                                    default: 9001
 # Include{serviceExpertRoot}
             default: false
 # Include{serviceExpert}

--- a/charts/stable/mosquitto/values.yaml
+++ b/charts/stable/mosquitto/values.yaml
@@ -9,9 +9,20 @@ service:
       main:
         port: 1883
         targetPort: 1883
+  websockets:
+    enabled: true
+    ports:
+      websockets:
+        enabled: true
+        port: 9001
+        targetPort: 9001
 
 auth:
   # -- By enabling this, `allow_anonymous` gets set to `false` in the mosquitto config.
+  enabled: false
+
+websockets:
+  # -- By enabling this, an additional listener with protocol websockets is added in the mosquitto config.
   enabled: false
 
 configmap:
@@ -20,6 +31,10 @@ configmap:
     data:
       mosquitto.conf: |
         listener {{ .Values.service.main.ports.main.port }}
+        {{- if .Values.websockets.enabled }}
+        listener {{ .Values.service.websockets.ports.websockets.targetPort }}
+        protocol websockets
+        {{- end }}
         {{- if .Values.auth.enabled }}
         allow_anonymous false
         {{- else }}


### PR DESCRIPTION
**Description**
Modify the mosquitto app to add a App Configuration question for enabling websockets support.
If enabled, automatically add the additional listener to the mosquitto.conf file and publish as a separate service.

⚒️ Fixes  #3800

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
In my existing mosquitto app I have edited the questions.yaml and values.yaml and then edited the app configuration to enable the websockets service.


**📃 Notes:**
I am new to charts development, and haven't been able to fully test on a _new_ app deployment, so would appreciate a detailed review of this change please.

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
