### PR TITLE
fix(seedsync): nest securityContext values under container

### DIFF
--- a/charts/stable/seedsync/Chart.yaml
+++ b/charts/stable/seedsync/Chart.yaml
@@ -25,4 +25,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/seedsync
   - https://github.com/ipsingh06/seedsync
 type: application
-version: 4.0.0
+version: 4.0.1

--- a/charts/stable/seedsync/values.yaml
+++ b/charts/stable/seedsync/values.yaml
@@ -4,9 +4,10 @@ image:
   tag: latest@sha256:e8e69dcebd7cd9b15af6484736e6d51df49d0e2757e067b1fe8b9b820c6780d1
 
 securityContext:
-  readOnlyRootFilesystem: false
-  runAsGroup: 0
-  runAsUser: 0
+  container:
+    readOnlyRootFilesystem: false
+    runAsGroup: 0
+    runAsUser: 0
 
 service:
   main:


### PR DESCRIPTION
**Description**
`ReadOnly Root Filesystem` needs to be disabled by default for `seedsync` otherwise you won't actually be able to set it up with a remote server.

You get this with read only, works fine when disabled:
`An error occurred while installing scanner script to remote server: 'Unknown error - mkdir: cannot create directory ‘/home/seedsync’: Read-only file system /usr/local/bin/run_as_user: 15: /usr/local/bin/run_as_user: cannot create /var/tmp/passwd: Read-only file system`

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

Current version of `seedsync` on stable only works when manually disabling read-only. I believe it's not pulling the default value due to a change in structure (missing the nested `container` parent key).

**📃 Notes:**

N/A

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
