### PR TITLE
fix(mosquitto): use targetPort in mosquitto.conf

### DIFF
--- a/charts/stable/mosquitto/Chart.yaml
+++ b/charts/stable/mosquitto/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/mosquitto
   - https://github.com/eclipse/mosquitto
 type: application
-version: 6.1.0
+version: 6.1.1
 annotations:
   truecharts.org/catagories: |
     - homeautomation

--- a/charts/stable/mosquitto/values.yaml
+++ b/charts/stable/mosquitto/values.yaml
@@ -30,7 +30,7 @@ configmap:
     enabled: true
     data:
       mosquitto.conf: |
-        listener {{ .Values.service.main.ports.main.port }}
+        listener {{ .Values.service.main.ports.main.targetPort }}
         {{- if .Values.websockets.enabled }}
         listener {{ .Values.service.websockets.ports.websockets.targetPort }}
         protocol websockets


### PR DESCRIPTION
**Description**
The configuration file mosquitto.conf includes the value for the port to listen on.
This was incorrectly using the variable service.main.ports.main.port which is the port exposing the service to the outside world.
It should instead use the variable service.main.ports.main.targetPort, which is the internal(!) port in the container.
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Not tested.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
