### PR TITLE
feat(prometheus): Filter veth from (duplicate) network device metrics

### DIFF
--- a/charts/stable/prometheus/Chart.yaml
+++ b/charts/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.60.0"
+appVersion: "0.61.0"
 dependencies:
   - name: common
     repository: https://library-charts.truecharts.org

--- a/charts/stable/prometheus/values.yaml
+++ b/charts/stable/prometheus/values.yaml
@@ -1152,6 +1152,8 @@ node-exporter:
   extraArgs:
     collector.filesystem.ignored-mount-points: "^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+|var/db/system/.+|mnt/[a-zA-Z0-9-_\\.]+/ix-applications/.+)($|/)"
     collector.filesystem.ignored-fs-types: "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
+    collector.netdev.device-exclude: "^veth.*$"
+    collector.netclass.ignored-devices: "^veth.*$"
     path.rootfs: /host
   extraVolumes:
     - name: host


### PR DESCRIPTION
**Description**
Update promtheus chart node-exporter values to drop `veth...` devices from network metrics.

⚒️ Fixes  https://github.com/truecharts/charts/issues/4066

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
