### PR TITLE
Add quetions to prometheus chart

### DIFF
--- a/charts/stable/prometheus/Chart.yaml
+++ b/charts/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.60.0"
+appVersion: "0.60.1"
 dependencies:
   - name: common
     repository: https://library-charts.truecharts.org

--- a/charts/stable/prometheus/questions.yaml
+++ b/charts/stable/prometheus/questions.yaml
@@ -79,6 +79,38 @@ questions:
                 schema:
                   type: boolean
                   default: false
+              - variable: additionalScrapeConfigs
+                label: "Additional Scrape Configs"
+                description: "Additional Scrape configuration from an external Secret"
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: enabled
+                      label: "Enable"
+                      schema:
+                        type: boolean
+                        default: false
+                        show_subquestions_if: true
+                        subquestions:
+                          - variable: external
+                            group: "External"
+                            label: "External Secret"
+                            schema:
+                              additional_attrs: true
+                              type: dict
+                              attrs:
+                                - variable: name
+                                  label: "Secret name"
+                                  description: "Name of the secret that Prometheus should use for the additional scrape configuration"
+                                  schema:
+                                    type: string
+                                    default: ""
+                                - variable: key
+                                  label: "Secret key"
+                                  description: "Name of the key inside the secret to be used for the additional scrape configuration"
+                                  schema:
+                                    type: string
+                                    default: ""
 
   - variable: alertmanager
     group: "App Configuration"


### PR DESCRIPTION
**Description**

Add question block to the prometheus chart for configuring additionalScrapeConfigs. This allows an external Secret to be used to configure Prometheus targets. Useful for things like static_sd_configs.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
