### PR TITLE
cert-manager: show correct fields for DigitalOcean and RFC2136 Cluster Issuers

### DIFF
--- a/charts/enterprise/cert-manager/CHANGELOG.md
+++ b/charts/enterprise/cert-manager/CHANGELOG.md
@@ -1,0 +1,3 @@
+v1.0.8:
+
+* [7775](https://github.com/truecharts/charts/issues/7775): Show correct values for `cert-manager` when DigitalOcean or RFC2136 are selected

--- a/charts/enterprise/cert-manager/CHANGELOG.md
+++ b/charts/enterprise/cert-manager/CHANGELOG.md
@@ -1,3 +1,0 @@
-v1.0.8:
-
-* [7775](https://github.com/truecharts/charts/issues/7775): Show correct values for `cert-manager` when DigitalOcean or RFC2136 are selected

--- a/charts/enterprise/cert-manager/Chart.yaml
+++ b/charts/enterprise/cert-manager/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/enterprise/cert-manager
   - https://cert-manager.io/
 type: application
-version: 1.0.7
+version: 1.0.8
 annotations:
   truecharts.org/catagories: |
     - core

--- a/charts/enterprise/cert-manager/questions.yaml
+++ b/charts/enterprise/cert-manager/questions.yaml
@@ -1,6 +1,6 @@
 # Include{groups}
 questions:
-# Include{global}
+  # Include{global}
   - variable: clusterIssuer
     group: App Configuration
     label: Cluster Certificate Issuer
@@ -9,13 +9,13 @@ questions:
       type: dict
       attrs:
         - variable: ACME
-          label: 'ACME Issuer'
+          label: "ACME Issuer"
           schema:
             type: list
             default: []
             items:
               - variable: ACMEEntry
-                label: 'ACME Issuer Entry'
+                label: "ACME Issuer Entry"
                 schema:
                   additional_attrs: true
                   type: dict
@@ -52,15 +52,15 @@ questions:
                       schema:
                         type: string
                         show_if: [["type", "!=", "HTTP01"]]
-                        default: 'Letsencrypt-Production'
+                        default: "Letsencrypt-Production"
                         enum:
-                          - value: 'https://acme-v02.api.letsencrypt.org/directory'
+                          - value: "https://acme-v02.api.letsencrypt.org/directory"
                             description: Letsencrypt-Production
-                          - value: 'https://acme-staging-v02.api.letsencrypt.org/directory'
+                          - value: "https://acme-staging-v02.api.letsencrypt.org/directory"
                             description: Letsencrypt-Staging
-                          - value: 'https://api.buypass.no/acme-v02/directory'
+                          - value: "https://api.buypass.no/acme-v02/directory"
                             description: BuyPass-Production
-                          - value: 'https://api.test4.buypass.no/acme-v02/directory'
+                          - value: "https://api.test4.buypass.no/acme-v02/directory"
                             description: BuyPass-Staging
                           - value: custom
                             description: Custom
@@ -70,7 +70,7 @@ questions:
                       schema:
                         type: string
                         show_if: [["server", "=", "custom"]]
-                        default: 'https://acme-staging-v02.api.letsencrypt.org/directory'
+                        default: "https://acme-staging-v02.api.letsencrypt.org/directory"
                     - variable: email
                       label: Email
                       description: "Email adress to use for certificate issuing must match your DNS provider email when required"
@@ -168,7 +168,7 @@ questions:
                       label: rfc2136 Namesever
                       description: "rfc2136 Namesever"
                       schema:
-                        show_if: [["type", "=", "digitalocean"]]
+                        show_if: [["type", "=", "rfc2136"]]
                         type: string
                         required: true
                         default: ""
@@ -176,7 +176,7 @@ questions:
                       label: rfc2136 tsig Key Name
                       description: "rfc2136 tsig Key Name"
                       schema:
-                        show_if: [["type", "=", "digitalocean"]]
+                        show_if: [["type", "=", "rfc2136"]]
                         type: string
                         required: true
                         default: ""
@@ -184,7 +184,7 @@ questions:
                       label: rfc2136 tsig Algorithm
                       description: "rfc2136 tsig Algorithm"
                       schema:
-                        show_if: [["type", "=", "digitalocean"]]
+                        show_if: [["type", "=", "rfc2136"]]
                         type: string
                         required: true
                         default: ""
@@ -192,7 +192,7 @@ questions:
                       label: rfc2136 sig Secret
                       description: "rfc2136 sig Secret"
                       schema:
-                        show_if: [["type", "=", "digitalocean"]]
+                        show_if: [["type", "=", "rfc2136"]]
                         type: string
                         required: true
                         default: ""
@@ -204,7 +204,7 @@ questions:
             default: []
             items:
               - variable: CAEntry
-                label: 'CA Issuer Entry'
+                label: "CA Issuer Entry"
                 schema:
                   additional_attrs: true
                   type: dict
@@ -248,7 +248,7 @@ questions:
                         default: ""
 
         - variable: selfSigned
-          label: 'SelfSigned Issuer'
+          label: "SelfSigned Issuer"
           schema:
             additional_attrs: true
             type: dict

--- a/charts/enterprise/cert-manager/questions.yaml
+++ b/charts/enterprise/cert-manager/questions.yaml
@@ -1,6 +1,6 @@
 # Include{groups}
 questions:
-  # Include{global}
+# Include{global}
   - variable: clusterIssuer
     group: App Configuration
     label: Cluster Certificate Issuer
@@ -9,13 +9,13 @@ questions:
       type: dict
       attrs:
         - variable: ACME
-          label: "ACME Issuer"
+          label: 'ACME Issuer'
           schema:
             type: list
             default: []
             items:
               - variable: ACMEEntry
-                label: "ACME Issuer Entry"
+                label: 'ACME Issuer Entry'
                 schema:
                   additional_attrs: true
                   type: dict
@@ -52,15 +52,15 @@ questions:
                       schema:
                         type: string
                         show_if: [["type", "!=", "HTTP01"]]
-                        default: "Letsencrypt-Production"
+                        default: 'Letsencrypt-Production'
                         enum:
-                          - value: "https://acme-v02.api.letsencrypt.org/directory"
+                          - value: 'https://acme-v02.api.letsencrypt.org/directory'
                             description: Letsencrypt-Production
-                          - value: "https://acme-staging-v02.api.letsencrypt.org/directory"
+                          - value: 'https://acme-staging-v02.api.letsencrypt.org/directory'
                             description: Letsencrypt-Staging
-                          - value: "https://api.buypass.no/acme-v02/directory"
+                          - value: 'https://api.buypass.no/acme-v02/directory'
                             description: BuyPass-Production
-                          - value: "https://api.test4.buypass.no/acme-v02/directory"
+                          - value: 'https://api.test4.buypass.no/acme-v02/directory'
                             description: BuyPass-Staging
                           - value: custom
                             description: Custom
@@ -70,7 +70,7 @@ questions:
                       schema:
                         type: string
                         show_if: [["server", "=", "custom"]]
-                        default: "https://acme-staging-v02.api.letsencrypt.org/directory"
+                        default: 'https://acme-staging-v02.api.letsencrypt.org/directory'
                     - variable: email
                       label: Email
                       description: "Email adress to use for certificate issuing must match your DNS provider email when required"
@@ -204,7 +204,7 @@ questions:
             default: []
             items:
               - variable: CAEntry
-                label: "CA Issuer Entry"
+                label: 'CA Issuer Entry'
                 schema:
                   additional_attrs: true
                   type: dict
@@ -248,7 +248,7 @@ questions:
                         default: ""
 
         - variable: selfSigned
-          label: "SelfSigned Issuer"
+          label: 'SelfSigned Issuer'
           schema:
             additional_attrs: true
             type: dict


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #7775

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Locally edited `questions.yaml` on a TrueNAS SCALE 22.12.1 system and verified that during installation the correct fields were shown for each option

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
