### PR TITLE
feat(apps): Add podOptions in questions.yaml

### DIFF
--- a/charts/stable/home-assistant/Chart.yaml
+++ b/charts/stable/home-assistant/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/home-assistant/home-assistant
   - https://github.com/cdr/code-server
 type: application
-version: 19.0.14
+version: 19.0.15
 annotations:
   truecharts.org/catagories: |
     - home-automation

--- a/charts/stable/home-assistant/questions.yaml
+++ b/charts/stable/home-assistant/questions.yaml
@@ -16,6 +16,7 @@ questions:
 # Include{containerAdvanced}
 
 # Include{containerConfig}
+# Include{podOptions}
 # Include{serviceRoot}
 # Include{serviceMain}
 # Include{serviceSelectorLoadBalancer}

--- a/charts/stable/omada-controller/Chart.yaml
+++ b/charts/stable/omada-controller/Chart.yaml
@@ -18,7 +18,7 @@ name: omada-controller
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/omada-controller
   - https://github.com/mbentley/docker-omada-controller
-version: 9.0.14
+version: 9.0.15
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/omada-controller/questions.yaml
+++ b/charts/stable/omada-controller/questions.yaml
@@ -16,6 +16,7 @@ questions:
 # Include{containerAdvanced}
 
 # Include{containerConfig}
+# Include{podOptions}
 # Include{serviceRoot}
 # Include{serviceMain}
 # Include{serviceSelectorLoadBalancer}

--- a/charts/stable/zerotier/Chart.yaml
+++ b/charts/stable/zerotier/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: zerotier
-version: 5.0.10
+version: 5.0.11
 appVersion: "1.10.6"
 description: ZeroTier is a smart programmable Ethernet switch for planet Earth
 type: application

--- a/charts/stable/zerotier/questions.yaml
+++ b/charts/stable/zerotier/questions.yaml
@@ -41,6 +41,7 @@ questions:
 # Include{containerBasic}
 # Include{containerAdvanced}
 # Include{containerConfig}
+# Include{podOptions}
 # Include{serviceRoot}
         - variable: main
           label: "Main Service"


### PR DESCRIPTION
**Description**

Properly add Global Pod Options to a couple of charts that were requested since I think anything in the initial common PR doesn't have it in questions.yaml and I can't automate this 

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
