### PR TITLE
Changes default blocklist in the Transmission chart to a working one

### DIFF
--- a/charts/stable/transmission/Chart.yaml
+++ b/charts/stable/transmission/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/transmission
   - https://github.com/transmission/transmission
 type: application
-version: 16.0.20
+version: 16.0.21
 annotations:
   truecharts.org/catagories: |
     - download-tools

--- a/charts/stable/transmission/questions.yaml
+++ b/charts/stable/transmission/questions.yaml
@@ -84,7 +84,7 @@ questions:
                                         label: TRANSMISSION_BLOCKLIST_URL
                                         schema:
                                           type: string
-                                          default: "http://john.bitsurge.net/public/biglist.p2p.gz"
+                                          default: "https://github.com/Naunter/BT_BlockLists/releases/download/v.1/bt_blocklists.gz"
                                       - variable: TRANSMISSION_CACHE_SIZE_MB
                                         label: TRANSMISSION_CACHE_SIZE_MB
                                         schema:

--- a/charts/stable/transmission/values.yaml
+++ b/charts/stable/transmission/values.yaml
@@ -36,7 +36,7 @@ workload:
             # TRANSMISSION_BIND_ADDRESS_IPV4: "0.0.0.0"
             # TRANSMISSION_BIND_ADDRESS_IPV6: "::"
             # TRANSMISSION_BLOCKLIST_ENABLED: true
-            # TRANSMISSION_BLOCKLIST_URL: "http://john.bitsurge.net/public/biglist.p2p.gz"
+            # TRANSMISSION_BLOCKLIST_URL: "https://github.com/Naunter/BT_BlockLists/releases/download/v.1/bt_blocklists.gz"
             # TRANSMISSION_CACHE_SIZE_MB: 4
             # TRANSMISSION_DHT_ENABLED: true
             # TRANSMISSION_DOWNLOAD_DIR: "/downloads/complete"


### PR DESCRIPTION
**Description**

The john.bitsurge.net blocklist (the suggested default in the Transmission chart) is [no longer hosted at the address mentioned and never will be again](https://gist.github.com/johntyree/3331662?permalink_comment_id=3801748#gistcomment-3801748).  I've swapped it out for https://github.com/Naunter/BT_BlockLists/ , a maintained and seemingly pretty decent alternative?  Like John's it also aggregates a bunch of other lists.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I have not deployed this personally to TrueNas Scale yet, although I do use the blocklist with Transmission on another machine.  It seems to function similarly to John's (except it actually still works).  Given that this is a one-line default variable change to a non-mission-critical variable it should be good to go?  Let me know if it requires a more rigorous test. :)

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning