### PR TITLE
fix(Phoenixstats): Deprecate Chart

### DIFF
--- a/charts/incubator/phoenixstats/Chart.yaml
+++ b/charts/incubator/phoenixstats/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - name: common
     repository: https://library-charts.truecharts.org
     version: 10.6.11
-deprecated: false
+deprecated: true
 description: Simple Chart for displaying stats from any PhoenixMiner instance. Made to go with PhoenixMiner-AMD.
 home: https://truecharts.org/docs/charts/incubator/phoenixstats
 icon: https://truecharts.org/img/hotlink-ok/chart-icons/phoenixstats.png
@@ -25,4 +25,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/incubator/phoenixstats
   - https://hub.docker.com/r/lnxd/phoenixstats
 type: application
-version: 0.0.28
+version: 0.1.0


### PR DESCRIPTION
**Description**

Deprecates chart since you don't mine ETH anymore and no one needs a chart to monitor your dead ETH miners

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [X] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [X] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
