### PR TITLE
fix(sickgear): move to official image

### DIFF
--- a/charts/stable/sickgear/Chart.yaml
+++ b/charts/stable/sickgear/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.25.4"
+appVersion: "latest"
 dependencies:
   - name: common
     repository: https://library-charts.truecharts.org
@@ -20,10 +20,9 @@ maintainers:
 name: sickgear
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/sickgear
-  - https://github.com/linuxserver/docker-sickgear
   - https://github.com/SickGear/SickGear
 type: application
-version: 5.0.7
+version: 6.0.0
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/sickgear/values.yaml
+++ b/charts/stable/sickgear/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: tccr.io/truecharts/sickgear
   pullPolicy: IfNotPresent
-  tag: latest@sha256:85dac5001b46ccacec7b008bc32e59a64c576fd191a0f6220a089ad1ef002e2b
+  tag: latest@sha256:fb719e3e74a3dc4bbedd4fce61438ab25481b60de9adb9b545127ab925ec2f88
 
 env:
   APP_DATA: /config

--- a/charts/stable/sickgear/values.yaml
+++ b/charts/stable/sickgear/values.yaml
@@ -1,7 +1,10 @@
 image:
   repository: tccr.io/truecharts/sickgear
   pullPolicy: IfNotPresent
-  tag: version-release_0.25.4@sha256:6a78e9f784cf298552402143bee239858956f4783c7619e9a2b960c0d0d15d73
+  tag: latest@sha256:85dac5001b46ccacec7b008bc32e59a64c576fd191a0f6220a089ad1ef002e2b
+
+env:
+  APP_DATA: /config
 
 securityContext:
   readOnlyRootFilesystem: false


### PR DESCRIPTION
**Description**

Use the official image for sickgear instead of the LinuxServer.io image.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

Locally on my TrueNAS SCALE machine by rewriting the catalog values in place, then deploying a new instance of the app to make sure the new image was used.  The image path was not using the tccr.io domain in that case.

**📃 Notes:**

Please see also [containers #15029](https://github.com/truecharts/containers/pull/15029) for the parallel change there.

I bumped the major version since the image source changes, but saw no breaking change in my (admittedly) simple setup.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [x] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
