### PR TITLE
fix(nextcloud): temporary patch broken permission init

### DIFF
--- a/charts/stable/nextcloud/Chart.yaml
+++ b/charts/stable/nextcloud/Chart.yaml
@@ -37,7 +37,7 @@ sources:
   - https://github.com/nextcloud/docker
   - https://github.com/nextcloud/helm
 type: application
-version: 19.0.26
+version: 19.0.27
 annotations:
   truecharts.org/catagories: |
     - cloud

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -106,7 +106,6 @@ initContainers:
         echo "Forcing permissions on userdata folder..."
         echo "Trying to override ownship using nfs4xdr_winacl..."
         /usr/bin/nfs4xdr_winacl -a chown -G 33 -r -c '/var/www/html/data' -p '/var/www/html/data' || echo "Failed setting ownership..."
-        nfs4_setfacl -R -a A:g:33:RWX "/var/www/html/data"
         chmod 770 /var/www/html/data || echo "Failed to chmod..."
         fi
         EOF

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -93,7 +93,7 @@ probes:
 
 initContainers:
   prestart:
-    image: '{{ include "tc.common.images.selector" . }}'
+    image: '{{ .Values.ubuntuImage.repository }}:{{ .Values.ubuntuImage.tag }}'
     securityContext:
       runAsUser: 0
       runAsGroup: 0
@@ -104,19 +104,10 @@ initContainers:
       - |
         /bin/bash <<'EOF'
         echo "Forcing permissions on userdata folder..."
-        if nfs4xdr_getfacl && nfs4xdr_getfacl | grep -qv "Failed to get NFSv4 ACL"; then
-          echo "NFSv4 ACLs detected, Trying to override permissions using nfs4_setfacl..."
-          nfs4_setfacl -R -a A:g:33:RWX "/var/www/html/data"
-        else
-          echo "No NFSv4 ACLs detected, trying to override permissions using chown/chmod..."
-          echo "checking ownership..."
-          if [ $(stat -c %g .) -eq 33 ]; then
-            echo "Ownership already set to 33, skipping..."
-          else
-            echo "Changing ownership to group 33..."
-            chown -R :33 "/var/www/html/data"
-          fi
-          chmod 770 /var/www/html/data
+        echo "Trying to override ownship using nfs4xdr_winacl..."
+        /usr/bin/nfs4xdr_winacl -a chown -G 33 -r -c '/var/www/html/data' -p '/var/www/html/data' || echo "Failed setting ownership..."
+        nfs4_setfacl -R -a A:g:33:RWX "/var/www/html/data"
+        chmod 770 /var/www/html/data || echo "Failed to chmod..."
         fi
         EOF
 

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -93,7 +93,7 @@ probes:
 
 initContainers:
   prestart:
-    image: '{{ .Values.ubuntuImage.repository }}:{{ .Values.ubuntuImage.tag }}'
+    image: "{{ .Values.ubuntuImage.repository }}:{{ .Values.ubuntuImage.tag }}"
     securityContext:
       runAsUser: 0
       runAsGroup: 0

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -107,7 +107,6 @@ initContainers:
         echo "Trying to override ownship using nfs4xdr_winacl..."
         /usr/bin/nfs4xdr_winacl -a chown -G 33 -r -c '/var/www/html/data' -p '/var/www/html/data' || echo "Failed setting ownership..."
         chmod 770 /var/www/html/data || echo "Failed to chmod..."
-        fi
         EOF
 
     volumeMounts:


### PR DESCRIPTION
**Description**
As noted by iX-Systems employees, this specific app was still using a completely non-functional and inherently broken piece of garbage as permission setting.

This is a quick hotfix that:
A. Uses the correct ACL setting script
B. Uses the correct ACL setting image
C. Is not inherently FUBAR
D. Does not actually support nfsv4_ACL's due to the use of chmod.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
