### PR TITLE
chore(qbittorrent):  Use port for containerPort as the listen port is configured via CM, and default torrentudd port to torrent

### DIFF
--- a/charts/stable/qbittorrent/Chart.yaml
+++ b/charts/stable/qbittorrent/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/qbittorrent
   - https://github.com/qbittorrent/qBittorrent
 type: application
-version: 13.0.5
+version: 13.0.6
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/qbittorrent/questions.yaml
+++ b/charts/stable/qbittorrent/questions.yaml
@@ -71,7 +71,7 @@ questions:
                         attrs:
                           - variable: port
                             label: "Port"
-                            description: "This port exposes the container port on the service"
+                            description: "Does not have any effect. It defaults to the same port as torrent service"
                             schema:
                               type: int
                               default: 6881

--- a/charts/stable/qbittorrent/templates/common.yaml
+++ b/charts/stable/qbittorrent/templates/common.yaml
@@ -1,6 +1,11 @@
-{{/* Render the templates */}}
-{{ include "tc.common.loader.all" . }}
+{{/* Make sure all variables are set properly */}}
+{{- include "tc.common.loader.init" . }}
 
+{{/* Set it to the same port as "torrent" service/port */}}
+{{- $_ := set $.Values.service.torrentudp.ports.torrentudp "port" (int .Values.service.torrent.ports.torrent.port) -}}
 
 {{/* Render the configmap */}}
 {{ include "qbittorrent.configmap" . }}
+
+{{/* Render the templates */}}
+{{ include "tc.common.loader.apply" . }}

--- a/charts/stable/qbittorrent/values.yaml
+++ b/charts/stable/qbittorrent/values.yaml
@@ -18,14 +18,12 @@ service:
       torrent:
         enabled: true
         port: 6881
-        targetPort: 6881
   torrentudp:
     enabled: true
     ports:
       torrentudp:
         enabled: true
         port: 6881
-        targetPort: 6881
         protocol: UDP
 
 persistence:


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #5447

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
