### PR TITLE
feat(Joplin-Server): Add Email config for users

### DIFF
--- a/charts/stable/joplin-server/Chart.yaml
+++ b/charts/stable/joplin-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.7.4"
 description: This server allows you to sync any Joplin client
 name: joplin-server
-version: 8.0.42
+version: 8.1.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - joplin

--- a/charts/stable/joplin-server/questions.yaml
+++ b/charts/stable/joplin-server/questions.yaml
@@ -13,67 +13,77 @@ questions:
 # Include{controllerExpert}
 # Include{controllerExpertExtraArgs}
   - variable: env
-    group: "Container Configuration"
-    label: "Image Environment"
+    group: Container Configuration
+    label: Image Environment
     schema:
       additional_attrs: true
       type: dict
       attrs:
         - variable: APP_BASE_URL
-          label: "APP_BASE_URL"
-          description: "Sets the APP_BASE_URL env var"
+          label: APP_BASE_URL
+          description: Sets the APP_BASE_URL env var
           schema:
             type: string
             required: true
             default: ""
-        - variable: MAILER_HOST
-          label: "MAILER_HOST"
-          description: "Sets the MAILER_HOST env var, eg smtp.example.com"
-          schema:
-            type: string
-            default: ""
-        - variable: MAILER_PORT
-          label: "MAILER_PORT"
-          description: "Sets the MAILER_PORT env var, eg: SMTP PORT 465"
+        - variable: MAILER_ENABLED
+          label: MAILER_ENABLED
+          description: Set 1 to enabled and 0 to disable
           schema:
             type: int
-            default: 465
-        - variable: MAILER_SECURE
-          label: "MAILER_SECURE"
-          description: "Sets the MAILER_SECURE env var, HTTPS for the smtp"
-          schema:
-            type: boolean
-            default: true
-        - variable: MAILER_AUTH_USER
-          label: "MAILER_AUTH_USER"
-          description: "Sets the MAILER_AUTH_USER env var, username for Email server"
-          schema:
-            type: string
-            default: ""
-        - variable: MAILER_AUTH_PASSWORD
-          label: "MAILER_AUTH_PASSWORD"
-          description: "Sets the MAILER_AUTH_PASSWORD env var, password for Email server"
-          schema:
-            type: string
-            private: true
-            default: ""
-        - variable: MAILER_NOREPLY_NAME
-          label: "MAILER_NOREPLY_NAME"
-          description: "Sets the MAILER_NOREPLY_NAME env var, No Reply email name"
-          schema:
-            type: string
-            default: ""
-        - variable: MAILER_NOREPLY_EMAIL
-          label: "MAILER_NOREPLY_EMAIL"
-          description: "Sets the MAILER_NOREPLY_EMAIL env var, No Reply default email"
-          schema:
-            type: string
-            default: ""
+            min: 0
+            max: 1
+            default: 0
+            show_subquestions_if: true
+            subquestions:
+              - variable: MAILER_HOST
+                label: Mailer Host
+                description: Sets the MAILER_HOST env var, eg smtp.example.com
+                schema:
+                  type: string
+                  default: ""
+              - variable: MAILER_PORT
+                label: Mailer Port
+                description: Sets the MAILER_PORT env var, eg: SMTP PORT 465
+                schema:
+                  type: int
+                  default: 465
+              - variable: MAILER_SECURE
+                label: Mailer Secure
+                description: Sets the MAILER_SECURE env var, HTTPS for the smtp
+                schema:
+                  type: boolean
+                  default: true
+              - variable: MAILER_AUTH_USER
+                label: Mailer Auth User
+                description: Sets the MAILER_AUTH_USER env var, username for Email server
+                schema:
+                  type: string
+                  default: ""
+              - variable: MAILER_AUTH_PASSWORD
+                label: Mailer Auth Password
+                description: Sets the MAILER_AUTH_PASSWORD env var, password for Email server
+                schema:
+                  type: string
+                  private: true
+                  default: ""
+              - variable: MAILER_NOREPLY_NAME
+                label: Mailer No Reply Name
+                description: Sets the MAILER_NOREPLY_NAME env var, No Reply email name
+                schema:
+                  type: string
+                  default: ""
+              - variable: MAILER_NOREPLY_EMAIL
+                label: Mailer No Reply Email
+                description: Sets the MAILER_NOREPLY_EMAIL env var, No Reply default email
+                schema:
+                  type: string
+                  default: ""
 # Include{containerConfig}
 # Include{serviceRoot}
         - variable: main
-          label: "Main Service"
-          description: "The Primary service on which the healthcheck runs, often the webUI"
+          label: Main Service
+          description: The Primary service on which the healthcheck runs, often the webUI
           schema:
             additional_attrs: true
             type: dict
@@ -81,22 +91,22 @@ questions:
 # Include{serviceSelectorLoadBalancer}
 # Include{serviceSelectorExtras}
                     - variable: main
-                      label: "Main Service Port Configuration"
+                      label: Main Service Port Configuration
                       schema:
                         additional_attrs: true
                         type: dict
                         attrs:
                           - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
+                            label: Port
+                            description: This port exposes the container port on the service
                             schema:
                               type: int
                               default: 22300
                               required: true
 # Include{advancedPortHTTP}
                                 - variable: targetPort
-                                  label: "Target Port"
-                                  description: "The internal(!) port on the container the Application runs on"
+                                  label: Target Port
+                                  description: The internal(!) port on the container the Application runs on
                                   schema:
                                     type: int
                                     default: 22300
@@ -106,8 +116,8 @@ questions:
 # Include{serviceList}
 # Include{persistenceRoot}
         - variable: config
-          label: "App Config Storage"
-          description: "Stores the Application Configuration."
+          label: App Config Storage
+          description: Stores the Application Configuration.
           schema:
             additional_attrs: true
             type: dict
@@ -117,7 +127,7 @@ questions:
 # Include{persistenceList}
 # Include{ingressRoot}
         - variable: main
-          label: "Main Ingress"
+          label: Main Ingress
           schema:
             additional_attrs: true
             type: dict
@@ -130,42 +140,42 @@ questions:
 # Include{security}
 # Include{securityContextAdvancedRoot}
               - variable: privileged
-                label: "Privileged mode"
+                label: Privileged mode
                 schema:
                   type: boolean
                   default: false
               - variable: readOnlyRootFilesystem
-                label: "ReadOnly Root Filesystem"
+                label: ReadOnly Root Filesystem
                 schema:
                   type: boolean
                   default: false
               - variable: allowPrivilegeEscalation
-                label: "Allow Privilege Escalation"
+                label: Allow Privilege Escalation
                 schema:
                   type: boolean
                   default: false
               - variable: runAsNonRoot
-                label: "runAsNonRoot"
+                label: runAsNonRoot
                 schema:
                   type: boolean
                   default: false
 # Include{securityContextAdvanced}
 # Include{podSecurityContextRoot}
         - variable: runAsUser
-          label: "runAsUser"
-          description: "The UserID of the user running the application"
+          label: runAsUser
+          description: The UserID of the user running the application
           schema:
             type: int
             default: 0
         - variable: runAsGroup
-          label: "runAsGroup"
-          description: "The groupID this App of the user running the application"
+          label: runAsGroup
+          description: The groupID this App of the user running the application
           schema:
             type: int
             default: 0
         - variable: fsGroup
-          label: "fsGroup"
-          description: "The group that should own ALL storage."
+          label: fsGroup
+          description: The group that should own ALL storage.
           schema:
             type: int
             default: 568

--- a/charts/stable/joplin-server/questions.yaml
+++ b/charts/stable/joplin-server/questions.yaml
@@ -34,51 +34,56 @@ questions:
             min: 0
             max: 1
             default: 0
-            show_subquestions_if: true
-            subquestions:
-              - variable: MAILER_HOST
-                label: Mailer Host
-                description: Sets the MAILER_HOST env var, eg smtp.example.com
-                schema:
-                  type: string
-                  default: ""
-              - variable: MAILER_PORT
-                label: Mailer Port
-                description: Sets the MAILER_PORT env var, eg: SMTP PORT 465
-                schema:
-                  type: int
-                  default: 465
-              - variable: MAILER_SECURE
-                label: Mailer Secure
-                description: Sets the MAILER_SECURE env var, HTTPS for the smtp
-                schema:
-                  type: boolean
-                  default: true
-              - variable: MAILER_AUTH_USER
-                label: Mailer Auth User
-                description: Sets the MAILER_AUTH_USER env var, username for Email server
-                schema:
-                  type: string
-                  default: ""
-              - variable: MAILER_AUTH_PASSWORD
-                label: Mailer Auth Password
-                description: Sets the MAILER_AUTH_PASSWORD env var, password for Email server
-                schema:
-                  type: string
-                  private: true
-                  default: ""
-              - variable: MAILER_NOREPLY_NAME
-                label: Mailer No Reply Name
-                description: Sets the MAILER_NOREPLY_NAME env var, No Reply email name
-                schema:
-                  type: string
-                  default: ""
-              - variable: MAILER_NOREPLY_EMAIL
-                label: Mailer No Reply Email
-                description: Sets the MAILER_NOREPLY_EMAIL env var, No Reply default email
-                schema:
-                  type: string
-                  default: ""
+        - variable: MAILER_HOST
+          label: Mailer Host
+          description: Sets the MAILER_HOST env var, eg smtp.example.com
+          schema:
+            show_if: [["MAILER_ENABLED", "=", "1"]]
+            type: string
+            default: ""
+        - variable: MAILER_PORT
+          label: Mailer Port
+          description: Sets the MAILER_PORT env var, eg: SMTP PORT 465
+          schema:
+            show_if: [["MAILER_ENABLED", "=", "1"]]
+            type: int
+            default: 465
+        - variable: MAILER_SECURE
+          label: Mailer Secure
+          description: Sets the MAILER_SECURE env var, HTTPS for the smtp
+          schema:
+            show_if: [["MAILER_ENABLED", "=", "1"]]
+            type: boolean
+            default: true
+        - variable: MAILER_AUTH_USER
+          label: Mailer Auth User
+          description: Sets the MAILER_AUTH_USER env var, username for Email server
+          schema:
+            show_if: [["MAILER_ENABLED", "=", "1"]]
+            type: string
+            default: ""
+        - variable: MAILER_AUTH_PASSWORD
+          label: Mailer Auth Password
+          description: Sets the MAILER_AUTH_PASSWORD env var, password for Email server
+          schema:
+            show_if: [["MAILER_ENABLED", "=", "1"]]
+            type: string
+            private: true
+            default: ""
+        - variable: MAILER_NOREPLY_NAME
+          label: Mailer No Reply Name
+          description: Sets the MAILER_NOREPLY_NAME env var, No Reply email name
+          schema:
+            show_if: [["MAILER_ENABLED", "=", "1"]]
+            type: string
+            default: ""
+        - variable: MAILER_NOREPLY_EMAIL
+          label: Mailer No Reply Email
+          description: Sets the MAILER_NOREPLY_EMAIL env var, No Reply default email
+          schema:
+            show_if: [["MAILER_ENABLED", "=", "1"]]
+            type: string
+            default: ""
 # Include{containerConfig}
 # Include{serviceRoot}
         - variable: main

--- a/charts/stable/joplin-server/questions.yaml
+++ b/charts/stable/joplin-server/questions.yaml
@@ -26,6 +26,55 @@ questions:
             type: string
             required: true
             default: ""
+        - variable: MAILER_HOST
+          label: "MAILER_HOST"
+          description: "Sets the MAILER_HOST env var, eg smtp.example.com"
+          schema:
+            type: string
+            required: true
+            default: ""
+        - variable: MAILER_PORT
+          label: "MAILER_PORT"
+          description: "Sets the MAILER_PORT env var, eg: SMTP PORT 465"
+          schema:
+            type: string
+            required: true
+            default: ""
+        - variable: MAILER_SECURE
+          label: "MAILER_SECURE"
+          description: "Sets the MAILER_SECURE env var, HTTPS for the smtp"
+          schema:
+            type: string
+            required: true
+            default: "true"
+        - variable: MAILER_AUTH_USER
+          label: "MAILER_AUTH_USER"
+          description: "Sets the MAILER_AUTH_USER env var, username for Email server"
+          schema:
+            type: string
+            required: true
+            default: ""
+        - variable: MAILER_AUTH_PASSWORD
+          label: "MAILER_AUTH_PASSWORD"
+          description: "Sets the MAILER_AUTH_PASSWORD env var, password for Email server"
+          schema:
+            type: string
+            required: true
+            default: ""
+        - variable: MAILER_NOREPLY_NAME
+          label: "MAILER_NOREPLY_NAME"
+          description: "Sets the MAILER_NOREPLY_NAME env var, No Reply email name"
+          schema:
+            type: string
+            required: true
+            default: ""
+        - variable: MAILER_NOREPLY_EMAIL
+          label: "MAILER_NOREPLY_EMAIL"
+          description: "Sets the MAILER_NOREPLY_EMAIL env var, No Reply default email"
+          schema:
+            type: string
+            required: true
+            default: ""
 # Include{containerConfig}
 # Include{serviceRoot}
         - variable: main

--- a/charts/stable/joplin-server/questions.yaml
+++ b/charts/stable/joplin-server/questions.yaml
@@ -43,7 +43,7 @@ questions:
             default: ""
         - variable: MAILER_PORT
           label: Mailer Port
-          description: Sets the MAILER_PORT env var, eg: SMTP PORT 465
+          description: Sets the MAILER_PORT env var, eg SMTP PORT 465
           schema:
             show_if: [["MAILER_ENABLED", "=", "1"]]
             type: int

--- a/charts/stable/joplin-server/questions.yaml
+++ b/charts/stable/joplin-server/questions.yaml
@@ -37,7 +37,7 @@ questions:
           description: "Sets the MAILER_PORT env var, eg: SMTP PORT 465"
           schema:
             type: int
-            default:  465
+            default: 465
         - variable: MAILER_SECURE
           label: "MAILER_SECURE"
           description: "Sets the MAILER_SECURE env var, HTTPS for the smtp"

--- a/charts/stable/joplin-server/questions.yaml
+++ b/charts/stable/joplin-server/questions.yaml
@@ -31,49 +31,43 @@ questions:
           description: "Sets the MAILER_HOST env var, eg smtp.example.com"
           schema:
             type: string
-            required: true
             default: ""
         - variable: MAILER_PORT
           label: "MAILER_PORT"
           description: "Sets the MAILER_PORT env var, eg: SMTP PORT 465"
           schema:
-            type: string
-            required: true
-            default: ""
+            type: int
+            default:  465
         - variable: MAILER_SECURE
           label: "MAILER_SECURE"
           description: "Sets the MAILER_SECURE env var, HTTPS for the smtp"
           schema:
-            type: string
-            required: true
-            default: "true"
+            type: boolean
+            default: true
         - variable: MAILER_AUTH_USER
           label: "MAILER_AUTH_USER"
           description: "Sets the MAILER_AUTH_USER env var, username for Email server"
           schema:
             type: string
-            required: true
             default: ""
         - variable: MAILER_AUTH_PASSWORD
           label: "MAILER_AUTH_PASSWORD"
           description: "Sets the MAILER_AUTH_PASSWORD env var, password for Email server"
           schema:
             type: string
-            required: true
+            private: true
             default: ""
         - variable: MAILER_NOREPLY_NAME
           label: "MAILER_NOREPLY_NAME"
           description: "Sets the MAILER_NOREPLY_NAME env var, No Reply email name"
           schema:
             type: string
-            required: true
             default: ""
         - variable: MAILER_NOREPLY_EMAIL
           label: "MAILER_NOREPLY_EMAIL"
           description: "Sets the MAILER_NOREPLY_EMAIL env var, No Reply default email"
           schema:
             type: string
-            required: true
             default: ""
 # Include{containerConfig}
 # Include{serviceRoot}

--- a/charts/stable/joplin-server/values.yaml
+++ b/charts/stable/joplin-server/values.yaml
@@ -26,6 +26,14 @@ env:
     secretKeyRef:
       name: dbcreds
       key: plainhost
+  MAILER_ENABLED: 1
+  MAILER_HOST: ""
+  MAILER_PORT: 465
+  MAILER_SECURE: true
+  MAILER_AUTH_USER: ""
+  MAILER_AUTH_PASSWORD: ""
+  MAILER_NOREPLY_NAME: ""
+  MAILER_NOREPLY_EMAIL: ""
 
 probes:
   liveness:

--- a/charts/stable/joplin-server/values.yaml
+++ b/charts/stable/joplin-server/values.yaml
@@ -26,7 +26,7 @@ env:
     secretKeyRef:
       name: dbcreds
       key: plainhost
-  MAILER_ENABLED: 1
+  MAILER_ENABLED: 0
   MAILER_HOST: ""
   MAILER_PORT: 465
   MAILER_SECURE: true


### PR DESCRIPTION
**Description**

Joplin has all the email config in env vars so we should expose them to the users

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [X] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
