### PR TITLE
BREAKING CHANGES fix(shiori) fix postgres sidecar

### DIFF
--- a/charts/stable/shiori/Chart.yaml
+++ b/charts/stable/shiori/Chart.yaml
@@ -1,21 +1,5 @@
 apiVersion: v2
-appVersion: "1.5.0"
-version: 10.0.16
-kubeVersion: ">=1.16.0-0"
-name: shiori
-description: A simple bookmark manager built with Go
-type: application
-home: https://truecharts.org/charts/stable/shiori
-icon: https://truecharts.org/img/hotlink-ok/chart-icons/shiori.png
-keywords:
-  - shiori
-  - bookmark
-  - bookmark-manager
-  - web-interface
-sources:
-  - https://github.com/truecharts/charts/tree/master/charts/stable/shiori
-  - https://github.com/go-shiori/shiori
-  - https://github.com/nicholaswilde/docker-shiori
+appVersion: "1.5.3"
 dependencies:
   - name: common
     repository: https://library-charts.truecharts.org
@@ -24,10 +8,27 @@ dependencies:
     name: postgresql
     repository: https://charts.truecharts.org/
     version: 11.0.18
+deprecated: false
+description: A simple bookmark manager built with Go.
+home: https://truecharts.org/charts/stable/shiori
+icon: https://truecharts.org/img/hotlink-ok/chart-icons/shiori.png
+keywords:
+  - shiori
+  - bookmark
+  - bookmark-manager
+  - web-interface
+kubeVersion: ">=1.16.0-0"
 maintainers:
   - email: info@truecharts.org
     name: TrueCharts
     url: https://truecharts.org
+name: shiori
+sources:
+  - https://github.com/truecharts/charts/tree/master/charts/stable/shiori
+  - https://github.com/go-shiori/shiori
+  - https://github.com/go-shiori/shiori/pkgs/container/shiori
+type: application
+version: 11.0.0
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/shiori/questions.yaml
+++ b/charts/stable/shiori/questions.yaml
@@ -11,8 +11,8 @@ questions:
 # Include{containerConfig}
 # Include{serviceRoot}
         - variable: main
-          label: "Main Service"
-          description: "The Primary service on which the healthcheck runs, often the webUI"
+          label: Main Service
+          description: The Primary service on which the healthcheck runs, often the webUI
           schema:
             additional_attrs: true
             type: dict
@@ -20,14 +20,14 @@ questions:
 # Include{serviceSelectorLoadBalancer}
 # Include{serviceSelectorExtras}
                     - variable: main
-                      label: "Main Service Port Configuration"
+                      label: Main Service Port Configuration
                       schema:
                         additional_attrs: true
                         type: dict
                         attrs:
                           - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
+                            label: Port
+                            description: This port exposes the container port on the service
                             schema:
                               type: int
                               default: 10098
@@ -38,8 +38,8 @@ questions:
 # Include{serviceList}
 # Include{persistenceRoot}
         - variable: data
-          label: "App Data Storage"
-          description: "Stores the Application Data."
+          label: App Data Storage
+          description: Stores the Application Data.
           schema:
             additional_attrs: true
             type: dict
@@ -48,7 +48,7 @@ questions:
 # Include{persistenceList}
 # Include{ingressRoot}
         - variable: main
-          label: "Main Ingress"
+          label: Main Ingress
           schema:
             additional_attrs: true
             type: dict
@@ -60,41 +60,41 @@ questions:
 # Include{security}
 # Include{securityContextAdvancedRoot}
               - variable: privileged
-                label: "Privileged mode"
+                label: Privileged mode
                 schema:
                   type: boolean
                   default: false
               - variable: readOnlyRootFilesystem
-                label: "ReadOnly Root Filesystem"
+                label: ReadOnly Root Filesystem
                 schema:
                   type: boolean
                   default: true
               - variable: allowPrivilegeEscalation
-                label: "Allow Privilege Escalation"
-                schema:
-                  type: boolean
-                  default: true
-              - variable: runAsNonRoot
-                label: "runAsNonRoot"
+                label: Allow Privilege Escalation
                 schema:
                   type: boolean
                   default: false
+              - variable: runAsNonRoot
+                label: runAsNonRoot
+                schema:
+                  type: boolean
+                  default: true
 # Include{podSecurityContextRoot}
         - variable: runAsUser
-          label: "runAsUser"
-          description: "The UserID of the user running the application"
+          label: runAsUser
+          description: The UserID of the user running the application
           schema:
             type: int
-            default: 0
+            default: 568
         - variable: runAsGroup
-          label: "runAsGroup"
-          description: "The groupID this App of the user running the application"
+          label: runAsGroup
+          description: The groupID this App of the user running the application
           schema:
             type: int
-            default: 0
+            default: 568
         - variable: fsGroup
-          label: "fsGroup"
-          description: "The group that should own ALL storage."
+          label: fsGroup
+          description: The group that should own ALL storage.
           schema:
             type: int
             default: 568

--- a/charts/stable/shiori/templates/_secret.tpl
+++ b/charts/stable/shiori/templates/_secret.tpl
@@ -16,8 +16,8 @@ stringData:
   {{/* Database */}}
   SHIORI_DBMS: "postgresql"
   SHIORI_PG_PORT: "5432"
-  SHIORI_PG_USER: "{{ .Values.postgresql.postgresqlUsername }}"
+  SHIORI_PG_USER: {{ .Values.postgresql.postgresqlUsername }}
   SHIORI_PG_PASS: {{ .Values.postgresql.postgresqlPassword | trimAll "\"" }}
-  SHIORI_PG_NAME: "{{ .Values.postgresql.postgresqlDatabase }}"
-  SHIORI_PG_HOST: {{ printf "%v-%v" .Release.Name "postgresql" }}
+  SHIORI_PG_NAME: {{ .Values.postgresql.postgresqlDatabase }}
+  SHIORI_PG_HOST: {{ .Values.postgresql.url.plain | trimAll "\"" }}
 {{- end -}}

--- a/charts/stable/shiori/templates/_secret.tpl
+++ b/charts/stable/shiori/templates/_secret.tpl
@@ -1,0 +1,23 @@
+{{/* Define the secret */}}
+{{- define "shiori.secret" -}}
+
+{{- $secretName := printf "%s-secret" (include "tc.common.names.fullname" .) }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "tc.common.labels" . | nindent 4 }}
+stringData:
+  SHIORI_DIR: "/data"
+
+  {{/* Database */}}
+  SHIORI_DBMS: "postgresql"
+  SHIORI_PG_PORT: "5432"
+  SHIORI_PG_USER: "{{ .Values.postgresql.postgresqlUsername }}"
+  SHIORI_PG_PASS: {{ .Values.postgresql.postgresqlPassword | trimAll "\"" }}
+  SHIORI_PG_NAME: "{{ .Values.postgresql.postgresqlDatabase }}"
+  SHIORI_PG_HOST: {{ printf "%v-%v" .Release.Name "postgresql" }}
+{{- end -}}

--- a/charts/stable/shiori/templates/_secret.tpl
+++ b/charts/stable/shiori/templates/_secret.tpl
@@ -11,7 +11,7 @@ metadata:
   labels:
     {{- include "tc.common.labels" . | nindent 4 }}
 stringData:
-  SHIORI_DIR: "/data"
+  SHIORI_DIR: {{ .Values.persistence.data.mountPath }}
 
   {{/* Database */}}
   SHIORI_DBMS: "postgresql"

--- a/charts/stable/shiori/templates/common.yaml
+++ b/charts/stable/shiori/templates/common.yaml
@@ -1,1 +1,8 @@
-{{ include "tc.common.loader.all" . }}
+{{/* Make sure all variables are set properly */}}
+{{- include "tc.common.loader.init" . }}
+
+{{/* Render secret */}}
+{{- include "shiori.secret" . }}
+
+{{/* Render the templates */}}
+{{ include "tc.common.loader.apply" . }}

--- a/charts/stable/shiori/values.yaml
+++ b/charts/stable/shiori/values.yaml
@@ -1,27 +1,15 @@
 image:
-  repository: tccr.io/truecharts/shiori
+  repository: ghcr.io/go-shiori/shiori
   pullPolicy: IfNotPresent
-  tag: version-v1.5.0@sha256:6c6331888c9a5162def49b6212327242f7f5c96e2d5a1bb031f79321cc1c0549
+  tag: v1.5.3@sha256:18dd8f354d6f23919c55ed7e63b85747659dad81173766146e81dd051b71c0df
 
 securityContext:
-  allowPrivilegeEscalation: true
-  runAsNonRoot: false
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
 
 podSecurityContext:
-  runAsUser: 0
-  runAsGroup: 0
-
-env:
-  SHIORI_PG_NAME: "{{ .Values.postgresql.postgresqlDatabase }}"
-  SHIORI_PG_USER: "{{ .Values.postgresql.postgresqlUsername }}"
-  SHIORI_PG_PASS:
-    secretKeyRef:
-      name: dbcreds
-      key: postgresql-password
-  SHIORI_PG_HOST:
-    secretKeyRef:
-      name: dbcreds
-      key: plainhost
+  runAsUser: 568
+  runAsGroup: 568
 
 service:
   main:
@@ -33,13 +21,13 @@ service:
 persistence:
   data:
     enabled: true
-    mountPath: "/data"
+    mountPath: /data
   varrun:
     enabled: true
 
 postgresql:
   enabled: true
-  existingSecret: "dbcreds"
+  existingSecret: dbcreds
   postgresqlUsername: shiori
   postgresqlDatabase: shiori
 

--- a/charts/stable/shiori/values.yaml
+++ b/charts/stable/shiori/values.yaml
@@ -1,7 +1,7 @@
 image:
-  repository: ghcr.io/go-shiori/shiori
+  repository: tccr.io/truecharts/shiori
   pullPolicy: IfNotPresent
-  tag: v1.5.3@sha256:18dd8f354d6f23919c55ed7e63b85747659dad81173766146e81dd051b71c0df
+  tag: 1.5.3@sha256:99696bfc727ab1792297cba1e0ba755953bc0cfa38f2c19532c56d68985479a8
 
 envFrom:
   - secretRef:

--- a/charts/stable/shiori/values.yaml
+++ b/charts/stable/shiori/values.yaml
@@ -10,6 +10,7 @@ securityContext:
 podSecurityContext:
   runAsUser: 568
   runAsGroup: 568
+
 envFrom:
   - secretRef:
       name: "{{ include "tc.common.names.fullname" . }}-secret"

--- a/charts/stable/shiori/values.yaml
+++ b/charts/stable/shiori/values.yaml
@@ -10,7 +10,9 @@ securityContext:
 podSecurityContext:
   runAsUser: 568
   runAsGroup: 568
-
+envFrom:
+  - secretRef:
+      name: "{{ include "tc.common.names.fullname" . }}-secret"
 service:
   main:
     ports:

--- a/charts/stable/shiori/values.yaml
+++ b/charts/stable/shiori/values.yaml
@@ -13,7 +13,8 @@ podSecurityContext:
 
 envFrom:
   - secretRef:
-      name: "{{ include "tc.common.names.fullname" . }}-secret"
+      name: '{{ include "tc.common.names.fullname" . }}-secret'
+
 service:
   main:
     ports:

--- a/charts/stable/shiori/values.yaml
+++ b/charts/stable/shiori/values.yaml
@@ -3,14 +3,6 @@ image:
   pullPolicy: IfNotPresent
   tag: v1.5.3@sha256:18dd8f354d6f23919c55ed7e63b85747659dad81173766146e81dd051b71c0df
 
-securityContext:
-  runAsNonRoot: true
-  readOnlyRootFilesystem: true
-
-podSecurityContext:
-  runAsUser: 568
-  runAsGroup: 568
-
 envFrom:
   - secretRef:
       name: '{{ include "tc.common.names.fullname" . }}-secret'


### PR DESCRIPTION
**Description**
fixed shiori postgres sidecar implementation and changed the upstream image. added a config map in case if we want to give the user to opt-in to the DB or not as this will be a breaking change as it was suppose to use a DB.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [X] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [X] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
