### PR TITLE
fix(metrics): Default metrics to off

### DIFF
--- a/charts/enterprise/blocky/Chart.yaml
+++ b/charts/enterprise/blocky/Chart.yaml
@@ -25,7 +25,7 @@ sources:
   - https://0xerr0r.github.io/blocky/
   - https://github.com/0xERR0R/blocky
   - https://github.com/Mozart409/blocky-frontend
-version: 5.0.42
+version: 5.0.43
 annotations:
   truecharts.org/catagories: |
     - network

--- a/charts/enterprise/blocky/values.yaml
+++ b/charts/enterprise/blocky/values.yaml
@@ -325,7 +325,7 @@ metrics:
   main:
     # -- Enable and configure a Prometheus serviceMonitor for the chart under this key.
     # @default -- See values.yaml
-    enabled: true
+    enabled: false
     type: "servicemonitor"
     endpoints:
       - port: main

--- a/charts/enterprise/traefik/Chart.yaml
+++ b/charts/enterprise/traefik/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/traefik/traefik-helm-chart
   - https://traefik.io/
 type: application
-version: 18.0.15
+version: 18.0.16
 annotations:
   truecharts.org/catagories: |
     - network

--- a/charts/enterprise/traefik/values.yaml
+++ b/charts/enterprise/traefik/values.yaml
@@ -129,7 +129,7 @@ logs:
 
 metrics:
   main:
-    enabled: true
+    enabled: false
     type: servicemonitor
     endpoints:
       - port: metrics


### PR DESCRIPTION
**Description**

Better to keep Traefik metrics default to False since it'll cause errors without the Prometheus operator installed.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
