### PR TITLE
fix(home-assistant) Dynamically set trusted proxies

### DIFF
--- a/charts/stable/home-assistant/Chart.yaml
+++ b/charts/stable/home-assistant/Chart.yaml
@@ -27,7 +27,7 @@ sources:
   - https://github.com/home-assistant/home-assistant
   - https://github.com/cdr/code-server
 type: application
-version: 18.0.22
+version: 18.0.23
 annotations:
   truecharts.org/catagories: |
     - home-automation

--- a/charts/stable/home-assistant/values.yaml
+++ b/charts/stable/home-assistant/values.yaml
@@ -138,7 +138,7 @@ configmap:
         http:
           use_x_forwarded_for: true
           trusted_proxies:
-            - 172.16.0.0/16
+            - 172.16.0.0/12
 
 postgresql:
   enabled: true

--- a/charts/stable/home-assistant/values.yaml
+++ b/charts/stable/home-assistant/values.yaml
@@ -34,6 +34,9 @@ initContainers:
 # # When hostNetwork is true set dnsPolicy to ClusterFirstWithHostNet
 # dnsPolicy: ClusterFirstWithHostNet
 
+homeassistant:
+  trusted_proxies: []
+
 # Enable a prometheus-operator servicemonitor
 prometheus:
   serviceMonitor:
@@ -141,7 +144,9 @@ configmap:
             {{- if hasKey .Values "ixChartContext" }}
             - {{ .Values.ixChartContext.kubernetes_config.cluster_cidr }}
             {{- else }}
-            - 172.16.0.0/16
+              {{- range .Values.homeassistant.trusted_proxies }}
+            - {{ . }}
+              {{- end }}
             {{- end }}
 postgresql:
   enabled: true

--- a/charts/stable/home-assistant/values.yaml
+++ b/charts/stable/home-assistant/values.yaml
@@ -138,8 +138,11 @@ configmap:
         http:
           use_x_forwarded_for: true
           trusted_proxies:
-            - 172.16.0.0/12
-
+            {{- if hasKey .Values "ixChartContext" }}
+            - {{ .Values.ixChartContext.kubernetes_config.cluster_cidr }}
+            {{- else }}
+            - 172.16.0.0/16
+            {{- end }}
 postgresql:
   enabled: true
   postgresqlUsername: home-assistant


### PR DESCRIPTION
**Description**
~~Setting subnet to /12 fixes the reverse proxy error described [here](https://community.home-assistant.io/t/reverse-proxy-error/312936/29?u=depasseg). ~~
Dynamically set trusted proxies
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
a user in a support ticket confirmed access via domain by doing this.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
