### PR TITLE
fix(stash): add `/blobs` PVC storage

### DIFF
--- a/charts/stable/stash/Chart.yaml
+++ b/charts/stable/stash/Chart.yaml
@@ -18,7 +18,7 @@ name: stash
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/stash
   - https://github.com/stashapp/stash
-version: 11.0.0
+version: 11.0.1
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/stash/questions.yaml
+++ b/charts/stable/stash/questions.yaml
@@ -61,6 +61,14 @@ questions:
             type: dict
             attrs:
 # Include{persistenceBasic}
+        - variable: blobs
+          label: "App Blobs Storage"
+          description: "Binary data for scene covers, performer images, etc"
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{persistenceBasic}
         - variable: data
           label: "App Data Storage"
           description: "Stores the Application Data."

--- a/charts/stable/stash/questions.yaml
+++ b/charts/stable/stash/questions.yaml
@@ -53,6 +53,14 @@ questions:
             type: dict
             attrs:
 # Include{persistenceBasic}
+        - variable: generated
+          label: "App Generated Storage"
+          description: "Thumbnails, clips, etc"
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{persistenceBasic}
         - variable: metadata
           label: "App MetaData Storage"
           description: "Stores the Application MetaData."

--- a/charts/stable/stash/values.yaml
+++ b/charts/stable/stash/values.yaml
@@ -41,6 +41,9 @@ persistence:
   metadata:
     enabled: true
     mountPath: "/metadata"
+  blobs:
+    enabled: true
+    mountPath: "/blobs"
   data:
     enabled: true
     mountPath: "/data"


### PR DESCRIPTION
**Description**

As per [v0.20.0 release notes](https://github.com/stashapp/stash/releases/tag/v0.20.0):

> The `Filesystem` storage system is recommended for large libraries, _and is the default for new systems_.
> 
> **Docker users: please ensure that the Binary Data filesystem path is mapped to a persistent location if you choose to use the Filesystem binary storage type. Not doing so may result your binary data (scene covers, performer images etc) being lost.**

This PR adds the binary storage PVC at `/blobs` (the install wizard default).

I also noticed that the questions.yaml doesn't allow customizing the `/generated` PVC. It was added in 3c90d1fa1ba07f1508b2245224c370a12a423779. Was this intended or an oversight @xstar97?

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
