### PR TITLE
fix(cnpg): use hardcoded and fixed cnpg-webhook-service servicename

### DIFF
--- a/charts/operators/cloudnative-pg/Chart.yaml
+++ b/charts/operators/cloudnative-pg/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
 dependencies:
   - name: common
     repository: https://library-charts.truecharts.org
-    version: 12.12.1
+    version: 12.12.3
 kubeVersion: ">=1.16.0-0"
 maintainers:
   - email: info@truecharts.org
@@ -23,7 +23,7 @@ sources:
   - https://github.com/cloudnative-pg
   - https://cloudnative-pg.io/
 type: application
-version: 0.0.1
+version: 0.0.2
 annotations:
   truecharts.org/catagories: |
     - operators

--- a/charts/operators/cloudnative-pg/templates/_mutatingwebhookconfiguration.tpl
+++ b/charts/operators/cloudnative-pg/templates/_mutatingwebhookconfiguration.tpl
@@ -22,7 +22,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: {{ include "tc.v1.common.lib.chart.names.fullname" $ }}
+      name: cnpg-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /mutate-postgresql-cnpg-io-v1-backup
       port: {{ .Values.service.main.ports.main.port }}
@@ -43,7 +43,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: {{ include "tc.v1.common.lib.chart.names.fullname" $ }}
+      name: cnpg-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /mutate-postgresql-cnpg-io-v1-cluster
       port: {{ .Values.service.main.ports.main.port }}
@@ -64,7 +64,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: {{ include "tc.v1.common.lib.chart.names.fullname" $ }}
+      name: cnpg-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /mutate-postgresql-cnpg-io-v1-scheduledbackup
       port: {{ .Values.service.main.ports.main.port }}

--- a/charts/operators/cloudnative-pg/templates/_validatingwebhookconfiguration.tpl
+++ b/charts/operators/cloudnative-pg/templates/_validatingwebhookconfiguration.tpl
@@ -22,7 +22,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: {{ include "tc.v1.common.lib.chart.names.fullname" $ }}
+      name: cnpg-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /validate-postgresql-cnpg-io-v1-backup
       port: {{ .Values.service.main.ports.main.port }}
@@ -43,7 +43,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: {{ include "tc.v1.common.lib.chart.names.fullname" $ }}
+      name: cnpg-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /validate-postgresql-cnpg-io-v1-cluster
       port: {{ .Values.service.main.ports.main.port }}
@@ -64,7 +64,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: {{ include "tc.v1.common.lib.chart.names.fullname" $ }}
+      name: cnpg-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /validate-postgresql-cnpg-io-v1-scheduledbackup
       port: {{ .Values.service.main.ports.main.port }}
@@ -85,7 +85,7 @@ webhooks:
     - v1
   clientConfig:
     service:
-      name: {{ include "tc.v1.common.lib.chart.names.fullname" $ }}
+      name: cnpg-webhook-service
       namespace: {{ .Release.Namespace }}
       path: /validate-postgresql-cnpg-io-v1-pooler
       port: {{ .Values.service.main.ports.main.port }}

--- a/charts/operators/cloudnative-pg/values.yaml
+++ b/charts/operators/cloudnative-pg/values.yaml
@@ -13,7 +13,7 @@ workload:
             - --leader-elect
             - --config-map-name={{ include "tc.v1.common.lib.chart.names.fullname" $ }}-config
             - --secret-name={{ include "tc.v1.common.lib.chart.names.fullname" $ }}-config
-            - --webhook-port={{ $.Values.service.main.ports.main.targetPort }}
+            - --webhook-port={{ $.Values.service.cnpg-webhook-service.ports.webhook.targetPort }}
           command:
             - /manager
           probes:

--- a/charts/operators/cloudnative-pg/values.yaml
+++ b/charts/operators/cloudnative-pg/values.yaml
@@ -18,13 +18,13 @@ workload:
             - /manager
           probes:
             liveness:
-              port: main
+              port: cnpg-webhook-service
               path: /readyz
             readiness:
-              port: main
+              port: cnpg-webhook-service
               path: /readyz
             startup:
-              port: main
+              port: cnpg-webhook-service
               type: tcp
           env:
             OPERATOR_IMAGE_NAME: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -40,16 +40,17 @@ service:
   main:
     ports:
       main:
+        protocol: http
+        port: 8080
+  cnpg-webhook-service:
+    enabled: true
+    expandObjectName: false
+    ports:
+      cnpg-webhook-service:
+        enabled: true
         protocol: https
         port: 443
         targetPort: 9443
-  metrics:
-    enabled: true
-    ports:
-      metrics:
-        enabled: true
-        protocol: http
-        port: 8080
 
 operator:
   register: true
@@ -81,7 +82,7 @@ metrics:
     enabled: false
     type: "podmonitor"
     endpoints:
-      - port: metrics
+      - port: main
         interval: 5s
         scrapeTimeout: 5s
         path: /

--- a/charts/operators/cloudnative-pg/values.yaml
+++ b/charts/operators/cloudnative-pg/values.yaml
@@ -13,7 +13,7 @@ workload:
             - --leader-elect
             - --config-map-name={{ include "tc.v1.common.lib.chart.names.fullname" $ }}-config
             - --secret-name={{ include "tc.v1.common.lib.chart.names.fullname" $ }}-config
-            - --webhook-port={{ $.Values.service.cnpg-webhook-service.ports.webhook.targetPort }}
+            - --webhook-port=9443
           command:
             - /manager
           probes:

--- a/charts/operators/cloudnative-pg/values.yaml
+++ b/charts/operators/cloudnative-pg/values.yaml
@@ -18,13 +18,13 @@ workload:
             - /manager
           probes:
             liveness:
-              port: cnpg-webhook-service
+              port: webhook
               path: /readyz
             readiness:
-              port: cnpg-webhook-service
+              port: webhook
               path: /readyz
             startup:
-              port: cnpg-webhook-service
+              port: webhook
               type: tcp
           env:
             OPERATOR_IMAGE_NAME: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -46,7 +46,7 @@ service:
     enabled: true
     expandObjectName: false
     ports:
-      cnpg-webhook-service:
+      webhook:
         enabled: true
         protocol: https
         port: 443

--- a/charts/operators/cloudnative-pg/values.yaml
+++ b/charts/operators/cloudnative-pg/values.yaml
@@ -18,13 +18,15 @@ workload:
             - /manager
           probes:
             liveness:
-              port: 9443
+              port: webhook
+              type: https
               path: /readyz
             readiness:
-              port: 9443
+              port: webhook
+              type: https
               path: /readyz
             startup:
-              port: 9443
+              port: webhook
               type: tcp
           env:
             OPERATOR_IMAGE_NAME: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/operators/cloudnative-pg/values.yaml
+++ b/charts/operators/cloudnative-pg/values.yaml
@@ -18,13 +18,13 @@ workload:
             - /manager
           probes:
             liveness:
-              port: webhook
+              port: 9443
               path: /readyz
             readiness:
-              port: webhook
+              port: 9443
               path: /readyz
             startup:
-              port: webhook
+              port: 9443
               type: tcp
           env:
             OPERATOR_IMAGE_NAME: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
**Description**
It seems cnpg uses a hardcoded servicename, we need to adapt for that as well.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
