### PR TITLE
fix(valheim): Updating chart to use latest valheim-server image

### DIFF
--- a/charts/stable/valheim/Chart.yaml
+++ b/charts/stable/valheim/Chart.yaml
@@ -18,7 +18,7 @@ name: valheim
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/valheim
   - https://github.com/lloesche/valheim-server-docker
-version: 5.0.14
+version: 5.0.15
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/valheim/values.yaml
+++ b/charts/stable/valheim/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: tccr.io/truecharts/valheim-server
-  tag: latest@sha256:bc9b41516c963c953bed2d76c3ef74c3d7e8ac4d6b69f3ef860ec0f3e1767e8d
+  tag: latest@sha256:a582f3d4fa6c456c6dcc64b9ac74b3f374436240a781c70f0ae1bcbe4b0916f8
   pullPolicy: IfNotPresent
 
 secretEnv:


### PR DESCRIPTION
**Description**
Following merge of https://github.com/truecharts/containers/pull/20780 as per my understanding this needs to be updated in order to get the latest image deployed as part of next release.

Digest value taken from https://github.com/truecharts/containers/pkgs/container/valheim-server

⚒️ Fixes  #7855

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
