### PR TITLE
fix(nextcloud): make previews.max_allowed_resolution string type

### DIFF
--- a/charts/stable/nextcloud/Chart.yaml
+++ b/charts/stable/nextcloud/Chart.yaml
@@ -29,7 +29,7 @@ sources:
   - https://github.com/nextcloud/docker
   - https://github.com/nextcloud/helm
 type: application
-version: 21.0.17
+version: 21.0.18
 annotations:
   truecharts.org/catagories: |
     - cloud

--- a/charts/stable/nextcloud/questions.yaml
+++ b/charts/stable/nextcloud/questions.yaml
@@ -180,7 +180,7 @@ questions:
                       label: Max Allowed Resolution
                       schema:
                         type: string
-                        valid_chars: '^[0-9]{2}(\.[0-9]{1})?$'
+                        valid_chars: '^[0-9]{3}(\.[0-9]{2})?$'
                         show_if: [["imaginary", "=", true]]
                         required: true
                         default: "18.0"

--- a/charts/stable/nextcloud/questions.yaml
+++ b/charts/stable/nextcloud/questions.yaml
@@ -179,10 +179,11 @@ questions:
                     - variable: max_allowed_resolution
                       label: Max Allowed Resolution
                       schema:
-                        type: int
+                        type: string
+                        valid_chars: '^[0-9]{2}(\.[0-9]{1})?$'
                         show_if: [["imaginary", "=", true]]
                         required: true
-                        default: 18.0
+                        default: "18.0"
                     - variable: max_file_size_image
                       label: Max File Size Image
                       schema:


### PR DESCRIPTION
**Description**
I see an error when upgrading nextcloud instance: `[EINVAL] values.nextcloud.previews.max_allowed_resolution: Not an integer`
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I have not personally tested this because testing would be more complex than warrented for the fix IMO

**📃 Notes:**
The options I saw for this fix were:

1. Update default value to `18`
2. Update type to `string`

I selected option 2 because the `imaginary` repo specifies `18.0` as the default.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
