### PR TITLE
fix(sshwifty) remove a variable to allow env to work

### DIFF
--- a/charts/incubator/sshwifty/Chart.yaml
+++ b/charts/incubator/sshwifty/Chart.yaml
@@ -20,7 +20,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/incubator/sshwifty
   - https://github.com/niruix/sshwifty
 type: application
-version: 0.0.8
+version: 0.0.9
 annotations:
   truecharts.org/catagories: |
     - ssh

--- a/charts/incubator/sshwifty/questions.yaml
+++ b/charts/incubator/sshwifty/questions.yaml
@@ -103,12 +103,6 @@ questions:
                                         schema:
                                           type: int
                                           default: 10
-                                      - variable: SSHWIFTY_ONLYALLOWPRESETREMOTES
-                                        label: Only Allow Preset Remotes
-                                        description: Allow the Preset Remotes only, and refuse to connect to any other remote host.
-                                        schema:
-                                          type: boolean
-                                          default: false
 
 # Include{containerBasic}
 # Include{containerAdvanced}

--- a/charts/incubator/sshwifty/values.yaml
+++ b/charts/incubator/sshwifty/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: tccr.io/truecharts/sshwifty
   pullPolicy: IfNotPresent
-  tag: latest@sha256:3f4f3c44825a1bf3b1320194077b9e1fda44b5ad30f9070c4db2a638512bbf10
+  tag: vlatest@sha256:6e3b1db5e973f4177039fcca867f4a799ad71a691a9912a1110c1ded7165266e
 
 securityContext:
   container:
@@ -42,7 +42,8 @@ workload:
             # SSHWIFTY_TLSCERTIFICATEFILE: ""
             # SSHWIFTY_TLSCERTIFICATEKEYFILE: ""
             # SSHWIFTY_PRESETS: [] json obj array https://github.com/nirui/sshwifty#configuration-file | preset section.
-            SSHWIFTY_ONLYALLOWPRESETREMOTES: false
+            # Can not set this variable, only functional via config file.
+            # SSHWIFTY_ONLYALLOWPRESETREMOTES:
 
 service:
   main:


### PR DESCRIPTION
**Description**

removing the SSHWIFTY_ONLYALLOWPRESETREMOTES  variable allows the app to work in a stateless mode.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
