### PR TITLE
fix(mongo-express): Remove required db name

### DIFF
--- a/charts/incubator/mongo-express/Chart.yaml
+++ b/charts/incubator/mongo-express/Chart.yaml
@@ -26,7 +26,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/incubator/mongo-express
   - https://github.com/mongo-express/mongo-express
 type: application
-version: 0.0.4
+version: 0.0.5
 annotations:
   truecharts.org/catagories: |
     - database

--- a/charts/incubator/mongo-express/questions.yaml
+++ b/charts/incubator/mongo-express/questions.yaml
@@ -49,8 +49,7 @@ questions:
                                         description: Database name
                                         schema:
                                           type: string
-                                          required: true
-                                          default: mongo-express
+                                          default: ""
                                       - variable: ME_CONFIG_MONGODB_AUTH_USERNAME
                                         label: MongoDB Database username
                                         description: Database username


### PR DESCRIPTION
**Description**

We don't need to specify a DB name, just the username/password, if using root, so removing the required. Last test before Stable

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
