### PR TITLE
fix(unpoller): do not use /metrics for probes

### DIFF
--- a/charts/stable/unpoller/Chart.yaml
+++ b/charts/stable/unpoller/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/unpoller
   - https://github.com/unifi-poller/unifi-poller
 type: application
-version: 6.0.4
+version: 6.0.5
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/stable/unpoller/values.yaml
+++ b/charts/stable/unpoller/values.yaml
@@ -28,11 +28,11 @@ workload:
         main:
           probes:
             liveness:
-              path: /metrics
+              path: /
             readiness:
-              path: /metrics
+              path: /
             startup:
-              path: /metrics
+              path: /
           env:
             # UP_UNIFI_DEFAULT_URL: "https://127.0.0.1:8443"
             # UP_UNIFI_DEFAULT_USER: "unifipoller"


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Using /metrics for probes causes metrics to be scraped. This makes probes unnecessarily expensive and leads to more scrapes than expected against the Unifi controller (especially if the Prometheus scrape interval is significantly less than the liveness probe interval).

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Run `helm template . --debug` and check the probes path is `/`.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
