### PR TITLE
fix(minecraft-bungeecord) set rcon to the actual rcon port

### DIFF
--- a/charts/incubator/minecraft-bungeecord/Chart.yaml
+++ b/charts/incubator/minecraft-bungeecord/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: minecraft-bungeecord
-version: 0.0.27
+version: 0.0.28
 appVersion: "2022.4.1"
 description: A Spigot BungeeCord server.
 type: application

--- a/charts/incubator/minecraft-bungeecord/values.yaml
+++ b/charts/incubator/minecraft-bungeecord/values.yaml
@@ -27,7 +27,7 @@ secretEnv:
   RCON_PASSWORD: "secretrconpass"
 
 env:
-  RCON_PORT: "{{ .Values.service.main.ports.main.port }}"
+  RCON_PORT: "{{ .Values.service.rcon.ports.rcon.port }}"
   TYPE: "BUNGEECORD"
   ONLINE_MODE: false
   MEMORY: 512M


### PR DESCRIPTION
**Description**
fix the issue where `RCON_PORT`  applied the value from the main port instead of the rcon port.
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
