### PR TITLE
fix(portainer) portainer requires automountServiceAccountToken true

### DIFF
--- a/charts/stable/portainer/Chart.yaml
+++ b/charts/stable/portainer/Chart.yaml
@@ -19,7 +19,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/portainer
   - https://docs.portainer.io/start/install-ce/server
   - https://docs.portainer.io/start/install/server
-version: 4.0.2
+version: 4.0.3
 annotations:
   truecharts.org/catagories: |
     - management

--- a/charts/stable/portainer/values.yaml
+++ b/charts/stable/portainer/values.yaml
@@ -63,6 +63,7 @@ portal:
 workload:
   main:
     podSpec:
+      automountServiceAccountToken: true
       containers:
         main:
           imageSelector: image


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Set `automountServiceAccountToken: true` for portainer's main pod.

Without this, the token is not projected into the container and portainer fails to connect to the local cluster.

```
error.go:34 > HTTP error | error="open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory" msg="Unable to initiate communications with environment" status_code=500
```

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Run `helm template --namespace=ix-portainer .` in the chart and verify that the output contains `automountServiceAccountToken: true` in the `Deployment` object's `spec.template.spec`.

Mutated an existing portainer app's `Deployment` object with kubectl to add `automountServiceAccountToken: true` and verified it could then connect to the local cluster.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
