### PR TITLE
feat(resilio-sync): *Breaking* add predefined data storage

### DIFF
--- a/charts/stable/resilio-sync/Chart.yaml
+++ b/charts/stable/resilio-sync/Chart.yaml
@@ -21,7 +21,7 @@ name: resilio-sync
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/resilio-sync
   - https://github.com/orgs/linuxserver/packages/container/package/resilio-sync
-version: 9.0.23
+version: 10.0.0
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/resilio-sync/questions.yaml
+++ b/charts/stable/resilio-sync/questions.yaml
@@ -90,6 +90,14 @@ questions:
             type: dict
             attrs:
 # Include{persistenceBasic}
+        - variable: data
+          label: "App Data Storage"
+          description: "Stores the Application Data."
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{persistenceBasic}
 # Include{persistenceList}
 # Include{ingressRoot}
         - variable: main

--- a/charts/stable/resilio-sync/values.yaml
+++ b/charts/stable/resilio-sync/values.yaml
@@ -27,6 +27,9 @@ persistence:
   config:
     enabled: true
     mountPath: "/config"
+  data:
+    enabled: true
+    mountPath: "/sync"
   varrun:
     enabled: true
 portal:


### PR DESCRIPTION
**Description**
Adds /sync as predefined storage.

⚒️ Fixes  #

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [X] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**


**📃 Notes:**
I dont use to test

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
