### PR TITLE
refactor(traefik): BREAKING CHANGE move traefik to new CRD's and move config to tc-system

### DIFF
--- a/charts/enterprise/traefik/Chart.yaml
+++ b/charts/enterprise/traefik/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "2.9.10"
 dependencies:
   - name: common
     repository: https://library-charts.truecharts.org
-    version: 12.9.2
+    version: 12.9.5
 deprecated: false
 description: Traefik is a flexible reverse proxy and Ingress Provider.
 home: https://truecharts.org/charts/enterprise/traefik
@@ -23,7 +23,7 @@ sources:
   - https://github.com/traefik/traefik-helm-chart
   - https://traefik.io/
 type: application
-version: 17.0.39
+version: 18.0.0
 annotations:
   truecharts.org/catagories: |
     - network

--- a/charts/enterprise/traefik/templates/_portalhook.tpl
+++ b/charts/enterprise/traefik/templates/_portalhook.tpl
@@ -1,17 +1,13 @@
 {{/* Define the portalHook */}}
 {{- define "traefik.portalhook" -}}
 {{- if .Values.portalhook.enabled }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
 ---
 
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: portalhook
-  namespace: {{ $namespace }}
+  name: portalhook{{ if .Values.ingressClass.enabled }}-{{ .Release.Name }}{{ end }}
+  namespace: tc-system
 data:
   {{- $ports := dict }}
   {{- range $.Values.service }}

--- a/charts/enterprise/traefik/templates/_tlsoptions.tpl
+++ b/charts/enterprise/traefik/templates/_tlsoptions.tpl
@@ -2,7 +2,7 @@
 {{- define "traefik.tlsOptions" -}}
 {{- range $name, $config := .Values.tlsOptions }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: TLSOption
 metadata:
   name: {{ $name }}

--- a/charts/enterprise/traefik/templates/middlewares/addPrefix.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/addPrefix.yaml
@@ -1,16 +1,13 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 {{- range $index, $middlewareData := .Values.middlewares.addPrefix }}
 
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $middlewareData.name }}
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ $middlewareData.name }}
+  namespace: tc-system
 spec:
   addPrefix:
     prefix: {{ $middlewareData.prefix }}

--- a/charts/enterprise/traefik/templates/middlewares/basic-middleware.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/basic-middleware.yaml
@@ -1,34 +1,31 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: compress
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}compress
+  namespace: tc-system
 spec:
   compress: {}
 ---
 # Here, an average of 300 requests per second is allowed.
 # In addition, a burst of 200 requests is allowed.
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: basic-ratelimit
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}basic-ratelimit
+  namespace: tc-system
 spec:
   rateLimit:
     average: 600
     burst: 400
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: basic-secure-headers
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}basic-secure-headers
+  namespace: tc-system
 spec:
   headers:
     accessControlAllowMethods:
@@ -49,14 +46,14 @@ spec:
     customResponseHeaders:
       server: ''
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: chain-basic
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}chain-basic
+  namespace: tc-system
 spec:
   chain:
     middlewares:
-    - name: basic-ratelimit
-    - name: basic-secure-headers
-    - name: compress
+    - name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}basic-ratelimit
+    - name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}basic-secure-headers
+    - name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}compress

--- a/charts/enterprise/traefik/templates/middlewares/basicauth.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/basicauth.yaml
@@ -1,8 +1,5 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 {{ range $index, $middlewareData := .Values.middlewares.basicAuth }}
 ---
 {{- $users := list }}
@@ -14,7 +11,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{printf "%v-%v" $middlewareData.name "secret" }}
-  namespace: {{ $namespace }}
+  namespace: tc-system
 type: Opaque
 stringData:
   users: |
@@ -23,11 +20,11 @@ stringData:
     {{- end }}
 ---
 # Declaring the user list
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $middlewareData.name }}
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ $middlewareData.name }}
+  namespace: tc-system
 spec:
   basicAuth:
     secret: {{printf "%v-%v" $middlewareData.name "secret" }}

--- a/charts/enterprise/traefik/templates/middlewares/chain.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/chain.yaml
@@ -1,17 +1,17 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
+{{- $namespace := "tc-system" }}
+{{- if .Values.ingressClass.enabled }}
+{{- $namespace := ( printf "tc-system-%s" .Release.Name ) }}
 {{- end }}
 {{ range $index, $middlewareData := .Values.middlewares.chain }}
 
 ---
 # Declaring the user list
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $middlewareData.name }}
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ $middlewareData.name }}
+  namespace: tc-system
 spec:
   chain:
     middlewares:

--- a/charts/enterprise/traefik/templates/middlewares/forwardauth.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/forwardauth.yaml
@@ -1,15 +1,12 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 {{ range $index, $middlewareData := .Values.middlewares.forwardAuth }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $middlewareData.name }}
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ $middlewareData.name }}
+  namespace: tc-system
 spec:
   forwardAuth:
     address: {{ $middlewareData.address }}

--- a/charts/enterprise/traefik/templates/middlewares/geoblock.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/geoblock.yaml
@@ -1,16 +1,13 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 {{- range $index, $middlewareData := .Values.middlewares.geoBlock }}
 
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $middlewareData.name }}
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ $middlewareData.name }}
+  namespace: tc-system
 spec:
   plugin:
     GeoBlock:

--- a/charts/enterprise/traefik/templates/middlewares/ipwhitelist.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/ipwhitelist.yaml
@@ -1,17 +1,14 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 {{ range $index, $middlewareData := .Values.middlewares.ipWhiteList }}
 
 ---
 # Declaring the user list
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $middlewareData.name }}
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ $middlewareData.name }}
+  namespace: tc-system
 spec:
   ipWhiteList:
     sourceRange:

--- a/charts/enterprise/traefik/templates/middlewares/ratelimit.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/ratelimit.yaml
@@ -1,17 +1,14 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 {{ range $index, $middlewareData := .Values.middlewares.rateLimit }}
 
 ---
 # Declaring the user list
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $middlewareData.name }}
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ $middlewareData.name }}
+  namespace: tc-system
 spec:
   rateLimit:
     average: {{ $middlewareData.average }}

--- a/charts/enterprise/traefik/templates/middlewares/real-ip.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/real-ip.yaml
@@ -1,16 +1,13 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 {{- range $index, $middlewareData := .Values.middlewares.realIP }}
 
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $middlewareData.name }}
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ $middlewareData.name }}
+  namespace: tc-system
 spec:
   plugin:
     traefik-real-ip:

--- a/charts/enterprise/traefik/templates/middlewares/redirectScheme.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/redirectScheme.yaml
@@ -1,17 +1,14 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 {{ range $index, $middlewareData := .Values.middlewares.redirectScheme }}
 
 ---
 # Declaring the user list
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $middlewareData.name }}
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ $middlewareData.name }}
+  namespace: tc-system
 spec:
   redirectScheme:
     scheme: {{ $middlewareData.scheme }}

--- a/charts/enterprise/traefik/templates/middlewares/redirectregex.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/redirectregex.yaml
@@ -1,17 +1,14 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 {{ range $index, $middlewareData := .Values.middlewares.redirectRegex }}
 
 ---
 # Declaring the user list
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $middlewareData.name }}
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ $middlewareData.name }}
+  namespace: tc-system
 spec:
   redirectRegex:
     regex: {{ $middlewareData.regex | quote }}

--- a/charts/enterprise/traefik/templates/middlewares/stripPrefixRegex.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/stripPrefixRegex.yaml
@@ -1,16 +1,13 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 
 {{ range $index, $middlewareData := .Values.middlewares.stripPrefixRegex }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $middlewareData.name }}
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ $middlewareData.name }}
+  namespace: tc-system
 spec:
   stripPrefixRegex:
     regex:

--- a/charts/enterprise/traefik/templates/middlewares/tc-chains.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/tc-chains.yaml
@@ -1,29 +1,26 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: tc-opencors-chain
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}tc-opencors-chain
+  namespace: tc-system
 spec:
   chain:
     middlewares:
-    - name: basic-ratelimit
-    - name: tc-opencors-headers
-    - name: compress
+    - name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}basic-ratelimit
+    - name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}tc-opencors-headers
+    - name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}compress
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: tc-closedcors-chain
-  namespace: {{ $namespace }}
+  namespace: tc-system
 spec:
   chain:
     middlewares:
-    - name: basic-ratelimit
-    - name: tc-closedcors-headers
-    - name: compress
+    - name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}basic-ratelimit
+    - name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}tc-closedcors-headers
+    - name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}compress

--- a/charts/enterprise/traefik/templates/middlewares/tc-headers.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/tc-headers.yaml
@@ -1,14 +1,11 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: tc-opencors-headers
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}tc-opencors-headers
+  namespace: tc-system
 spec:
   headers:
     accessControlAllowHeaders:
@@ -34,11 +31,11 @@ spec:
     sslRedirect: true
     stsSeconds: 63072000
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: tc-closedcors-headers
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}tc-closedcors-headers
+  namespace: tc-system
 spec:
   headers:
     accessControlAllowMethods:

--- a/charts/enterprise/traefik/templates/middlewares/tc-nextcloud.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/tc-nextcloud.yaml
@@ -1,25 +1,22 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: tc-nextcloud-redirectregex-dav
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}tc-nextcloud-redirectregex-dav
+  namespace: tc-system
 spec:
   redirectRegex:
     regex: "https://(.*)/.well-known/(card|cal)dav"
     replacement: "https://${1}/remote.php/dav/"
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: tc-nextcloud-chain
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}tc-nextcloud-chain
+  namespace: tc-system
 spec:
   chain:
     middlewares:
-    - name: tc-nextcloud-redirectregex-dav
+    - name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}tc-nextcloud-redirectregex-dav

--- a/charts/enterprise/traefik/templates/middlewares/theme-park.yaml
+++ b/charts/enterprise/traefik/templates/middlewares/theme-park.yaml
@@ -1,16 +1,13 @@
 {{- $values := .Values }}
-{{- $namespace := ( printf "ix-%s" .Release.Name ) }}
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "default" }}
-{{- end }}
+
 {{- range $index, $middlewareData := .Values.middlewares.themePark }}
 
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: {{ $middlewareData.name }}
-  namespace: {{ $namespace }}
+  name: {{ if .Values.ingressClass.enabled }}{{ .Release.Name }}-{{ end }}{{ $middlewareData.name }}
+  namespace: tc-system
 spec:
   plugin:
     traefik-themepark:

--- a/charts/enterprise/traefik/values.yaml
+++ b/charts/enterprise/traefik/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: tccr.io/truecharts/traefik
-  tag: 2.9.10@sha256:53a8cc0ea5d6fb681aa1e39864fbf0d1ecec8fab3547df4a59f68989bdf10925
+  tag: 2.10.1@sha256:b654073e7f5645b74e9d63369f6df473203b8d32d26adc8bfb76a3c5eeb4cb64
   pullPolicy: IfNotPresent
 manifestManager:
   enabled: true
@@ -291,8 +291,8 @@ rbac:
         verbs:
           - update
       - apiGroups:
-          - traefik.io
           - traefik.containo.us
+          - traefik.io
         resources:
           - middlewares
           - middlewaretcps
@@ -414,5 +414,3 @@ portal:
   open:
     enabled: true
     path: /dashboard/
-    override:
-      protocol: http


### PR DESCRIPTION
**Description**
Traefik couldn't be updated due to CRD namespace chagnes.
This PR changes the CRD namespace to `traefik.io` as required, so we can actually update traefik.

Besides this, it moves the portalhook from either `default` or `tc-*ingressclassname*`
to `tc-system` (our project config storage namespace). In case of ingressclass use, `portalhook` will get a suffix instead

the reason behind this is, is the fact non-SCALE users currently cannot use ingressclass at all and neither can platforms without a `default` namespace.

This will require all apps to be updated accordingly, as the name and location of the middleware also changes to `tc-system`, including a suffix with the ingressClass name where needed.

This move of portalhook, also allows us to fix the "loadbalancer port suffixed to ingress" bug on SCALE portal button.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
To be clear: IngressClass is still not 100% supported.
But that doesn't mean we should make it inherently problematic.

The "Breaking" portion of this PR, is just the fact all charts/apps have to be updated accordingly or otherwise would not function with ingress anymore. It does not require manual intervention byond updating, hoever.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
