### PR TITLE
feat(minecraft-bungeecord) housekeeping + rootless

### DIFF
--- a/charts/stable/minecraft-bungeecord/Chart.yaml
+++ b/charts/stable/minecraft-bungeecord/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
     repository: https://library-charts.truecharts.org
     version: 12.13.0
 deprecated: false
-description: A Spigot BungeeCord server.
+description: the front-end of a cluster of minecraft-java containers.
 home: https://truecharts.org/charts/stable/minecraft-bungeecord
 icon: https://truecharts.org/img/hotlink-ok/chart-icons/minecraft-bungeecord.png
 keywords:
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/minecraft-bungeecord
   - https://github.com/itzg/docker-bungeecord
 type: application
-version: 4.0.19
+version: 4.1.0
 annotations:
   truecharts.org/catagories: |
     - proxy

--- a/charts/stable/minecraft-bungeecord/ci/base-values.yaml
+++ b/charts/stable/minecraft-bungeecord/ci/base-values.yaml
@@ -1,0 +1,1 @@
+imageSelector: image

--- a/charts/stable/minecraft-bungeecord/ci/j11-values.yaml
+++ b/charts/stable/minecraft-bungeecord/ci/j11-values.yaml
@@ -1,4 +1,1 @@
-image:
-  repository: itzg/bungeecord
-  tag: java11-2022.4.1@sha256:33c5185872d54533e996490523c61c01d24d38c412c7021ff1f5e8bc4f9f7e45
-  pullPolicy: Always
+imageSelector: j11Image

--- a/charts/stable/minecraft-bungeecord/ci/j8-values.yaml
+++ b/charts/stable/minecraft-bungeecord/ci/j8-values.yaml
@@ -1,4 +1,1 @@
-image:
-  repository: itzg/bungeecord
-  tag: java8-2022.4.1@sha256:112285cf835ce5777f7222238963bbbd4e49ef1150900b92d561d68c0807d14a
-  pullPolicy: Always
+imageSelector: j8Image

--- a/charts/stable/minecraft-bungeecord/questions.yaml
+++ b/charts/stable/minecraft-bungeecord/questions.yaml
@@ -15,8 +15,6 @@ questions:
                                     default: "image"
                                     enum:
                                       - value: "image"
-                                        description: "Default Image"
-                                      - value: "j17Image"
                                         description: "Java 17"
                                       - value: "j11Image"
                                         description: "Java 11"
@@ -76,18 +74,37 @@ questions:
                                         schema:
                                           type: boolean
                                           default: true
-                                      - variable: REPLACE_ENV_VARIABLES
-                                        label: "Replace Env Variables"
-                                        description: "Replace variables that match your defined environment variables in all the files in /server."
-                                        schema:
-                                          type: boolean
-                                          default: false
                                       - variable: ONLINE_MODE
                                         label: "Enable Online Mode"
                                         description: "MUST set to false which is required by bungeecord"
                                         schema:
                                           type: boolean
                                           default: false
+                                      - variable: genericpacks
+                                        label: "Show Generic Packs Settings"
+                                        schema:
+                                          type: boolean
+                                          default: false
+                                          show_subquestions_if: true
+                                          subquestions:
+                                            - variable: GENERIC_PACKS
+                                              label: "Generic Packs"
+                                              description: "Names of generic packs"
+                                              schema:
+                                                type: string
+                                                default: ""
+                                            - variable: GENERIC_PACKS_PREFIX
+                                              label: "Generic Packs Prefix"
+                                              description: "The URL of the service to download from"
+                                              schema:
+                                                type: string
+                                                default: ""
+                                            - variable: GENERIC_PACKS_SUFFIX
+                                              label: "Generic Packs Suffix"
+                                              description: "The file type"
+                                              schema:
+                                                type: string
+                                                default: ".zip"
                                       - variable: advancedenvironment
                                         label: "Show Advanced Server Settings"
                                         schema:
@@ -132,6 +149,18 @@ questions:
                                               schema:
                                                 type: string
                                                 default: ""
+                                            - variable: REPLACE_ENV_VARIABLES
+                                              label: "Replace Env Variables"
+                                              description: "Replace variables that match your defined environment variables in all the files in /server."
+                                              schema:
+                                                type: boolean
+                                                default: false
+                                            - variable: REPLACE_ENV_VARIABLE_PREFIX
+                                              label: "Replace Env Variable Prefix"
+                                              description: "define a prefix"
+                                              schema:
+                                                type: string
+                                                default: "CFG_"
 # Include{containerBasic}
 # Include{containerAdvanced}
 # Include{containerConfig}
@@ -217,13 +246,13 @@ questions:
                 description: "The UserID of the user running the application"
                 schema:
                   type: int
-                  default: 0
+                  default: 568
               - variable: runAsGroup
                 label: "runAsGroup"
                 description: "The groupID of the user running the application"
                 schema:
                   type: int
-                  default: 0
+                  default: 568
 # Include{securityContextContainer}
 # Include{securityContextAdvanced}
 # Include{securityContextPod}

--- a/charts/stable/minecraft-bungeecord/values.yaml
+++ b/charts/stable/minecraft-bungeecord/values.yaml
@@ -14,10 +14,6 @@ j8Image:
 tty: true
 stdin: true
 
-securityContext:
-  container:
-    readOnlyRootFilesystem: false
-
 workload:
   main:
     podSpec:

--- a/charts/stable/minecraft-bungeecord/values.yaml
+++ b/charts/stable/minecraft-bungeecord/values.yaml
@@ -2,10 +2,6 @@ image:
   repository: tccr.io/truecharts/bungeecord
   tag: v2022.4.1@sha256:b21a2b80aa272bb7ae40b4af1256eee5e0129b0ed4a5224424187e083720678d
   pullPolicy: Always
-j17Image:
-  repository: tccr.io/truecharts/bungeecord-java17
-  tag: v2022.4.1@sha256:e566d72347caca3019e7dd7a45feb4efbdd75b190242bd5d2d08b40a3430ea35
-  pullPolicy: Always
 j11Image:
   repository: tccr.io/truecharts/bungeecord-java11
   tag: v2022.4.1@sha256:faad46c04fc6e729e94630fc73a259b5aaea7eae9e5334ccaad2381eb0e0313d
@@ -14,37 +10,14 @@ j8Image:
   repository: tccr.io/truecharts/bungeecord-java8
   tag: v2022.4.1@sha256:240694a8f4028188f11d1ba198f656eedf0ac00cf881535cd97b4f1a86ae3231
   pullPolicy: Always
-service:
-  main:
-    ports:
-      main:
-        port: 25565
-        targetPort: 25577
-  rcon:
-    enabled: true
-    ports:
-      rcon:
-        enabled: true
-        port: 25578
-persistence:
-  config:
-    enabled: true
-    mountPath: "/config"
-  server:
-    enabled: true
-    mountPath: "/server"
-  plugins:
-    enabled: true
-    mountPath: "/plugins"
-portal:
-  open:
-    enabled: false
+
+tty: true
+stdin: true
+
 securityContext:
   container:
     readOnlyRootFilesystem: false
-    runAsNonRoot: false
-    runAsUser: 0
-    runAsGroup: 0
+
 workload:
   main:
     podSpec:
@@ -60,15 +33,46 @@ workload:
               type: tcp
           env:
             RCON_PORT: "{{ .Values.service.rcon.ports.rcon.port }}"
+            RCON_PASSWORD: "secretrconpass"
             TYPE: "BUNGEECORD"
             ONLINE_MODE: false
             MEMORY: 512M
             INIT_MEMORY: 512M
             MAX_MEMORY: 512M
             NETWORKADDRESS_CACHE_TTL: 60
-            REPLACE_ENV_VARIABLES: true
+            REPLACE_ENV_VARIABLES: false
+            ENV_VARIABLE_PREFIX: "CFG_"
+            # GENERIC_PACKS: "configs-v9.0.1,mods-v4.3.6"
+            # GENERIC_PACKS_PREFIX: "https://cdn.example.org/"
+            # GENERIC_PACKS_SUFFIX="".zip"
             # JVM_OPTS: ""
             # JVM_XX_OPTS: ""
             # PLUGINS: ""
 
-            RCON_PASSWORD: "secretrconpass"
+service:
+  main:
+    ports:
+      main:
+        port: 25565
+        targetPort: 25577
+  rcon:
+    enabled: true
+    ports:
+      rcon:
+        enabled: true
+        port: 25578
+
+persistence:
+  config:
+    enabled: true
+    mountPath: "/config"
+  server:
+    enabled: true
+    mountPath: "/server"
+  plugins:
+    enabled: true
+    mountPath: "/plugins"
+
+portal:
+  open:
+    enabled: false


### PR DESCRIPTION
**Description**
chart can be run as normal apps(568) user.

added the tty and stdin to interact with the server shell to run commands.

remove excess image option where image and java17 were the same.

move REPLACE_ENV_VARIABLES to advanced section and default to false, added its side env to create custom ENV prefixes.

added generic packs section.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
