### PR TITLE
fix(clusterissuer): fix `issuerRef` for self-signed CAs

### DIFF
--- a/charts/enterprise/clusterissuer/Chart.yaml
+++ b/charts/enterprise/clusterissuer/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/enterprise/clusterissuer
   - https://cert-manager.io/
 type: application
-version: 3.0.0
+version: 3.0.1
 annotations:
   truecharts.org/catagories: |
     - core

--- a/charts/enterprise/clusterissuer/templates/clusterissuer/_CA.tpl
+++ b/charts/enterprise/clusterissuer/templates/clusterissuer/_CA.tpl
@@ -28,7 +28,7 @@ spec:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: selfsigned-ca-issuer
+    name: {{ .name }}-selfsigned-ca-issuer
     kind: ClusterIssuer
     group: cert-manager.io
 {{- else }}


### PR DESCRIPTION
**Description**

Configuring a self-signed CA with `clusterissuer` like this currently fails due to the incorrect `issuerRef`:

![image](https://github.com/truecharts/charts/assets/3743342/59b49e68-c6cc-4a0a-87df-41b472adaf24)

The error message from the certificate signing request:

```text
Referenced "ClusterIssuer" not found: clusterissuer.cert-manager.io "selfsigned-ca-issuer" not found
```

This PR fixes the incorrect `issuerRef`

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
