### PR TITLE
feat(authelia) enable OAuth Consent Options

### DIFF
--- a/charts/stable/authelia/Chart.yaml
+++ b/charts/stable/authelia/Chart.yaml
@@ -39,7 +39,7 @@ sources:
   - https://github.com/authelia/chartrepo
   - https://github.com/authelia/authelia
 type: application
-version: 14.0.10
+version: 14.0.11
 annotations:
   truecharts.org/catagories: |
     - security

--- a/charts/stable/authelia/questions.yaml
+++ b/charts/stable/authelia/questions.yaml
@@ -912,6 +912,16 @@ questions:
                                         description: "one_factor"
                                       - value: "two_factor"
                                         description: "two_factor"
+                                - variable: consent_mode
+                                  label: "Consent Mode"
+                                  description: "Configures the consent mode. This can be set to auto (default), explicit (consent required every time) or implicit (Automatically assumes consent for every authorization, never asking the user if they wish to give consent."
+                                  schema:
+                                    type: string
+                                    default: "auto"
+                                    enum:
+                                      - value: "auto"
+                                      - value: "explicit"
+                                      - value: "implicit"
                                 - variable: userinfo_signing_algorithm
                                   label: "Userinfo Signing Algorithm"
                                   description: "The algorithm used to sign userinfo endpoint responses for this client, either none or RS256."

--- a/charts/stable/authelia/questions.yaml
+++ b/charts/stable/authelia/questions.yaml
@@ -920,8 +920,11 @@ questions:
                                     default: "auto"
                                     enum:
                                       - value: "auto"
+                                        description: "auto"
                                       - value: "explicit"
+                                        description: "explicit"
                                       - value: "implicit"
+                                        description: "implicit"
                                 - variable: userinfo_signing_algorithm
                                   label: "Userinfo Signing Algorithm"
                                   description: "The algorithm used to sign userinfo endpoint responses for this client, either none or RS256."

--- a/charts/stable/authelia/templates/_configmap.tpl
+++ b/charts/stable/authelia/templates/_configmap.tpl
@@ -205,6 +205,7 @@ data:
           public: {{ $client.public }}
           {{- end }}
           authorization_policy: {{ default "two_factor" $client.authorization_policy }}
+          consent_mode: {{ default "auto" $client.consent_mode}}
           redirect_uris:
           {{- range $client.redirect_uris }}
           - {{ . }}

--- a/charts/stable/authelia/values.yaml
+++ b/charts/stable/authelia/values.yaml
@@ -586,6 +586,9 @@ identity_providers:
     ## The policy to require for this client; one_factor or two_factor.
     # authorization_policy: two_factor
 
+    ## Configures the consent mode; auto, explicit or implicit
+    # consent_mode: auto
+
     ## Audience this client is allowed to request.
     # audience: []
 


### PR DESCRIPTION
**Description**
<!--
Changed the chart to include an addition option for consent mode when configuring client for OAuth. I have added in the option in values.yaml, questions.yaml and edited the config map.
-->
⚒️ Fixes  #5136 

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
