### PR TITLE
fix(frigate): render parent max_frames only when at least one child has value

### DIFF
--- a/charts/incubator/frigate/Chart.yaml
+++ b/charts/incubator/frigate/Chart.yaml
@@ -24,7 +24,7 @@ sources:
   - https://github.com/blakeblackshear/frigate
   - https://hub.docker.com/r/blakeblackshear/frigate
 type: application
-version: 5.0.7
+version: 5.0.8
 annotations:
   truecharts.org/catagories: |
     - nvr

--- a/charts/incubator/frigate/templates/_configmap.tpl
+++ b/charts/incubator/frigate/templates/_configmap.tpl
@@ -107,6 +107,7 @@ data:
         threshold: {{ .Values.frigate.detect.stationary.threshold | default 50 }}
         {{- if (hasKey .Values.frigate.detect.stationary "max_frames") }}
         {{- if or (hasKey .Values.frigate.detect.stationary.max_frames "default") (hasKey .Values.frigate.detect.stationary.max_frames "objects") }}
+        {{- if or .Values.frigate.detect.stationary.max_frames.default .Values.frigate.detect.stationary.max_frames.objects }}
         max_frames:
           {{- with .Values.frigate.detect.stationary.max_frames.default }}
           default: {{ . }}
@@ -117,6 +118,7 @@ data:
             {{ .object }}: {{ .frames }}
             {{- end }}
           {{- end }}
+        {{- end }}
         {{- end }}
         {{- end }}
     {{- end }}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #5195

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
