### PR TITLE
fix(metallb): Ensure metallb is running before creating resources

### DIFF
--- a/charts/enterprise/metallb/Chart.yaml
+++ b/charts/enterprise/metallb/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/metallb/metallb
   - https://metallb.universe.tf
 type: application
-version: 5.0.0
+version: 5.0.1
 annotations:
   truecharts.org/catagories: |
     - core

--- a/charts/enterprise/metallb/templates/_wait.tpl
+++ b/charts/enterprise/metallb/templates/_wait.tpl
@@ -1,0 +1,68 @@
+{{- define "metallb.wait" -}}
+{{- $fullName := include "tc.common.names.fullname" . -}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ $fullName }}-wait
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ $fullName }}-wait
+      containers:
+        - name: {{ $fullName }}-wait
+          image: {{ .Values.ubuntuImage.repository }}:{{ .Values.ubuntuImage.tag }}
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              /bin/bash <<'EOF'
+              kubectl wait --namespace metallb-system --for=condition=ready pod --selector=app=metallb --timeout=90s
+              EOF
+      restartPolicy: OnFailure
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $fullName }}-wait
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+rules:
+  - apiGroups:  ["*"]
+    resources:  ["pods"]
+    verbs:  ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $fullName }}-wait
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $fullName }}-wait
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullName }}-wait
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullName }}-wait
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+{{- end -}}

--- a/charts/enterprise/metallb/templates/common.yaml
+++ b/charts/enterprise/metallb/templates/common.yaml
@@ -13,3 +13,5 @@
 {{- include "metallb.comm" . }}
 
 {{- include "metallb.pool" . }}
+
+{{- include "metallb.wait" . }}


### PR DESCRIPTION
**Description**
When MetalLB is installed as first chart, the pods aren't running yet because the manifests where just added.
This adds a wait job, to ensure the pods are actually running before trying to add the metallb resources.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
