### PR TITLE
changing main service to actual panel port

### DIFF
--- a/charts/incubator/crafty-4/Chart.yaml
+++ b/charts/incubator/crafty-4/Chart.yaml
@@ -28,4 +28,4 @@ annotations:
   truecharts.org/catagories: |
     - GameServers
     - minecraft
-version: 0.0.40
+version: 0.0.41

--- a/charts/incubator/crafty-4/questions.yaml
+++ b/charts/incubator/crafty-4/questions.yaml
@@ -34,15 +34,15 @@ questions:
                             description: This port exposes the container port on the service
                             schema:
                               type: int
-                              default: 10586
+                              default: 8443
                               required: true
-# Include{advancedPortHTTP}
+# Include{advancedPortHTTPS}
                                 - variable: targetPort
                                   label: Target Port
                                   description: The internal(!) port on the container the Application runs on
                                   schema:
                                     type: int
-                                    default: 8000
+                                    default: 8443
         - variable: sub
           label: Sub Service
           description: The Sub service on which the healthcheck runs, often the webUI
@@ -63,7 +63,7 @@ questions:
                             description: This port exposes the container port on the service
                             schema:
                               type: int
-                              default: 8443
+                              default: 10586
                               required: true
 # Include{advancedPortHTTPS}
                                 - variable: targetPort
@@ -71,7 +71,7 @@ questions:
                                   description: The internal(!) port on the container the Application runs on
                                   schema:
                                     type: int
-                                    default: 8443
+                                    default: 8000
         - variable: minecraft
           label: Minecraft Service
           description: Container Port 25500

--- a/charts/incubator/crafty-4/questions.yaml
+++ b/charts/incubator/crafty-4/questions.yaml
@@ -34,7 +34,7 @@ questions:
                             description: This port exposes the container port on the service
                             schema:
                               type: int
-                              default: 8443
+                              default: 10586
                               required: true
 # Include{advancedPortHTTPS}
                                 - variable: targetPort
@@ -63,7 +63,7 @@ questions:
                             description: This port exposes the container port on the service
                             schema:
                               type: int
-                              default: 10586
+                              default: 10587
                               required: true
 # Include{advancedPortHTTPS}
                                 - variable: targetPort

--- a/charts/incubator/crafty-4/values.yaml
+++ b/charts/incubator/crafty-4/values.yaml
@@ -12,20 +12,20 @@ securityContext:
 
 probes:
   liveness:
-    type: HTTP
+    type: HTTPS
     path: /
   readiness:
-    type: HTTP
+    type: HTTPS
     path: /
   startup:
-    type: HTTP
+    type: HTTPS
     path: /
 
 service:
   main:
     ports:
       main:
-        port: 8443
+        port: 10586
         protocol: HTTPS
         targetPort: 8443
   sub:
@@ -33,7 +33,7 @@ service:
     ports:
       sub:
         enabled: true
-        port: 10586
+        port: 10587
         protocol: HTTPS
         targetPort: 8000
   bedrock:

--- a/charts/incubator/crafty-4/values.yaml
+++ b/charts/incubator/crafty-4/values.yaml
@@ -25,17 +25,17 @@ service:
   main:
     ports:
       main:
-        port: 10586
-        protocol: HTTP
-        targetPort: 8000
+        port: 8443
+        protocol: HTTPS
+        targetPort: 8443
   sub:
     enabled: true
     ports:
       sub:
         enabled: true
-        port: 8443
+        port: 10586
         protocol: HTTPS
-        targetPort: 8443
+        targetPort: 8000
   bedrock:
     enabled: true
     ports:
@@ -49,7 +49,7 @@ service:
     ports:
       dynmap:
         enabled: true
-        port: 8123
+        port: 8124
         targetPort: 8123
   minecraft:
     enabled: true


### PR DESCRIPTION
**Description**
Fix an issue to declare the actual panel port as the main service port.
the sub port ~~`8000`~~ 10587 also needs to be `https` in order to access the web gui on ~~`8443`~~ 10586.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
