### PR TITLE
fix(icloudpd): set correct value for china, sync time

### DIFF
--- a/charts/incubator/icloudpd/Chart.yaml
+++ b/charts/incubator/icloudpd/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/incubator/icloudpd
   - https://github.com/Womabre/-TrueNAS-docker-templates
 type: application
-version: 2.0.14
+version: 2.0.15
 annotations:
   truecharts.org/SCALE-support: "true"
   truecharts.org/catagories: |

--- a/charts/incubator/icloudpd/questions.yaml
+++ b/charts/incubator/icloudpd/questions.yaml
@@ -53,7 +53,7 @@ questions:
           description: This is the number of minutes to delay the first synchronization.
           schema:
             type: int
-            default: 86400
+            default: 0
         - variable: notification_days
           label: Notification Days
           description: When your cookie is nearing expiration, this is the number of days in advance it should notify you.

--- a/charts/incubator/icloudpd/values.yaml
+++ b/charts/incubator/icloudpd/values.yaml
@@ -99,7 +99,7 @@ env:
   photo_album: "{{ .Values.icloudpd.photo_album }}"
   convert_heic_to_jpeg: '{{ ternary "True" "False" .Values.icloudpd.convert_heic_to_jpeg }}'
   jpeg_quality: "{{ .Values.icloudpd.jpeg_quality }}"
-  icloud_china: '{{ ternary "True" "False" .Values.icloudpd.icloud_china }}'
+  icloud_china: '{{ ternary "True" "" .Values.icloudpd.icloud_china }}'
   command_line_options: "{{ .Values.icloudpd.command_line_options }}"
   notification_title: "{{ .Values.icloudpd.notification_title }}"
   notification_type: "{{ .Values.icloudpd.notification_type }}"


### PR DESCRIPTION
**Description**

* The sync script will use iCloud China if any value is set for the environment so it needs to be empty [ref](https://github.com/boredazfcuk/docker-icloudpd/blob/3506b434652e58b2c64f1d8915c49b25537425f5/sync-icloud.sh#L12).
* The default value for synchronisation_delay is zero. Also the script will use 60 minutes as the value if it's any value > 60 [ref](https://github.com/boredazfcuk/docker-icloudpd/blob/3506b434652e58b2c64f1d8915c49b25537425f5/sync-icloud.sh#L26)

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

I have a [stripped down catalog](https://github.com/conorbranagan/truecharts-catalog/tree/contrib) which has just this chart with these changes and it is confirmed working. Before this fix it was trying to login to icloud.com.cn.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
