### PR TITLE
fix(clusterissuer): let users provide raw base64-encoded CA .crt and .key values via Web GUI

### DIFF
--- a/charts/enterprise/clusterissuer/Chart.yaml
+++ b/charts/enterprise/clusterissuer/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/enterprise/clusterissuer
   - https://cert-manager.io/
 type: application
-version: 1.0.5
+version: 1.0.6
 annotations:
   truecharts.org/catagories: |
     - core

--- a/charts/enterprise/clusterissuer/questions.yaml
+++ b/charts/enterprise/clusterissuer/questions.yaml
@@ -233,8 +233,11 @@ questions:
                         show_if: [["selfSigned", "=", true]]
                         default: "my-selfsigned-ca"
                     - variable: crt
-                      label: "Custom CA cert (experimental)"
-                      description: "certificate for Certiticate Authority"
+                      label: "Base64-encoded string of the PEM-encoded CA certificate (experimental)"
+                      description: >
+                        Note that the certificate must be Base64-encoded. The command `$ cat ca.pem | base64 -w0`
+                        should help you on GNU-based systems (Debian, Ubuntu, etc.) and `$ cat ca.pem | base64 -b0`
+                        on BSD-based systems (most notably macOS).
                       schema:
                         type: string
                         required: true
@@ -242,8 +245,11 @@ questions:
                         show_if: [["selfSigned", "=", false]]
                         default: ""
                     - variable: key
-                      label: "Custom CA key (experimental)"
-                      description: "key Certiticate Authority"
+                      label: "Base64-encoded string of the PEM-encoded CA private key (experimental)"
+                      description: >
+                        Note that the private key must be Base64-encoded. The command `$ cat ca.key | base64 -w0`
+                        should help you on GNU-based systems (Debian, Ubuntu, etc.) and `$ cat ca.key | base64 -b0`
+                        on BSD-based systems (most notably macOS).
                       schema:
                         type: string
                         required: true

--- a/charts/enterprise/clusterissuer/templates/clusterissuer/_CA.tpl
+++ b/charts/enterprise/clusterissuer/templates/clusterissuer/_CA.tpl
@@ -36,8 +36,8 @@ metadata:
   name: {{ .name }}-ca
   namespace: cert-manager
 data:
-  tls.crt: {{ .crt | b64enc }}
-  tls.key: {{ .key | b64enc }}
+  tls.crt: {{ .crt }}
+  tls.key: {{ .key }}
 {{- end }}
 ---
 apiVersion: cert-manager.io/v1


### PR DESCRIPTION
**Description**

Of the two workarounds for the issue being fixed, I went with option 1):

1. We let users do the base64-encoding via `cat crt.pem | base64 -w0` ([as described in the cert-manager docs](https://cert-manager.io/docs/configuration/ca/#deployment)) and pass along the provided value like this: `tls.crt: {{ .crt }}`
2. We "undo" the string joining of the Web GUI with something like this: `{{ .crt | replace " " "\n" | b64enc }}`

This is necessary until the Web GUI supports multi-line `textarea` form fields ([upstream blocking issue](https://ixsystems.atlassian.net/browse/NAS-112061)).

⚒️ Fixes  #9446

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
