### PR TITLE
fix(dependencies): don't run manifest Manager on most dependency apps.

### DIFF
--- a/charts/dependency/clickhouse/Chart.yaml
+++ b/charts/dependency/clickhouse/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://clickhouse.com/
   - https://hub.docker.com/r/yandex/clickhouse-server
 type: application
-version: 3.0.15
+version: 3.0.16
 annotations:
   truecharts.org/catagories: |
     - database

--- a/charts/dependency/clickhouse/values.yaml
+++ b/charts/dependency/clickhouse/values.yaml
@@ -68,3 +68,6 @@ env:
 
 portal:
   enabled: false
+
+manifests:
+  enabled: false

--- a/charts/dependency/mariadb/Chart.yaml
+++ b/charts/dependency/mariadb/Chart.yaml
@@ -25,7 +25,7 @@ sources:
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
 type: application
-version: 5.0.22
+version: 5.0.23
 annotations:
   truecharts.org/catagories: |
     - database

--- a/charts/dependency/mariadb/values.yaml
+++ b/charts/dependency/mariadb/values.yaml
@@ -122,3 +122,6 @@ existingSecret: ""
 
 portal:
   enabled: false
+
+manifests:
+  enabled: false

--- a/charts/dependency/memcached/Chart.yaml
+++ b/charts/dependency/memcached/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
 type: application
-version: 5.0.20
+version: 5.0.21
 annotations:
   truecharts.org/catagories: |
     - database

--- a/charts/dependency/memcached/values.yaml
+++ b/charts/dependency/memcached/values.yaml
@@ -12,3 +12,6 @@ service:
 
 portal:
   enabled: false
+
+manifests:
+  enabled: false

--- a/charts/dependency/mongodb/Chart.yaml
+++ b/charts/dependency/mongodb/Chart.yaml
@@ -24,7 +24,7 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://www.mongodb.com
 type: application
-version: 4.0.23
+version: 4.0.24
 annotations:
   truecharts.org/catagories: |
     - database

--- a/charts/dependency/mongodb/values.yaml
+++ b/charts/dependency/mongodb/values.yaml
@@ -123,3 +123,6 @@ env:
 
 portal:
   enabled: false
+
+manifests:
+  enabled: false

--- a/charts/dependency/postgresql/Chart.yaml
+++ b/charts/dependency/postgresql/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/dependency/postgresql
   - https://www.postgresql.org/
 type: application
-version: 11.0.19
+version: 11.0.20
 annotations:
   truecharts.org/catagories: |
     - database

--- a/charts/dependency/postgresql/values.yaml
+++ b/charts/dependency/postgresql/values.yaml
@@ -127,3 +127,6 @@ env:
 
 portal:
   enabled: false
+
+manifests:
+  enabled: false

--- a/charts/dependency/promtail/Chart.yaml
+++ b/charts/dependency/promtail/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://grafana.com/oss/loki/
   - https://grafana.com/docs/loki/latest/
 type: application
-version: 6.0.10
+version: 6.0.11
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/dependency/promtail/values.yaml
+++ b/charts/dependency/promtail/values.yaml
@@ -253,3 +253,6 @@ config:
     scrape_configs:
       {{- tpl .Values.config.snippets.scrapeConfigs . | nindent 2 }}
       {{- tpl .Values.config.snippets.extraScrapeConfigs . | nindent 2 }}
+
+manifests:
+  enabled: false

--- a/charts/dependency/redis/Chart.yaml
+++ b/charts/dependency/redis/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
 type: application
-version: 5.0.25
+version: 5.0.26
 annotations:
   truecharts.org/catagories: |
     - database

--- a/charts/dependency/redis/values.yaml
+++ b/charts/dependency/redis/values.yaml
@@ -207,3 +207,6 @@ persistence:
 
 portal:
   enabled: false
+
+manifests:
+  enabled: false

--- a/charts/dependency/solr/Chart.yaml
+++ b/charts/dependency/solr/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/apache/solr
   - https://hub.docker.com/r/bitnami/solr/
 type: application
-version: 2.0.21
+version: 2.0.22
 annotations:
   truecharts.org/catagories: |
     - search

--- a/charts/dependency/solr/values.yaml
+++ b/charts/dependency/solr/values.yaml
@@ -138,3 +138,6 @@ env:
 
 portal:
   enabled: true
+
+manifests:
+  enabled: false


### PR DESCRIPTION
**Description**
Manifest Manager causes a slight, but significant, delay in Helm Install and Upgrade.
This becomes a problem when it's ran 2 or more times, once for each dependency as well.

As dependencies are not really aimed to be combined with other TrueCharts Apps and, mostly, do not contain ManifestManager related resources, it can simply be disabled for them.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
