### PR TITLE
feat(NextPVR): Add missing UDP ports

### DIFF
--- a/charts/stable/nextpvr/Chart.yaml
+++ b/charts/stable/nextpvr/Chart.yaml
@@ -20,7 +20,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/nextpvr
   - https://hub.docker.com/nextpvr/nextpvr_amd64
   - https://github.com/sub3/NextPVR/wiki/Install-Docker
-version: 4.0.7
+version: 5.0.0
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/nextpvr/Chart.yaml
+++ b/charts/stable/nextpvr/Chart.yaml
@@ -20,7 +20,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/nextpvr
   - https://hub.docker.com/nextpvr/nextpvr_amd64
   - https://github.com/sub3/NextPVR/wiki/Install-Docker
-version: 5.0.0
+version: 4.1.0
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/nextpvr/questions.yaml
+++ b/charts/stable/nextpvr/questions.yaml
@@ -45,6 +45,43 @@ questions:
                               type: int
                               default: 10183
                               required: true
+        - variable: nextpvr-udp
+          label: NextPVR UDP Ports
+          description: Additional UDP Ports that may be required
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{serviceSelectorLoadBalancer}
+# Include{serviceSelectorExtras}
+                    - variable: nextpvr-udp1
+                      label: NextPVR Standard UDP Port
+                      description: Used with certain devices (HomeRUNHD Tuner)
+                      schema:
+                        additional_attrs: true
+                        type: dict
+                        attrs:
+                          - variable: port
+                            label: Port
+                            description: This port exposes the container port on the service
+                            schema:
+                              type: int
+                              default: 16891
+                              required: true
+                    - variable: nextpvr-udp2
+                      label: NextPVR Legacy UDP Port
+                      description: Used with certain legacy devices (HomeRUNHD Tuner)
+                      schema:
+                        additional_attrs: true
+                        type: dict
+                        attrs:
+                          - variable: port
+                            label: Port
+                            description: This port exposes the container port on the service
+                            schema:
+                              type: int
+                              default: 8026
+                              required: true
 # Include{serviceExpertRoot}
             default: false
 # Include{serviceExpert}

--- a/charts/stable/nextpvr/values.yaml
+++ b/charts/stable/nextpvr/values.yaml
@@ -12,6 +12,19 @@ service:
       main:
         port: 10183
         targetPort: 8866
+  nextpvr-udp:
+    enabled: true
+    ports:
+      nextpvr-udp1:
+        enabled: true
+        protocol: UDP
+        port: 16891
+        targetPort: 16891
+      nextpvr-udp2:
+        enabled: true
+        protocol: UDP
+        port: 8026
+        targetPort: 8026
 
 persistence:
   config:


### PR DESCRIPTION
**Description**

As per DockerHUB and a user report on the forum I think we're missing a couple of ports

https://hub.docker.com/r/nextpvr/nextpvr_amd64

This should fix it

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
