### PR TITLE
fix(paperless-ngx): Set defaults for OCR_LANGUAGES

### DIFF
--- a/charts/stable/paperless-ngx/Chart.yaml
+++ b/charts/stable/paperless-ngx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: paperless-ngx
-version: 1.1.1
+version: 1.1.2
 appVersion: "1.16.5"
 description: Paperless-ngx is an application by Daniel Quinn and contributors that indexes your scanned documents.
 type: application
@@ -20,7 +20,7 @@ sources:
 dependencies:
   - name: common
     repository: https://library-charts.truecharts.org
-    version: 12.15.0
+    version: 13.2.2
   - condition: redis.enabled
     name: redis
     repository: https://deps.truecharts.org

--- a/charts/stable/paperless-ngx/Chart.yaml
+++ b/charts/stable/paperless-ngx/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
   - condition: redis.enabled
     name: redis
     repository: https://deps.truecharts.org
-    version: 6.0.66
+    version: 7.0.6
 maintainers:
   - email: info@truecharts.org
     name: TrueCharts

--- a/charts/stable/paperless-ngx/questions.yaml
+++ b/charts/stable/paperless-ngx/questions.yaml
@@ -54,13 +54,13 @@ questions:
                                         description: "Additional OCR languages to install. By default, paperless comes with English, German, Italian, Spanish and French. If your language is not in this list, install additional languages with this configuration option. Use LangCodes for the additional languages in a SPACED list."
                                         schema:
                                           type: string
-                                          default: ""
+                                          default: "eng fra deu spa ita"
                                       - variable: PAPERLESS_OCR_LANGUAGE
                                         label: "Additional Language Selector"
-                                        description: "If additional languages are selected above, you can set the default language used with OCR using LangCodes below, default is none"
+                                        description: "If additional languages are selected above, you can set the default language used with OCR using LangCodes below, default is eng. Can use eng+fra if muliple"
                                         schema:
                                           type: string
-                                          default: ""
+                                          default: "eng"
 # Include{containerBasic}
 # Include{containerAdvanced}
 

--- a/charts/stable/paperless-ngx/values.yaml
+++ b/charts/stable/paperless-ngx/values.yaml
@@ -95,5 +95,5 @@ workload:
             PAPERLESS_ADMIN_USER: "admin"
             PAPERLESS_ADMIN_PASSWORD: "admin"
             PAPERLESS_ADMIN_MAIL: "admin@admin.com"
-            PAPERLESS_OCR_LANGUAGE: ""
-            PAPERLESS_OCR_LANGUAGES: ""
+            PAPERLESS_OCR_LANGUAGE: "eng"
+            PAPERLESS_OCR_LANGUAGES: "eng fra deu spa ita"


### PR DESCRIPTION
**Description**

Turns out even if it passes testing they still need to be manually set inside the ENV VARs

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
