### PR TITLE
fix(clusterissuer): Increase `max_length` for crt/key Web GUI fields

### DIFF
--- a/charts/enterprise/clusterissuer/Chart.yaml
+++ b/charts/enterprise/clusterissuer/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/enterprise/clusterissuer
   - https://cert-manager.io/
 type: application
-version: 1.0.2
+version: 1.0.3
 annotations:
   truecharts.org/catagories: |
     - core

--- a/charts/enterprise/clusterissuer/questions.yaml
+++ b/charts/enterprise/clusterissuer/questions.yaml
@@ -238,6 +238,7 @@ questions:
                       schema:
                         type: string
                         required: true
+                        max_length: 10240
                         show_if: [["selfSigned", "=", false]]
                         default: ""
                     - variable: key
@@ -246,6 +247,7 @@ questions:
                       schema:
                         type: string
                         required: true
+                        max_length: 10240
                         show_if: [["selfSigned", "=", false]]
                         default: ""
 

--- a/templates/questions/addons/vpn.yaml
+++ b/templates/questions/addons/vpn.yaml
@@ -169,3 +169,4 @@
                             schema:
                               type: string
                               required: true
+                              max_length: 10240


### PR DESCRIPTION
**Description**

Since certificates and private keys can easily exceed a character limit of 1024, I increased the `max_length` from the default of 1024 to 10240. I'm not sure how sensible the value is, but this should at least allow for larger two-/three-tiered certificate chains.

⚒️ Fixes  #8090

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
