### PR TITLE
fix(speedtest-exporter): set scrape interval to 1h

### DIFF
--- a/charts/stable/speedtest-exporter/Chart.yaml
+++ b/charts/stable/speedtest-exporter/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/speedtest-exporter
   - https://github.com/MiguelNdeCarvalho/speedtest-exporter/
 type: application
-version: 6.0.4
+version: 6.0.5
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/stable/speedtest-exporter/values.yaml
+++ b/charts/stable/speedtest-exporter/values.yaml
@@ -17,6 +17,7 @@ metrics:
     endpoints:
       - port: main
         path: /metrics
+        interval: 1h
     prometheusRule:
       enabled: false
 
@@ -26,14 +27,3 @@ portal:
 securityContext:
   container:
     readOnlyRootFilesystem: false
-workload:
-  main:
-    podSpec:
-      main:
-        probes:
-          liveness:
-            path: /metrics
-          readiness:
-            path: /metrics
-          startup:
-            path: /metrics


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Using the default value global Prometheus scrape interval of 15s causes excessive bandwidth use.

Also remove old ineffective/dead probe path fragment. Using `/metrics` is a bad idea anyways since every probe would trigger a speed test.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

`helm template . --debug` and check the `ServiceMonitor` resource. I also applied the change live in my cluster and observed the reduced frequency. I also checked the Prom web UI under `/service-discovery` for the new scrape interval.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
