### PR TITLE
fix(nextcloud): Fix .well-known redirections

### DIFF
--- a/charts/stable/nextcloud/Chart.yaml
+++ b/charts/stable/nextcloud/Chart.yaml
@@ -29,7 +29,7 @@ sources:
   - https://github.com/nextcloud/docker
   - https://github.com/nextcloud/helm
 type: application
-version: 21.0.5
+version: 21.0.6
 annotations:
   truecharts.org/catagories: |
     - cloud

--- a/charts/stable/nextcloud/templates/_configmap.tpl
+++ b/charts/stable/nextcloud/templates/_configmap.tpl
@@ -340,11 +340,6 @@ nginx-config:
             location = /.well-known/carddav { return 301 /remote.php/dav/; }
             location = /.well-known/caldav  { return 301 /remote.php/dav/; }
 
-            # According to the documentation these two lines are not necessary,
-            # but some users are still receiving errors
-            location = /.well-known/webfinger   { return 301 /index.php$uri; }
-            location = /.well-known/nodeinfo   { return 301 /index.php$uri; }
-
             location /.well-known/acme-challenge    { try_files $uri $uri/ =404; }
             location /.well-known/pki-validation    { try_files $uri $uri/ =404; }
 


### PR DESCRIPTION
**Description**
There is an issue with the Nextcloud Social app:
![.well-known/webfinger isn't properly set up!](https://github.com/truecharts/charts/assets/1633366/4670d2e8-bace-4999-b22f-f370b5c27f0c)
I've looked into it and found the cause to be most likely the Nginx configuration.
You can see here the redirection doesn't take into account any GET parameters:
![image](https://github.com/truecharts/charts/assets/1633366/ff6217ea-c34d-495c-aeec-9a29bb6189f4)
So it will always respond `{"message":"webfinger not supported"}`.
![image](https://github.com/truecharts/charts/assets/1633366/7b21acd3-fa26-4621-92fe-a6a63ec50196)
But when I try with a non-existent `.well-known`, I can see the redirection works as intended.
![image](https://github.com/truecharts/charts/assets/1633366/87e38144-c0e2-4f4c-b1a6-38fd0ad22d71)
So my conclusion is that these redirections needs to be removed.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
To test if the fix is effective you need to first install the Social app then test with your own user the url like this (replace `nextcloud-domain` and `AccountName` with correct values): https://nextcloud-domain/.well-known/webfinger?resource=acct:@AccountName@nextcloud-domain (the Social app should give you the Federated Cloud ID directly so you can use it there)
Then it should give an output different than `{"message":"webfinger not supported"}`.
And the ".well-known/webfinger isn't properly set up!" should not appear.

**📃 Notes:**
The last line `return 301 /index.php$request_uri;` should already cover any redirection and works properly.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`