### PR TITLE
fix(nextcloud): Correctly make use of accessIP when no ingress is enabled

### DIFF
--- a/charts/incubator/nextcloud/Chart.yaml
+++ b/charts/incubator/nextcloud/Chart.yaml
@@ -29,7 +29,7 @@ sources:
   - https://github.com/nextcloud/docker
   - https://github.com/nextcloud/helm
 type: application
-version: 20.0.0
+version: 20.0.1
 annotations:
   truecharts.org/catagories: |
     - cloud

--- a/charts/incubator/nextcloud/questions.yaml
+++ b/charts/incubator/nextcloud/questions.yaml
@@ -49,7 +49,7 @@ questions:
             type: dict
             attrs:
               - variable: run_optimize
-                label: Run Optiomize Scripts
+                label: Run Optimize Scripts
                 description: |
                   Runs the following commands at startup:</br>
                   occ db:add-missing-indices</br>
@@ -59,10 +59,6 @@ questions:
                   occ maintenance:mimetype:update-js</br>
                   occ maintenance:mimetype:update-db</br>
                   occ maintenance:update:htaccess</br>
-                schema:
-                  type: string
-                  required: true
-                  default: ""
                 schema:
                   type: boolean
                   default: false

--- a/charts/incubator/nextcloud/values.yaml
+++ b/charts/incubator/nextcloud/values.yaml
@@ -272,6 +272,12 @@ cronjobs:
       - occ preview:pre-generate
       - echo "Finished [occ preview:pre-generate]"
 
+ingress:
+  main:
+    enabled: true
+    hosts:
+     - host: abc.gom
+
 service:
   # Main service links to ingress easier
   # That's why the nginx is swapped with nextcloud

--- a/charts/incubator/nextcloud/values.yaml
+++ b/charts/incubator/nextcloud/values.yaml
@@ -272,7 +272,6 @@ cronjobs:
       - occ preview:pre-generate
       - echo "Finished [occ preview:pre-generate]"
 
-
 service:
   # Main service links to ingress easier
   # That's why the nginx is swapped with nextcloud

--- a/charts/incubator/nextcloud/values.yaml
+++ b/charts/incubator/nextcloud/values.yaml
@@ -272,11 +272,6 @@ cronjobs:
       - occ preview:pre-generate
       - echo "Finished [occ preview:pre-generate]"
 
-ingress:
-  main:
-    enabled: true
-    hosts:
-     - host: abc.gom
 
 service:
   # Main service links to ingress easier


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
