### PR TITLE
fix(browserless-chrome) allow user to set CONNECTION_TIMEOUT in gui.

### DIFF
--- a/charts/stable/browserless-chrome/Chart.yaml
+++ b/charts/stable/browserless-chrome/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/browserless-chrome
   - https://docs.browserless.io/docs/docker.html
   - https://hub.docker.com/r/browserless/chrome/
-version: 2.0.36
+version: 2.0.37
 annotations:
   truecharts.org/catagories: |
     - productivity

--- a/charts/stable/browserless-chrome/questions.yaml
+++ b/charts/stable/browserless-chrome/questions.yaml
@@ -82,6 +82,12 @@ questions:
           schema:
             type: int
             default: 5
+        - variable: CONNECTION_TIMEOUT
+          label: "CONNECTION_TIMEOUT"
+          description: "How long any session can run for in milliseconds. defaults to 30000 ms or 30 seconds"
+          schema:
+            type: int
+            default: 30000
         - variable: DEFAULT_BLOCK_ADS
           label: "DEFAULT_BLOCK_ADS"
           schema:

--- a/charts/stable/browserless-chrome/values.yaml
+++ b/charts/stable/browserless-chrome/values.yaml
@@ -6,7 +6,7 @@ image:
 imagePuppeteer:
   repository: tccr.io/truecharts/browserless-chrome-puppeteer13
   pullPolicy: IfNotPresent
-  tag: v1.51.1-puppeteer@sha256:ff3893628a3662a011d37cbaf30c414af53deeb44a56f9c5e73f8f1317d74ffe
+  tag: v1.51.1-puppeteer@sha256:5afac483afda1f569e166692f3612c926b8c8b6f111e47cd53a52cdd6fe329ec
 
 imageSelector: "image"
 


### PR DESCRIPTION
**Description**
added the option in the gui to be set by the user. still defaults to 30000 ms or 30 seconds.
⚒️ Fixes  #4057 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

**📃 Notes:**

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
