### PR TITLE
fix(Omada): Re-add conditional nodeport for Ingress

### DIFF
--- a/charts/stable/omada-controller/Chart.yaml
+++ b/charts/stable/omada-controller/Chart.yaml
@@ -18,7 +18,7 @@ name: omada-controller
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/omada-controller
   - https://github.com/mbentley/docker-omada-controller
-version: 8.0.2
+version: 8.0.3
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/omada-controller/Chart.yaml
+++ b/charts/stable/omada-controller/Chart.yaml
@@ -18,7 +18,7 @@ name: omada-controller
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/omada-controller
   - https://github.com/mbentley/docker-omada-controller
-version: 8.0.3
+version: 8.1.0
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/omada-controller/Chart.yaml
+++ b/charts/stable/omada-controller/Chart.yaml
@@ -18,7 +18,7 @@ name: omada-controller
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/omada-controller
   - https://github.com/mbentley/docker-omada-controller
-version: 8.1.0
+version: 8.0.3
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/omada-controller/values.yaml
+++ b/charts/stable/omada-controller/values.yaml
@@ -19,13 +19,6 @@ env:
   MANAGE_HTTPS_PORT: "{{ if .Values.ingress.main.enabled }}443{{ else }}{{ .Values.service.main.ports.main.port }}{{ end }}"
   PORTAL_HTTPS_PORT: "{{ .Values.service.comm.ports.comm.port }}"
 
-service:
-  main:
-    ports:
-      main:
-        protocol: HTTPS
-        port: 8043
-
 probes:
   liveness:
     port: "{{ if .Values.ingress.main.enabled }}443{{ else }}{{ .Values.service.main.ports.main.port }}{{ end }}"
@@ -34,6 +27,12 @@ probes:
   startup:
     port: "{{ if .Values.ingress.main.enabled }}443{{ else }}{{ .Values.service.main.ports.main.port }}{{ end }}"
 
+service:
+  main:
+    ports:
+      main:
+        protocol: HTTPS
+        port: 8043
   comm:
     enabled: true
     ports:

--- a/charts/stable/omada-controller/values.yaml
+++ b/charts/stable/omada-controller/values.yaml
@@ -24,7 +24,10 @@ service:
     ports:
       main:
         protocol: HTTPS
+        # Nodeport fix for Ingress users
+        nodePort: "{{ if .ingress.main.enabled }}443{{ else }}{{ .Values.service.main.ports.main.port }}{{ end }}"
         port: 8043
+
   comm:
     enabled: true
     ports:

--- a/charts/stable/omada-controller/values.yaml
+++ b/charts/stable/omada-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: tccr.io/truecharts/omada-controller
-  tag: 5.5@sha256:394fa05a26de61a45f8b364c69b4253443e46e0ffd02dc68453fd020d73037e1
+  tag: 5.6@sha256:1524a2ec4b36faa37ba5e0716fccc488ed73cede848646bc528470bd292967cd
   pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/stable/omada-controller/values.yaml
+++ b/charts/stable/omada-controller/values.yaml
@@ -24,9 +24,15 @@ service:
     ports:
       main:
         protocol: HTTPS
-        # Nodeport fix for Ingress users
-        nodePort: "{{ if .ingress.main.enabled }}443{{ else }}{{ .Values.service.main.ports.main.port }}{{ end }}"
         port: 8043
+
+probes:
+  liveness:
+    port: "{{ if .Values.ingress.main.enabled }}443{{ else }}{{ .Values.service.main.ports.main.port }}{{ end }}"
+  readiness:
+    port: "{{ if .Values.ingress.main.enabled }}443{{ else }}{{ .Values.service.main.ports.main.port }}{{ end }}"
+  startup:
+    port: "{{ if .Values.ingress.main.enabled }}443{{ else }}{{ .Values.service.main.ports.main.port }}{{ end }}"
 
   comm:
     enabled: true


### PR DESCRIPTION
**Description**

Omada needs 443 on nodePort if we want to support Ingress (see versions 6.0) so added the same condition for Ingress users

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
