### PR TITLE
fix(prometheus): readd node-exporter and kube-state-metrics support

### DIFF
--- a/charts/enterprise/prometheus/Chart.yaml
+++ b/charts/enterprise/prometheus/Chart.yaml
@@ -6,11 +6,11 @@ dependencies:
     version: 12.8.1
   - condition: exporters.enabled,exporters.node-exporter.enabled
     name: node-exporter
-    repository: https://charts.truecharts.org
+    repository: https://deps.truecharts.org
     version: 1.0.1
   - condition: exporters.enabled,exporters.kube-state-metrics.enabled
     name: kube-state-metrics
-    repository: https://charts.truecharts.org
+    repository: https://deps.truecharts.org
     version: 1.0.0
 deprecated: false
 description: kube-prometheus-stack collects Kubernetes manifests, Grafana dashboards, and Prometheus rules combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.

--- a/charts/enterprise/prometheus/Chart.yaml
+++ b/charts/enterprise/prometheus/Chart.yaml
@@ -29,7 +29,7 @@ sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
 type: application
-version: 9.0.3
+version: 9.0.4
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/enterprise/prometheus/Chart.yaml
+++ b/charts/enterprise/prometheus/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
   - condition: exporters.enabled,exporters.node-exporter.enabled
     name: node-exporter
     repository: https://charts.truecharts.org
-    version: 1.0.0
+    version: 1.0.1
   - condition: exporters.enabled,exporters.kube-state-metrics.enabled
     name: kube-state-metrics
     repository: https://charts.truecharts.org

--- a/charts/enterprise/prometheus/Chart.yaml
+++ b/charts/enterprise/prometheus/Chart.yaml
@@ -4,6 +4,14 @@ dependencies:
   - name: common
     repository: https://library-charts.truecharts.org
     version: 12.8.1
+  - condition: exporters.enabled,exporters.node-exporter.enabled
+    name: node-exporter
+    repository: https://charts.truecharts.org
+    version: 1.0.0
+  - condition: exporters.enabled,exporters.kube-state-metrics.enabled
+    name: kube-state-metrics
+    repository: https://charts.truecharts.org
+    version: 1.0.0
 deprecated: false
 description: kube-prometheus-stack collects Kubernetes manifests, Grafana dashboards, and Prometheus rules combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
 icon: https://truecharts.org/img/hotlink-ok/chart-icons/prometheus.png

--- a/charts/enterprise/prometheus/questions.yaml
+++ b/charts/enterprise/prometheus/questions.yaml
@@ -153,7 +153,6 @@ questions:
                               default: 10087
                               required: true
 # Include{serviceExpertRoot}
-            default: false
 # Include{serviceExpert}
 # Include{serviceList}
 # Include{persistenceList}

--- a/charts/enterprise/prometheus/questions.yaml
+++ b/charts/enterprise/prometheus/questions.yaml
@@ -23,6 +23,7 @@ questions:
                 schema:
                   type: string
                   default: "info"
+
   - variable: prometheus
     group: "App Configuration"
     label: "Prometheus Settings"
@@ -79,6 +80,37 @@ questions:
                 schema:
                   type: boolean
                   default: false
+
+  - variable: exporters
+    group: "App Configuration"
+    label: "Exporter Settings"
+    schema:
+      additional_attrs: true
+      type: dict
+      attrs:
+        - variable: node-exporter
+          label: "node-exporter"
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+              - variable: enabled
+                label: "Enable"
+                schema:
+                  type: boolean
+                  default: true
+        - variable: kube-state-metrics
+          label: "Kube-State-Metrics"
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+              - variable: enabled
+                label: "Enable"
+                schema:
+                  type: boolean
+                  default: true
+
   - variable: alertmanager
     group: "App Configuration"
     label: "Alertmanager Settings"

--- a/charts/enterprise/prometheus/questions.yaml
+++ b/charts/enterprise/prometheus/questions.yaml
@@ -81,36 +81,6 @@ questions:
                   type: boolean
                   default: false
 
-  - variable: exporters
-    group: "App Configuration"
-    label: "Exporter Settings"
-    schema:
-      additional_attrs: true
-      type: dict
-      attrs:
-        - variable: node-exporter
-          label: "node-exporter"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-              - variable: enabled
-                label: "Enable"
-                schema:
-                  type: boolean
-                  default: true
-        - variable: kube-state-metrics
-          label: "Kube-State-Metrics"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-              - variable: enabled
-                label: "Enable"
-                schema:
-                  type: boolean
-                  default: true
-
   - variable: alertmanager
     group: "App Configuration"
     label: "Alertmanager Settings"

--- a/charts/enterprise/prometheus/questions.yaml
+++ b/charts/enterprise/prometheus/questions.yaml
@@ -81,6 +81,36 @@ questions:
                   type: boolean
                   default: false
 
+  - variable: exporters
+    group: "App Configuration"
+    label: "Exporter Settings"
+    schema:
+      additional_attrs: true
+      type: dict
+      attrs:
+        - variable: node-exporter
+          label: "node-exporter"
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+              - variable: enabled
+                label: "Enable"
+                schema:
+                  type: boolean
+                  default: true
+        - variable: kube-state-metrics
+          label: "Kube-State-Metrics"
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+              - variable: enabled
+                label: "Enable"
+                schema:
+                  type: boolean
+                  default: true
+
   - variable: alertmanager
     group: "App Configuration"
     label: "Alertmanager Settings"

--- a/charts/enterprise/prometheus/values.yaml
+++ b/charts/enterprise/prometheus/values.yaml
@@ -1129,37 +1129,14 @@ exporters:
     ## @param exporters.kube-state-metrics.enabled Enable kube-state-metrics
     ##
     enabled: true
-## @param node-exporter [object] Node Exporter deployment configuration
-##
-node-exporter:
-  service:
-    port: 9910
-    targetPort: 9910
-    labels:
-      jobLabel: node-exporter
-  serviceMonitor:
-    enabled: true
-    jobLabel: jobLabel
-  extraArgs:
-    collector.filesystem.ignored-mount-points: "^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+|var/db/system/.+|mnt/[a-zA-Z0-9-_\\.]+/ix-applications/.+)($|/)"
-    collector.filesystem.ignored-fs-types: "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
-    collector.netdev.device-exclude: "^veth.*$"
-    collector.netclass.ignored-devices: "^veth.*$"
-    path.rootfs: /host
-  extraVolumes:
-    - name: host
-      hostPath:
-        path: /
-  extraVolumeMounts:
-    - name: host
-      mountPath: /host
-      readOnly: true
+
 ## @param kube-state-metrics [object] Node Exporter deployment configuration
 ##
 kube-state-metrics:
   serviceMonitor:
     enabled: true
     honorLabels: true
+
 ## Component scraping for kubelet and kubelet hosted cAdvisor
 ##
 kubelet:


### PR DESCRIPTION
**Description**
Readds both node-exporter and kube-state-metrics.
Also adds the GUI option in SCALE to disable them, in case users want to run those as seperate charts/apps.

Basically undoes the breakingchange from last time, so users can now safely update.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
