### PR TITLE
fix(traefik): don't hardcode targetPort, let it fallback to port

### DIFF
--- a/charts/stable/traefik/Chart.yaml
+++ b/charts/stable/traefik/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/traefik/traefik-helm-chart
   - https://traefik.io/
 type: application
-version: 16.0.7
+version: 16.0.8
 annotations:
   truecharts.org/catagories: |
     - network

--- a/charts/stable/traefik/values.yaml
+++ b/charts/stable/traefik/values.yaml
@@ -139,6 +139,7 @@ service:
     ports:
       main:
         port: 9000
+        targetPort: 9000
         protocol: HTTP
         # -- Forwarded Headers should never be enabled on Main entrypoint
         forwardedHeaders:

--- a/charts/stable/traefik/values.yaml
+++ b/charts/stable/traefik/values.yaml
@@ -139,7 +139,6 @@ service:
     ports:
       main:
         port: 9000
-        targetPort: 9000
         protocol: HTTP
         # -- Forwarded Headers should never be enabled on Main entrypoint
         forwardedHeaders:
@@ -192,7 +191,7 @@ service:
           insecureMode: false
   #      tcpexample:
   #        enabled: true
-  #        targetPort: 9443
+  #        port: 9999
   #        protocol: TCP
   #        tls:
   #          enabled: false
@@ -211,7 +210,6 @@ service:
       metrics:
         enabled: true
         port: 9180
-        targetPort: 9180
         protocol: HTTP
         # -- Forwarded Headers should never be enabled on Metrics entrypoint
         forwardedHeaders:


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #5778

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

In the `_args.tpl`, each entrypoint is created based on the `port` of the service.
So `targetPort` has to match `port` everytime. Removing to let it fallback to `port`

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
