### PR TITLE
fix(heimdall) set tag to 2.5.5

### DIFF
--- a/charts/stable/heimdall/Chart.yaml
+++ b/charts/stable/heimdall/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2021.11.28"
+appVersion: "2.5.5"
 dependencies:
   - name: common
     repository: https://library-charts.truecharts.org
@@ -20,7 +20,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/heimdall
   - https://github.com/linuxserver/Heimdall/
 type: application
-version: 14.0.1
+version: 14.0.2
 annotations:
   truecharts.org/catagories: |
     - organizers

--- a/charts/stable/heimdall/values.yaml
+++ b/charts/stable/heimdall/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: tccr.io/truecharts/heimdall
-  tag: 2021.11.28@sha256:41c9f097e16123cdd8e0b05edf8d6dfac2bc45431bc6e28360310b169de5da1d
+  tag: 2.5.5@sha256:8456359363e59d24570db3e44e94e33ae0336e919c5ecd1cac937caf7722bc84
   pullPolicy: IfNotPresent
 
 securityContext:


### PR DESCRIPTION
**Description**
cli reverted old container tag...just setting the correct tag again.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
