### PR TITLE
fix(kopia) Actually use kopia credentials

### DIFF
--- a/charts/incubator/kopia/Chart.yaml
+++ b/charts/incubator/kopia/Chart.yaml
@@ -19,7 +19,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/incubator/kopia
   - https://kopia.io/docs/installation/#docker-images
   - https://github.com/kopia/kopia
-version: 6.0.4
+version: 6.0.5
 annotations:
   truecharts.org/catagories: |
     - utility

--- a/charts/incubator/kopia/questions.yaml
+++ b/charts/incubator/kopia/questions.yaml
@@ -18,21 +18,6 @@ questions:
                                     additional_attrs: true
                                     type: dict
                                     attrs:
-                                      - variable: USER
-                                        label: "Kopia User"
-                                        description: "Repository user"
-                                        schema:
-                                          type: string
-                                          default: "secret"
-                                          required: true
-                                      - variable: KOPIA_PASSWORD
-                                        label: "Kopia Password"
-                                        description: "Repository password"
-                                        schema:
-                                          type: string
-                                          default: "secret"
-                                          required: true
-                                          private: true
                                       - variable: KOPIA_SERVER_USERNAME
                                         label: "Kopia Server Username"
                                         description: "Username for WebUI"

--- a/charts/incubator/kopia/questions.yaml
+++ b/charts/incubator/kopia/questions.yaml
@@ -18,6 +18,21 @@ questions:
                                     additional_attrs: true
                                     type: dict
                                     attrs:
+                                      - variable: USER
+                                          label: "Kopia User"
+                                          description: "Repository user"
+                                          schema:
+                                            type: string
+                                            default: "secret"
+                                            required: true
+                                      - variable: KOPIA_PASSWORD
+                                        label: "Kopia Password"
+                                        description: "Repository password"
+                                        schema:
+                                          type: string
+                                          default: "secret"
+                                          required: true
+                                          private: true
                                       - variable: KOPIA_SERVER_USERNAME
                                         label: "Kopia Server Username"
                                         description: "Username for WebUI"

--- a/charts/incubator/kopia/questions.yaml
+++ b/charts/incubator/kopia/questions.yaml
@@ -22,7 +22,6 @@ questions:
                                         label: Repo User
                                         schema:
                                           type: string
-                                          private: true
                                           default: ""
                                           required: true
                                       - variable: password

--- a/charts/incubator/kopia/questions.yaml
+++ b/charts/incubator/kopia/questions.yaml
@@ -12,42 +12,40 @@ questions:
 # Include{containerMain}
 
                                 - variable: kopia
-                                  group: "App Configuration"
-                                  label: "Image Environment"
+                                  group: App Configuration
+                                  label: Kopia Configuration
                                   schema:
                                     additional_attrs: true
                                     type: dict
                                     attrs:
-                                      - variable: USER
-                                        label: "Kopia User"
-                                        description: "Repository user"
+                                      - variable: user
+                                        label: Repo User
                                         schema:
                                           type: string
-                                          default: "secret"
-                                          required: true
-                                      - variable: KOPIA_PASSWORD
-                                        label: "Kopia Password"
-                                        description: "Repository password"
-                                        schema:
-                                          type: string
-                                          default: "secret"
-                                          required: true
                                           private: true
-                                      - variable: KOPIA_SERVER_USERNAME
-                                        label: "Kopia Server Username"
-                                        description: "Username for WebUI"
+                                          default: ""
+                                          required: true
+                                      - variable: password
+                                        label: Repo Password
                                         schema:
                                           type: string
-                                          default: "server_user"
-                                          required: true
-                                      - variable: KOPIA_SERVER_PASSWORD
-                                        label: "Kopia Server Password"
-                                        description: "Password for WebUI"
-                                        schema:
-                                          type: string
-                                          default: "server_password"
-                                          required: true
                                           private: true
+                                          default: ""
+                                          required: true
+                                      - variable: server_username
+                                        label: Server UserName
+                                        schema:
+                                          type: string
+                                          private: true
+                                          default: ""
+                                          required: true
+                                      - variable: server_password
+                                        label:  Server Password
+                                        schema:
+                                          type: string
+                                          private: true
+                                          default: ""
+                                          required: true
 
 # Include{containerBasic}
 # Include{containerAdvanced}

--- a/charts/incubator/kopia/questions.yaml
+++ b/charts/incubator/kopia/questions.yaml
@@ -31,7 +31,6 @@ questions:
                                           type: string
                                           private: true
                                           default: ""
-                                          required: true
                                       - variable: server_username
                                         label: Server UserName
                                         schema:

--- a/charts/incubator/kopia/questions.yaml
+++ b/charts/incubator/kopia/questions.yaml
@@ -19,12 +19,12 @@ questions:
                                     type: dict
                                     attrs:
                                       - variable: USER
-                                          label: "Kopia User"
-                                          description: "Repository user"
-                                          schema:
-                                            type: string
-                                            default: "secret"
-                                            required: true
+                                        label: "Kopia User"
+                                        description: "Repository user"
+                                        schema:
+                                          type: string
+                                          default: "secret"
+                                          required: true
                                       - variable: KOPIA_PASSWORD
                                         label: "Kopia Password"
                                         description: "Repository password"

--- a/charts/incubator/kopia/questions.yaml
+++ b/charts/incubator/kopia/questions.yaml
@@ -28,21 +28,21 @@ questions:
                                         label: Repo Password
                                         schema:
                                           type: string
-                                          private: true
                                           default: ""
+                                          private: true
+                                          required: true
                                       - variable: server_username
                                         label: Server UserName
                                         schema:
                                           type: string
-                                          private: true
                                           default: ""
                                           required: true
                                       - variable: server_password
                                         label:  Server Password
                                         schema:
                                           type: string
-                                          private: true
                                           default: ""
+                                          private: true
                                           required: true
 
 # Include{containerBasic}

--- a/charts/incubator/kopia/templates/_secret.tpl
+++ b/charts/incubator/kopia/templates/_secret.tpl
@@ -5,6 +5,6 @@ enabled: true
 data:
   USER: {{ .Values.kopia.user | default "user" }}
   KOPIA_PASSWORD: {{ .Values.kopia.password | default "secret" }}
-  KOPIA_SERVER_USERNAME: {{ .Values.kopia.server_password | default "server_user" }}
+  KOPIA_SERVER_USERNAME: {{ .Values.kopia.server_username | default "server_user" }}
   KOPIA_SERVER_PASSWORD: {{ .Values.kopia.server_password | default "server_password" }}
 {{- end }}

--- a/charts/incubator/kopia/values.yaml
+++ b/charts/incubator/kopia/values.yaml
@@ -11,8 +11,6 @@ service:
         port: 10238
 
 kopia:
-  kopia_user: "user"
-  kopia_password: "secret"
   kopia_server_username: "user"
   kopia_server_password: "password"
 

--- a/charts/incubator/kopia/values.yaml
+++ b/charts/incubator/kopia/values.yaml
@@ -11,10 +11,10 @@ service:
         port: 10238
 
 kopia:
-  kopia_user: "user"
-  kopia_password: "secret"
-  kopia_server_username: "user"
-  kopia_server_password: "password"
+  user: "user"
+  password: "secret"
+  server_username: "user"
+  server_password: "password"
 
 workload:
   main:

--- a/charts/incubator/kopia/values.yaml
+++ b/charts/incubator/kopia/values.yaml
@@ -29,8 +29,8 @@ workload:
             - start
             - --address=http://0.0.0.0:{{ .Values.service.main.ports.main.port }}
             - --insecure
-            - --server-username={{ .Values.kopia.kopia_server_username }}
-            - --server-password={{ .Values.kopia.kopia_server_password }}
+            - --server-username={{ .Values.kopia.server_username }}
+            - --server-password={{ .Values.kopia.server_password }}
           probes:
             liveness:
               enabled: false

--- a/charts/incubator/kopia/values.yaml
+++ b/charts/incubator/kopia/values.yaml
@@ -11,6 +11,8 @@ service:
         port: 10238
 
 kopia:
+  kopia_user: "user"
+  kopia_password: "secret"
   kopia_server_username: "user"
   kopia_server_password: "password"
 

--- a/charts/incubator/kopia/values.yaml
+++ b/charts/incubator/kopia/values.yaml
@@ -29,8 +29,8 @@ workload:
             - start
             - --address=http://0.0.0.0:{{ .Values.service.main.ports.main.port }}
             - --insecure
-            - --server-username={{ .Values.kopia.server_username }}
-            - --server-password={{ .Values.kopia.server_password }}
+            - --server-username={{ .Values.kopia.kopia_server_username }}
+            - --server-password={{ .Values.kopia.kopia_server_password }}
           probes:
             liveness:
               enabled: false


### PR DESCRIPTION
**Description**
The server credentials set by the user are never used by kopia because of a typo.
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning


