### PR TITLE
fix(authelia): Allow SMTP without username and password (SMTP relay)

### DIFF
--- a/charts/stable/authelia/Chart.yaml
+++ b/charts/stable/authelia/Chart.yaml
@@ -39,7 +39,7 @@ sources:
   - https://github.com/authelia/chartrepo
   - https://github.com/authelia/authelia
 type: application
-version: 14.0.17
+version: 14.0.18
 annotations:
   truecharts.org/catagories: |
     - security

--- a/charts/stable/authelia/questions.yaml
+++ b/charts/stable/authelia/questions.yaml
@@ -509,13 +509,11 @@ questions:
                       schema:
                         type: string
                         default: ""
-                        required: false
                     - variable: plain_password
                       label: "Password"
                       schema:
                         type: string
                         default: ""
-                        required: false
                     - variable: sender
                       label: "Sender"
                       schema:

--- a/charts/stable/authelia/questions.yaml
+++ b/charts/stable/authelia/questions.yaml
@@ -509,13 +509,13 @@ questions:
                       schema:
                         type: string
                         default: ""
-                        required: true
+                        required: false
                     - variable: plain_password
                       label: "Password"
                       schema:
                         type: string
                         default: ""
-                        required: true
+                        required: false
                     - variable: sender
                       label: "Sender"
                       schema:

--- a/charts/stable/authelia/templates/_configmap.tpl
+++ b/charts/stable/authelia/templates/_configmap.tpl
@@ -173,7 +173,9 @@ data:
         host: {{ $notifier.smtp.host }}
         port: {{ default 25 $notifier.smtp.port }}
         timeout: {{ default "5s" $notifier.smtp.timeout }}
-        username: {{ $notifier.smtp.username }}
+        {{- with $notifier.smtp.username }}
+        username: {{ . }}
+        {{- end }}
         sender: {{ $notifier.smtp.sender }}
         identifier: {{ $notifier.smtp.identifier }}
         subject: {{ $notifier.smtp.subject | quote }}

--- a/charts/stable/authelia/templates/_secrets.tpl
+++ b/charts/stable/authelia/templates/_secrets.tpl
@@ -36,7 +36,7 @@ data:
   LDAP_PASSWORD: {{ .Values.authentication_backend.ldap.plain_password | b64enc | quote }}
   {{- end }}
 
-  {{- if .Values.notifier.smtp.enabled }}
+  {{- if and .Values.notifier.smtp.enabled .Values.notifier.smtp.plain_password }}
   SMTP_PASSWORD: {{ .Values.notifier.smtp.plain_password | b64enc | quote }}
   {{- end }}
 


### PR DESCRIPTION
**Description**
<!--
I have changed the requiredness of the SMTP settings password and username field from true to false. This is necessary to support SMTP relays without authentication. I’m creating this pr because is stumbled on the issue when I wanted to use my Exchange Online SMTP Relay.

-->
⚒️ Fixes  # <!--(issue)-->
Fixed SMTP username and password field to not required instead of required to support SMTP relays without authentication in Authelia.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
I have forked the branch and tested it by adding a new catalog to my Truenas Scale server. I have then installed the Authelia app again from my catalog and the username and password weren’t required anymore. Tested it for a few days and didn’t come across any errors.
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
-  [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
