### PR TITLE
feat(custom-app) Enable Options for Configuring Portal & bump app version

### DIFF
--- a/charts/stable/custom-app/Chart.yaml
+++ b/charts/stable/custom-app/Chart.yaml
@@ -19,7 +19,7 @@ name: custom-app
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/custom-app
 type: application
-version: 8.0.7
+version: 8.0.8
 annotations:
   truecharts.org/catagories: |
     - custom

--- a/charts/stable/custom-app/questions.yaml
+++ b/charts/stable/custom-app/questions.yaml
@@ -154,6 +154,65 @@ questions:
                                                     schema:
                                                       type: string
                                                       default: "/"
+  - variable: portal
+    group: "General Settings"
+    label: "Portal Configuration"
+    schema:
+      type: dict
+      additional_attrs: true
+      attrs:
+        - variable: open
+          label: "Open"
+          schema:
+            type: dict
+            additional_attrs: true
+            attrs:
+              - variable: enabled
+                label: "Enable WebUI Portal"
+                description: "Enable WebUI Portal"
+                schema:
+                  type: boolean
+                  default: true
+              - variable: overrides
+                label: "Override Portal Configuration"
+                description: "Override Portal Configuration"
+                schema:
+                  type: boolean
+                  default: false
+                  show_if: [["enabled", "=", true]]
+                  show_subquestions_if: true
+                  subquestions:
+                    - variable: override
+                      label: "Override Portal Configuration"
+                      description: "Override Portal Configuration"
+                      schema:
+                        type: dict
+                        additional_attrs: true
+                        attrs:
+                          - variable: protocol
+                            label: "Protocol"
+                            description: "Portal Protocol Override"
+                            schema:
+                              type: string
+                              enum:
+                                - value: ""
+                                  description: ""
+                                - value: "http"
+                                  description: "HTTP"
+                                - value: "https"
+                                  description: "HTTPS"
+                          - variable: host
+                            label: "Host"
+                            description: "Portal Host Override"
+                            schema:
+                              type: string
+                              default: ""
+                          - variable: port
+                            label: "Port"
+                            description: "Portal Port Override"
+                            schema:
+                              type: string
+                              default: ""
 # Include{containerConfig}
 # Include{podOptions}
 # Include{serviceRoot}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Adds support to custom-app to enable/disable the web portal as well as configure override settings for the port/host/protocol.

⚒️ Fixes  # <!--(issue)--> #8793

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
I copied my updated section of questions.yaml into the questions.yaml in my personal catalog and installed various scenarios of enabling/disabling and overriding parameters.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
