### PR TITLE
fix(wg-easy): update mtu default

### DIFF
--- a/charts/stable/wg-easy/Chart.yaml
+++ b/charts/stable/wg-easy/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/wg-easy
   - https://github.com/WeeJeWel/wg-easy
 type: application
-version: 4.0.16
+version: 4.0.17
 annotations:
   truecharts.org/catagories: |
     - networking

--- a/charts/stable/wg-easy/questions.yaml
+++ b/charts/stable/wg-easy/questions.yaml
@@ -31,7 +31,7 @@ questions:
                                         description: "The MTU the clients will use. Server uses default WG MTU."
                                         schema:
                                           type: int
-                                          default: 1420
+                                          default: 0
                                       - variable: WG_PERSISTENT_KEEPALIVE
                                         label: "WG_PERSISTENT_KEEPALIVE"
                                         description: "Value in seconds to keep the connection open."

--- a/charts/stable/wg-easy/values.yaml
+++ b/charts/stable/wg-easy/values.yaml
@@ -45,7 +45,7 @@ workload:
             WG_HOST: "localhost"
             PORT: "{{ .Values.service.main.ports.main.port }}"
             WG_PORT: "{{ .Values.service.vpn.ports.vpn.port }}"
-            WG_MTU: 1420
+            WG_MTU: 0
             WG_PERSISTENT_KEEPALIVE: 0
             WG_DEFAULT_ADDRESS: "10.8.0.x"
             WG_DEFAULT_DNS: "1.1.1.1"


### PR DESCRIPTION
**Description**
wg-easy mtu default is now 0 and not 1420.

⚒️ Fixes  # 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

**📃 Notes:**

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
