### PR TITLE
Qbit Doc Update VPN Section

### DIFF
--- a/charts/stable/qbittorrent/Chart.yaml
+++ b/charts/stable/qbittorrent/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/qbittorrent
   - https://github.com/qbittorrent/qBittorrent
 type: application
-version: 13.0.3
+version: 13.0.4
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/qbittorrent/docs/installation.md
+++ b/charts/stable/qbittorrent/docs/installation.md
@@ -35,7 +35,7 @@ This is ALSO the port Sonarr/Radarr and other services will use to connect to qB
 
 #### Listening Ports
 
-??? VPN "With VPN" - No need to port forward on your router - If you want fast seeding, you will need a service that supports port forwarding and set the TCP Listening Port to the port Desired - Mullvad for example, from Qbit Webui, Tools > Options > Connection tab. Set TCP Listening port to the Port Provided by Mullvad
+??? VPN "With VPN" - No need to port forward on your router - If you want fast seeding, you will need a service that supports port forwarding and set the TCP Listening Port to the port Desired - Mullvad for example, from Qbit Webui, Tools > Options > Connection tab. Set TCP Listening port to the Port Provided by Mullvad.
 
 ??? NOVPN "Without VPN" - You can leave the two ports default without a VPN - If you want fast seeding though, you will need to port forward this port on your router
 

--- a/charts/stable/qbittorrent/docs/installation.md
+++ b/charts/stable/qbittorrent/docs/installation.md
@@ -8,10 +8,14 @@ Typical setting user:group to `apps`, nothing fancy here
 
 - Placed the created `nzb` dataset within the `downloads` folder
 
-??? Note "Note"
-The `apps`:`apps` user:group is built into Truenas SCALE, it is the default user for most applications on Truenas SCALE. You do not have to create a separate user for each application.
+:::note
 
-    When configuring your application you'll typically see user:group `568`, this is the UID for `apps` and its recommended not to change it.
+The `apps`:`apps` user:group is built into Truenas SCALE, it is the default user for most applications on Truenas SCALE.
+You do not have to create a separate user for each application.
+
+When configuring your application you'll typically see user:group `568`, this is the UID for `apps` and its recommended not to change it.
+
+:::
 
 ![!Dataset: Tube](images/dataset.png)
 
@@ -35,9 +39,20 @@ This is ALSO the port Sonarr/Radarr and other services will use to connect to qB
 
 #### Listening Ports
 
-??? VPN "With VPN" - No need to port forward on your router - If you want fast seeding, you will need a service that supports port forwarding and set the TCP Listening Port to the port Desired - Mullvad for example, from Qbit Webui, Tools > Options > Connection tab. Set TCP Listening port to the Port Provided by Mullvad.
+:::tip VPN "With VPN"
 
-??? NOVPN "Without VPN" - You can leave the two ports default without a VPN - If you want fast seeding though, you will need to port forward this port on your router
+- No need to port forward on your router
+- If you want fast seeding, you will need a service that supports port forwarding and set the TCP Listening Port to the port Desired
+- Mullvad for example, from Qbit Webui, Tools > Options > Connection tab. Set TCP Listening port to the Port Provided by Mullvad.
+
+:::
+
+:::tip NOVPN "Without VPN"
+
+- You can leave the two ports default without a VPN
+- If you want fast seeding though, you will need to port forward this port on your router
+
+:::
 
 ![!Networking: qbittorrent](images/networking_listening.png)
 

--- a/charts/stable/qbittorrent/docs/installation.md
+++ b/charts/stable/qbittorrent/docs/installation.md
@@ -35,7 +35,7 @@ This is ALSO the port Sonarr/Radarr and other services will use to connect to qB
 
 #### Listening Ports
 
-??? VPN "With VPN" - No need to port forward on your router - If you want fast seeding, you will need a service that supports port forwarding - We use Mullvad, and changed the two ports below to the port that was allocated to me by Mullvad
+??? VPN "With VPN" - No need to port forward on your router - If you want fast seeding, you will need a service that supports port forwarding and set the TCP Listening Port to the port Desired - Mullvad for example, from Qbit Webui, Tools > Options > Connection tab. Set TCP Listening port to the Port Provided by Mullvad
 
 ??? NOVPN "Without VPN" - You can leave the two ports default without a VPN - If you want fast seeding though, you will need to port forward this port on your router
 


### PR DESCRIPTION
Updated VPN Section to remove references to changing Port on chart to Specify only the TCP Listening Port inside Qbit's webui when using a VPN with Port Forwarding