### PR TITLE
fix(plexanisync) reference plex_sections correctly

### DIFF
--- a/charts/incubator/plexanisync/Chart.yaml
+++ b/charts/incubator/plexanisync/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/RickDB/PlexAniSync
   - https://github.com/RickDB/PlexAniSync/pkgs/container/plexanisync
 type: application
-version: 0.0.4
+version: 0.0.5
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/incubator/plexanisync/templates/_secret.tpl
+++ b/charts/incubator/plexanisync/templates/_secret.tpl
@@ -25,7 +25,7 @@ metadata:
 stringData:
   settings.ini: |
     [PLEX]
-    anime_section = {{ join "|" $pas.plex_section }}
+    anime_section = {{ join "|" $pas.plex.plex_section }}
 
     authentication_method = {{ $pas.plex.plex_auth_method }}
 


### PR DESCRIPTION
**Description**
The plex_sections wasn't referenced correctly in secrets.tpl, so was being ignored

⚒️ Fixes  #7462

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Installed updated chart locally and checked for expected output

**📃 Notes:**


**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
