### PR TITLE
fix(Omada): Switch internal https port to 443, to stop redirection to 8043 on ingress

### DIFF
--- a/charts/stable/omada-controller/Chart.yaml
+++ b/charts/stable/omada-controller/Chart.yaml
@@ -18,7 +18,7 @@ name: omada-controller
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/omada-controller
   - https://github.com/mbentley/docker-omada-controller
-version: 6.1.1
+version: 6.2.0
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/omada-controller/questions.yaml
+++ b/charts/stable/omada-controller/questions.yaml
@@ -34,34 +34,6 @@ questions:
                             description: This port exposes the container port on the service
                             schema:
                               type: int
-                              default: 8088
-                              required: true
-# Include{advancedPortHTTP}
-                                - variable: targetPort
-                                  label: Target Port
-                                  description: The internal(!) port on the container the Application runs on
-                                  schema:
-                                    type: int
-                                    default: 8088
-        - variable: main-secure
-          label: Omada Controller Main HTTPS portal
-          description: Omada Controller Main User HTTPS portal
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelectorExtras}
-                    - variable: main-secure
-                      label: HTTPS Main Service Port Configuration
-                      schema:
-                        additional_attrs: true
-                        type: dict
-                        attrs:
-                          - variable: port
-                            label: Port
-                            description: This port exposes the container port on the service
-                            schema:
-                              type: int
                               default: 8043
                               required: true
 # Include{advancedPortHTTPS}
@@ -70,7 +42,7 @@ questions:
                                   description: The internal(!) port on the container the Application runs on
                                   schema:
                                     type: int
-                                    default: 8043
+                                    default: 443
         - variable: comm
           label: Omada Controller User HTTPS portal
           description: Omada Controller User HTTPS portal

--- a/charts/stable/omada-controller/questions.yaml
+++ b/charts/stable/omada-controller/questions.yaml
@@ -34,6 +34,34 @@ questions:
                             description: This port exposes the container port on the service
                             schema:
                               type: int
+                              default: 8088
+                              required: true
+# Include{advancedPortHTTP}
+                                - variable: targetPort
+                                  label: Target Port
+                                  description: The internal(!) port on the container the Application runs on
+                                  schema:
+                                    type: int
+                                    default: 8088
+        - variable: main-secure
+          label: Omada Controller Main HTTPS portal
+          description: Omada Controller Main User HTTPS portal
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{serviceSelectorExtras}
+                    - variable: main-secure
+                      label: HTTPS Main Service Port Configuration
+                      schema:
+                        additional_attrs: true
+                        type: dict
+                        attrs:
+                          - variable: port
+                            label: Port
+                            description: This port exposes the container port on the service
+                            schema:
+                              type: int
                               default: 8043
                               required: true
 # Include{advancedPortHTTPS}

--- a/charts/stable/omada-controller/values.yaml
+++ b/charts/stable/omada-controller/values.yaml
@@ -12,7 +12,7 @@ podSecurityContext:
   runAsGroup: 0
 
 env:
-  # Omada automatically redirects to that port. 
+  # Omada automatically redirects to that port.
   # Instead of consuming the external 443 port, it's better to switch internal
   # But still give user the ability to change it.
   MANAGE_HTTPS_PORT: "{{ .Values.service.main.ports.main.targetPort }}"

--- a/charts/stable/omada-controller/values.yaml
+++ b/charts/stable/omada-controller/values.yaml
@@ -12,15 +12,16 @@ podSecurityContext:
   runAsGroup: 0
 
 env:
-  MANAGE_HTTPS_PORT: "{{ .Values.service.main.ports.main.port }}"
+  MANAGE_HTTP_PORT: "{{ .Values.service.main.ports.main.port }}"
+  MANAGE_HTTPS_PORT: "{{ .Values.service.main-secure.ports.main-secure.port }}"
   PORTAL_HTTPS_PORT: "{{ .Values.service.comm.ports.comm.port }}"
 
 service:
   main:
     ports:
       main:
-        protocol: HTTPS
-        port: 8043
+        protocol: HTTP
+        port: 8088
   comm:
     enabled: true
     ports:
@@ -28,6 +29,12 @@ service:
         protocol: HTTPS
         enabled: true
         port: 8843
+  main-secure:
+    enabled: true
+    ports:
+      main-secure:
+        protocol: HTTPS
+        port: 8043
   omada-tcp:
     enabled: true
     ports:

--- a/charts/stable/omada-controller/values.yaml
+++ b/charts/stable/omada-controller/values.yaml
@@ -12,16 +12,19 @@ podSecurityContext:
   runAsGroup: 0
 
 env:
-  MANAGE_HTTP_PORT: "{{ .Values.service.main.ports.main.port }}"
-  MANAGE_HTTPS_PORT: "{{ .Values.service.main-secure.ports.main-secure.port }}"
+  # Omada automatically redirects to that port. 
+  # Instead of consuming the external 443 port, it's better to switch internal
+  # But still give user the ability to change it.
+  MANAGE_HTTPS_PORT: "{{ .Values.service.main.ports.main.targetPort }}"
   PORTAL_HTTPS_PORT: "{{ .Values.service.comm.ports.comm.port }}"
 
 service:
   main:
     ports:
       main:
-        protocol: HTTP
-        port: 8088
+        protocol: HTTPS
+        port: 8043
+        targetPort: 443
   comm:
     enabled: true
     ports:
@@ -29,12 +32,6 @@ service:
         protocol: HTTPS
         enabled: true
         port: 8843
-  main-secure:
-    enabled: true
-    ports:
-      main-secure:
-        protocol: HTTPS
-        port: 8043
   omada-tcp:
     enabled: true
     ports:


### PR DESCRIPTION
**Description**

Enabling ingress with Omada HTTPS has never worked, this should change it to use HTTP and allow Ingress to be used

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [X] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
