### PR TITLE
Change host mount types to hostPath

### DIFF
--- a/charts/dependency/node-exporter/Chart.yaml
+++ b/charts/dependency/node-exporter/Chart.yaml
@@ -21,7 +21,7 @@ name: node-exporter
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/dependency/node-exporter
 type: application
-version: 1.0.28
+version: 1.0.29
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/dependency/node-exporter/values.yaml
+++ b/charts/dependency/node-exporter/values.yaml
@@ -17,6 +17,7 @@ workload:
       containers:
         main:
           args:
+            - --path.rootfs=/host
             - --path.procfs=/hostproc
             - --path.sysfs=/hostsys
             - --web.listen-address=0.0.0.0:{{ .Values.service.main.ports.main.port }}
@@ -44,16 +45,19 @@ podOptions:
 persistence:
   host:
     enabled: true
+    type: hostPath
     hostPath: /
     mountPath: /host
     readOnly: true
   proc:
     enabled: true
+    type: hostPath
     hostPath: /proc
     mountPath: /hostproc
     readOnly: true
   sys:
     enabled: true
+    type: hostPath
     hostPath: /sys
     mountPath: /hostsys
     readOnly: true


### PR DESCRIPTION
**Description**
Fixes the volume types so host filesystems can be mounted inside the pod.
⚒️ Fixes  #9854 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Tested on my local install of TrueNAS Scale.

**📃 Notes:**
None.
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
