### PR TITLE
Remove leftover portal sub-path for guacamole

### DIFF
--- a/charts/stable/guacamole/Chart.yaml
+++ b/charts/stable/guacamole/Chart.yaml
@@ -20,7 +20,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/guacamole
   - https://github.com/apache/guacamole-client
 type: application
-version: 10.0.1
+version: 10.0.2
 annotations:
   truecharts.org/catagories: |
     - utilities

--- a/charts/stable/guacamole/questions.yaml
+++ b/charts/stable/guacamole/questions.yaml
@@ -2,7 +2,6 @@
 portals:
   open:
 # Include{portalLink}
-    path: /guacamole
 questions:
 # Include{global}
 # Include{workload}


### PR DESCRIPTION
**Description**
Follow-up to #10987, forgot to change corresponding portal URL.
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Straightforward

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
