### PR TITLE
fix(mosquitto): add second ingress question for websockets service

### DIFF
--- a/charts/stable/mosquitto/Chart.yaml
+++ b/charts/stable/mosquitto/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/mosquitto
   - https://github.com/eclipse/mosquitto
 type: application
-version: 6.1.1
+version: 6.1.2
 annotations:
   truecharts.org/catagories: |
     - homeautomation

--- a/charts/stable/mosquitto/questions.yaml
+++ b/charts/stable/mosquitto/questions.yaml
@@ -131,6 +131,16 @@ questions:
 # Include{ingressTLS}
 # Include{ingressTraefik}
 # Include{ingressExpert}
+        - variable: websockets
+          label: "WebSockets Ingress"
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{ingressDefault}
+# Include{ingressTLS}
+# Include{ingressTraefik}
+# Include{ingressExpert}
 # Include{ingressList}
 # Include{security}
 # Include{securityContextAdvancedRoot}

--- a/charts/stable/mosquitto/values.yaml
+++ b/charts/stable/mosquitto/values.yaml
@@ -17,6 +17,10 @@ service:
         port: 9001
         targetPort: 9001
 
+ingress:
+  websockets:
+    autoLink: true
+
 auth:
   # -- By enabling this, `allow_anonymous` gets set to `false` in the mosquitto config.
   enabled: false


### PR DESCRIPTION
**Description**
Add a second ingress question for the new WebSockets service, and use the autoLink function to take care of the templating.
The main service is not HTTP, so will need to use type LoadBalancer for now (until the traefik app supports TCP ingress).
⚒️ Fixes  #3800

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Not tested.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
