### PR TITLE
fix(cert-manager) fix ACME ClusterIssuer support

### DIFF
--- a/charts/enterprise/cert-manager/Chart.yaml
+++ b/charts/enterprise/cert-manager/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
 dependencies:
   - name: common
     repository: https://library-charts.truecharts.org
-    version: 12.2.19
+    version: 12.2.20
 kubeVersion: ">=1.16.0-0"
 maintainers:
   - email: info@truecharts.org

--- a/charts/enterprise/cert-manager/Chart.yaml
+++ b/charts/enterprise/cert-manager/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/enterprise/cert-manager
   - https://cert-manager.io/
 type: application
-version: 1.0.4
+version: 1.0.5
 annotations:
   truecharts.org/catagories: |
     - core

--- a/charts/enterprise/cert-manager/templates/clusterissuer/_ACME.tpl
+++ b/charts/enterprise/cert-manager/templates/clusterissuer/_ACME.tpl
@@ -1,5 +1,5 @@
 {{- define "certmanager.clusterissuer.acme" -}}
-{{- range .Values.clusterIssuer.acme }}
+{{- range .Values.clusterIssuer.ACME }}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -25,6 +25,7 @@ spec:
             name: {{ .name }}-clusterissuer-secret
             key: cf-api-token
          {{- else if .cfapikey }}
+          apiKeySecretRef:
             name: {{ .name }}-clusterissuer-secret
             key: cf-api-key
          {{ else }}


### PR DESCRIPTION
**Description**
I found a bug in the cert-manger as I worked to use it for myself. The first issue occur with all ACME based Cluster Issuers caused by a variable casing mismatch. The second is related to Cloudflare specifically when an API Key is used rather than a Token.
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I have tested this on my local instance

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
