### PR TITLE
fix(ci): Fix the automatic linking of Docker images

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -87,21 +87,37 @@ jobs:
               echo "Attempting to update sources of ${chartname}..."
               echo "Using go-yq verion: <$(go-yq -V)>"
               # Get all sources (except truecharts)
-              curr_sources=$(go-yq '.sources[] | select(. != "https://github.com/truecharts*" and . != "https://ghcr*" and . != "https://hub.docker*" and . != "https://quay*" and . != "https://github.com/truecharts/containers*")' "${chart}/Chart.yaml")
+              curr_sources=$(go-yq '.sources[] | select(. != "https://github.com/truecharts*" and . != "https://ghcr*" and . != "https://hub.docker*" and . != "https://quay*" and . != "https://github.com/truecharts/containers*" and test("^https?://"))' "${chart}/Chart.yaml")
               # Empty sources list in-place
               go-yq -i 'del(.sources.[])' "${chart}/Chart.yaml"
               # Add truechart source
               tcsource="https://github.com/truecharts/charts/tree/master/charts/$train/$chartname" go-yq -i '.sources += env(tcsource)' "${chart}/Chart.yaml"
               container=$(cat website/docs/charts/description_list.md | grep "\[${chartname}\]" | cut -f3 -d '|' | grep -v 'Not Found' || echo "")
               if [ ! -z "$container" ]; then
-                prefix="https://hub.docker.com/"
-                if echo ${container} | grep 'ghcr'; then
-                prefix="https://ghcr.com/"
-                elif echo ${container} | grep 'quay'; then
-                prefix="https://quay.com/"
-                elif echo ${container} | grep 'tccr'; then
-                prefix="https://github.com/truecharts/containers/tree/master/mirror/"
-                fi
+                case "$container" in
+                  *ghcr*|*quay*)
+                    # Both ghcr.io and quay.io have nice redirection.
+                    prefix="https://"
+                    ;;
+                  *lscr*)
+                    # Images hosted on lscr.io seem to all be available on Docker Hub under the linuxserver user.
+                    prefix="https://hub.docker.com/r/linuxserver/"
+                    # Get the image name without any pathing.
+                    container="${container##*/}"
+                    ;;
+                  *tccr*)
+                    prefix="https://github.com/truecharts/containers/tree/master/mirror/"
+                    # Get the image name without any pathing.
+                    container="${container##*/}"
+                    ;;
+                  *)
+                    prefix="https://hub.docker.com/r/"
+                    # If the image name does not contain a slash it is a Docker Official Image.
+                    if [ "$container" == "${container////}" ]; then
+                      prefix="https://hub.docker.com/_/"
+                    fi
+                  ;;
+                esac
                 container="${prefix}${container}" go-yq -i '.sources += env(container) | .sources |= unique' "${chart}/Chart.yaml"
               fi
               # Add the rest of the sources
@@ -109,7 +125,7 @@ jobs:
                 src="$line" go-yq -i '.sources += env(src)' "${chart}/Chart.yaml" || echo "src set error"
               done <<< "$curr_sources"
               echo "Sources of ${chartname} updated!"
-              }
+          }
           export -f sync_tag
 
           for train in enterprise stable incubator dependency; do


### PR DESCRIPTION
**Description**

There were a few issues with the previous implementation.  Some of the links were not generated correctly and Docker Official Images were not supported at all.

This should also automatically clean up non-links in the sources list which is causing linting issues.

After this runs there are still some issues where existing Chart.yaml files may include http instead of https URLs or other artifacts that should be cleaned up manually.

⚒️ Fixes

Numerous issues with Chart.yaml sources lists that contain dead links and non-URLs.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

Cut out the sync_tag function and ran it in its own script.  Tested against individual charts as well as running against all charts as the CI job would.

**📃 Notes:**

There is a change of indent to be consistent with what seemed prevalent in the file.  There is a move from an if-ladder to a case statement for nicer string matching.  There is the use of parameter expansion to manipulate strings.  Any of these might be worth careful review or an alternative, more accessible approach.

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
