### PR TITLE
fix(oscam): fix oscam probes

### DIFF
--- a/charts/stable/oscam/Chart.yaml
+++ b/charts/stable/oscam/Chart.yaml
@@ -20,7 +20,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/oscam
   - https://trac.streamboard.tv/oscam/browser/trunk
 type: application
-version: 9.0.16
+version: 9.0.17
 annotations:
   truecharts.org/catagories: |
     - DIY

--- a/charts/stable/oscam/values.yaml
+++ b/charts/stable/oscam/values.yaml
@@ -22,3 +22,30 @@ securityContext:
     runAsNonRoot: false
     runAsUser: 0
     runAsGroup: 20
+workload:
+  main:
+    podSpec:
+      containers:
+        main:
+          probes:
+            readiness:
+              enabled: true
+              type: exec
+              command:
+                - /bin/sh
+                - -c
+                - ps -aux | grep -v grep | grep oscam
+            liveness:
+              enabled: true
+              type: exec
+              command:
+                - /bin/sh
+                - -c
+                - ps -aux | grep -v grep | grep oscam
+            startup:
+              enabled: true
+              type: exec
+              command:
+                - /bin/sh
+                - -c
+                - ps -aux | grep -v grep | grep oscam


### PR DESCRIPTION
**Description**
Default HTTP probes are not failsafe, as the cluster IP range (which is usually something like 172.16.0.0/16) is not part of the list: ```httpallowed = 127.0.0.1,192.168.0.0-192.168.255.255,10.0.0.0-10.255.255.255,255.255.255.255``` provided by oscam image.

The result is: ```Startup probe failed: HTTP probe failed with statuscode: 403``` when installing OSCAM without any config changes.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Edited ix_values.yaml in ix-applications folder

**📃 Notes:**
Since ```curl``` is not available, I decided to use ```ps``` instead

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
