### PR TITLE
fix(valheim): fix open portal button

### DIFF
--- a/charts/stable/valheim/Chart.yaml
+++ b/charts/stable/valheim/Chart.yaml
@@ -19,7 +19,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/valheim
   - https://github.com/lloesche/valheim-server-docker
   - https://hub.docker.com/r/lloesche/valheim-server
-version: 5.0.3
+version: 5.0.4
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/valheim/questions.yaml
+++ b/charts/stable/valheim/questions.yaml
@@ -6,7 +6,7 @@ portals:
     host:
       - "$kubernetes-resource_configmap_portal_host"
     ports:
-      - "$kubernetes-resource_configmap_portal_port"
+      - "$variable-service.supervisor.ports.supervisor.port"
 questions:
 # Include{global}
 # Include{controller}

--- a/charts/stable/valheim/questions.yaml
+++ b/charts/stable/valheim/questions.yaml
@@ -9,91 +9,91 @@ questions:
 # Include{replica1}
 # Include{controllerExpertExtraArgs}
   - variable: secretEnv
-    group: "App Configuration"
-    label: "Image Secrets"
+    group: App Configuration
+    label: Image Secrets
     schema:
       additional_attrs: true
       type: dict
       attrs:
         - variable: SUPERVISOR_HTTP_USER
-          label: "SUPERVISOR_HTTP_USER"
+          label: SUPERVISOR_HTTP_USER
           schema:
             type: string
-            default: "admin"
+            default: admin
             required: true
         - variable: SUPERVISOR_HTTP_PASS
-          label: "SUPERVISOR_HTTP_PASS"
+          label: SUPERVISOR_HTTP_PASS
           schema:
             type: string
             required: true
             private: true
-            default: "REPLACETHIS"
+            default: REPLACETHIS
         - variable: SERVER_PASS
-          label: "SERVER_PASS"
+          label: SERVER_PASS
           schema:
             type: string
             required: true
             private: true
-            default: "REPLACETHIS"
+            default: REPLACETHIS
   - variable: env
-    group: "App Configuration"
-    label: "Image Environment"
+    group: App Configuration
+    label: Image Environment
     schema:
       additional_attrs: true
       type: dict
       attrs:
         - variable: STATUS_HTTP
-          label: "STATUS_HTTP"
+          label: STATUS_HTTP
           schema:
             type: boolean
             default: true
         - variable: SUPERVISOR_HTTP
-          label: "SUPERVISOR_HTTP"
+          label: SUPERVISOR_HTTP
           schema:
             type: boolean
             default: true
         - variable: SERVER_NAME
-          label: "SERVER_NAME"
+          label: SERVER_NAME
           schema:
             type: string
-            default: "My Server"
+            default: My Server
             required: true
         - variable: WORLD_NAME
-          label: "WORLD_NAME"
+          label: WORLD_NAME
           schema:
             type: string
-            default: "Dedicated"
+            default: Dedicated
             required: true
         - variable: SERVER_PUBLIC
-          label: "SERVER_PUBLIC"
+          label: SERVER_PUBLIC
           schema:
             type: boolean
             default: true
         - variable: UPDATE_INTERVAL
-          label: "UPDATE_INTERVAL"
+          label: UPDATE_INTERVAL
           schema:
             type: int
             default: 10800
             required: true
         - variable: BACKUPS
-          label: "BACKUPS"
+          label: BACKUPS
           schema:
             type: boolean
             default: true
         - variable: BACKUPS_INTERVAL
-          label: "BACKUPS_INTERVAL"
+          label: BACKUPS_INTERVAL
           schema:
             type: int
             default: 43200
             required: true
         - variable: BACKUPS_DIRECTORY
-          label: "BACKUPS_DIRECTORY"
+          label: BACKUPS_DIRECTORY
           schema:
             type: string
-            default: "/backups"
+            default: /backups
             required: true
         - variable: BACKUPS_MAX_AGE
-          label: "BACKUPS_MAX_AGE"
+          label: BACKUPS_MAX_AGE
           schema:
             type: int
             default: 3
@@ -101,8 +101,8 @@ questions:
 # Include{containerConfig}
 # Include{serviceRoot}
         - variable: main
-          label: "Main Service"
-          description: "The Primary service on which the healthcheck runs, often the webUI"
+          label: Main Service
+          description: The Primary service on which the healthcheck runs, often the webUI
           schema:
             additional_attrs: true
             type: dict
@@ -110,21 +110,21 @@ questions:
 # Include{serviceSelectorLoadBalancer}
 # Include{serviceSelectorExtras}
                     - variable: main
-                      label: "Main Service Port Configuration"
+                      label: Main Service Port Configuration
                       schema:
                         additional_attrs: true
                         type: dict
                         attrs:
                           - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
+                            label: Port
+                            description: This port exposes the container port on the service
                             schema:
                               type: int
                               default: 9010
                               required: true
         - variable: supervisor
-          label: "supervisor Service"
-          description: "The supervisor service"
+          label: supervisor Service
+          description: The supervisor service
           schema:
             additional_attrs: true
             type: dict
@@ -132,21 +132,21 @@ questions:
 # Include{serviceSelectorLoadBalancer}
 # Include{serviceSelectorExtras}
                     - variable: supervisor
-                      label: "supervisor Service Port Configuration"
+                      label: supervisor Service Port Configuration
                       schema:
                         additional_attrs: true
                         type: dict
                         attrs:
                           - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
+                            label: Port
+                            description: This port exposes the container port on the service
                             schema:
                               type: int
                               default: 9011
                               required: true
         - variable: valheim
-          label: "valheim Service"
-          description: "The valheim Game service"
+          label: valheim Service
+          description: The valheim Game service
           schema:
             additional_attrs: true
             type: dict
@@ -154,40 +154,40 @@ questions:
 # Include{serviceSelectorLoadBalancer}
 # Include{serviceSelectorExtras}
                     - variable: valheim1
-                      label: "valheim-1 Service Port Configuration"
+                      label: valheim-1 Service Port Configuration
                       schema:
                         additional_attrs: true
                         type: dict
                         attrs:
                           - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
+                            label: Port
+                            description: This port exposes the container port on the service
                             schema:
                               type: int
                               default: 2456
                               required: true
                     - variable: valheim2
-                      label: "valheim-2 Service Port Configuration"
+                      label: valheim-2 Service Port Configuration
                       schema:
                         additional_attrs: true
                         type: dict
                         attrs:
                           - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
+                            label: Port
+                            description: This port exposes the container port on the service
                             schema:
                               type: int
                               default: 2457
                               required: true
                     - variable: valheim3
-                      label: "valheim-3 Service Port Configuration"
+                      label: valheim-3 Service Port Configuration
                       schema:
                         additional_attrs: true
                         type: dict
                         attrs:
                           - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
+                            label: Port
+                            description: This port exposes the container port on the service
                             schema:
                               type: int
                               default: 2458
@@ -198,16 +198,16 @@ questions:
 # Include{serviceList}
 # Include{persistenceRoot}
         - variable: config
-          label: "App Config Storage"
-          description: "Stores the Application Configuration."
+          label: App Config Storage
+          description: Stores the Application Configuration.
           schema:
             additional_attrs: true
             type: dict
             attrs:
 # Include{persistenceBasic}
         - variable: backups
-          label: "App backups Storage"
-          description: "Stores the Application backups."
+          label: App backups Storage
+          description: Stores the Application backups.
           schema:
             additional_attrs: true
             type: dict
@@ -216,7 +216,7 @@ questions:
 # Include{persistenceList}
 # Include{ingressRoot}
         - variable: main
-          label: "Main Ingress"
+          label: Main Ingress
           schema:
             additional_attrs: true
             type: dict
@@ -225,7 +225,7 @@ questions:
 # Include{ingressTLS}
 # Include{ingressTraefik}
         - variable: supervisor
-          label: "supervisor Ingress"
+          label: supervisor Ingress
           schema:
             additional_attrs: true
             type: dict
@@ -237,41 +237,41 @@ questions:
 # Include{security}
 # Include{securityContextAdvancedRoot}
               - variable: privileged
-                label: "Privileged mode"
+                label: Privileged mode
                 schema:
                   type: boolean
                   default: false
               - variable: readOnlyRootFilesystem
-                label: "ReadOnly Root Filesystem"
+                label: ReadOnly Root Filesystem
                 schema:
                   type: boolean
                   default: false
               - variable: allowPrivilegeEscalation
-                label: "Allow Privilege Escalation"
+                label: Allow Privilege Escalation
                 schema:
                   type: boolean
                   default: false
               - variable: runAsNonRoot
-                label: "runAsNonRoot"
+                label: runAsNonRoot
                 schema:
                   type: boolean
                   default: false
 # Include{podSecurityContextRoot}
         - variable: runAsUser
-          label: "runAsUser"
-          description: "The UserID of the user running the application"
+          label: runAsUser
+          description: The UserID of the user running the application
           schema:
             type: int
             default: 0
         - variable: runAsGroup
-          label: "runAsGroup"
-          description: "The groupID this App of the user running the application"
+          label: runAsGroup
+          description: The groupID this App of the user running the application
           schema:
             type: int
             default: 0
         - variable: fsGroup
-          label: "fsGroup"
-          description: "The group that should own ALL storage."
+          label: fsGroup
+          description: The group that should own ALL storage.
           schema:
             type: int
             default: 568

--- a/charts/stable/valheim/questions.yaml
+++ b/charts/stable/valheim/questions.yaml
@@ -1,7 +1,12 @@
 # Include{groups}
 portals:
   open:
-# Include{portalLink}
+    protocols:
+      - "$kubernetes-resource_configmap_portal_protocol"
+    host:
+      - "$kubernetes-resource_configmap_portal_host"
+    ports:
+      - "$kubernetes-resource_configmap_portal_port"
 questions:
 # Include{global}
 # Include{controller}

--- a/charts/stable/valheim/questions.yaml
+++ b/charts/stable/valheim/questions.yaml
@@ -179,19 +179,6 @@ questions:
                               type: int
                               default: 2457
                               required: true
-                    - variable: valheim3
-                      label: valheim-3 Service Port Configuration
-                      schema:
-                        additional_attrs: true
-                        type: dict
-                        attrs:
-                          - variable: port
-                            label: Port
-                            description: This port exposes the container port on the service
-                            schema:
-                              type: int
-                              default: 2458
-                              required: true
 # Include{serviceExpertRoot}
             default: false
 # Include{serviceExpert}

--- a/charts/stable/valheim/values.yaml
+++ b/charts/stable/valheim/values.yaml
@@ -11,8 +11,8 @@ secretEnv:
 env:
   STATUS_HTTP: true
   STATUS_HTTP_PORT: "{{ .Values.service.main.ports.main.port }}"
-  SUPERVISOR_HTTP_PORT: "{{ .Values.service.supervisor.ports.supervisor.port }}"
   SUPERVISOR_HTTP: true
+  SUPERVISOR_HTTP_PORT: "{{ .Values.service.supervisor.ports.supervisor.port }}"
   SERVER_NAME: My Server
   SERVER_PORT: "{{ .Values.service.valheim.ports.valheim1.port }}"
   WORLD_NAME: Dedicated

--- a/charts/stable/valheim/values.yaml
+++ b/charts/stable/valheim/values.yaml
@@ -54,10 +54,6 @@ service:
         enabled: true
         port: 2457
         protocol: UDP
-      valheim3:
-        enabled: true
-        port: 2458
-        protocol: UDP
 
 ingress:
   supervisor:

--- a/charts/stable/valheim/values.yaml
+++ b/charts/stable/valheim/values.yaml
@@ -66,10 +66,10 @@ ingress:
 persistence:
   config:
     enabled: true
-    mountPath: "/config"
+    mountPath: /config
   backups:
     enabled: true
-    mountPath: "/backups"
+    mountPath: /backups
 
 portal:
   enabled: true


### PR DESCRIPTION
**Description**
The "Open" link previously opened the STATUS_HTTP_PORT, which serves a
status.json generated by querying the Valheim server's query port.  Now
it opens the SUPERVISOR_HTTP_PORT which presents a status and control
web interface for the various processes running under the supervisor.

This seems much more useful than the blank default and JSON file
available in the other server.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
```
.github/scripts/build-catalog.sh stable/valheim
scp catalog/stable/valheim/5.0.4/questions.yaml truenas.local:/mnt/data/ix-applications/catalogs/github_com_truecharts_catalog_main/stable/valheim/5.0.3/questions.yaml
```
Then added a new "valheim-test" app based on that locally modified questions.yaml.  The open button behaved as I'd like instead of opening a 404 page.

**📃 Notes:**
There are additional details here:  
https://github.com/lloesche/valheim-server-docker#status-web-server

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
