### PR TITLE
fix(kitchenowl): resolve issue #8804

### DIFF
--- a/charts/stable/kitchenowl/Chart.yaml
+++ b/charts/stable/kitchenowl/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/kitchenowl
   - https://tombursch.github.io/kitchenowl
 type: application
-version: 5.0.0
+version: 5.0.1
 annotations:
   truecharts.org/catagories: |
     - utilities

--- a/charts/stable/kitchenowl/questions.yaml
+++ b/charts/stable/kitchenowl/questions.yaml
@@ -6,13 +6,10 @@ questions:
 # Include{global}
 # Include{workload}
 # Include{workloadDeployment}
-
 # Include{replicas1}
 # Include{podSpec}
 # Include{containerMain}
-
-
-                                - variable: env
+                                - variable: kitchenowl
                                   group: "App Configuration"
                                   label: "Image Environment"
                                   schema:
@@ -26,9 +23,15 @@ questions:
                                           type: string
                                           required: true
                                           default: ""
+                                      - variable: JWT_SECRET_KEY
+                                        label: "JWT_SECRET_KEY"
+                                        description: "JWT secret for encryption"
+                                        schema:
+                                          type: string
+                                          required: true
+                                          default: ""
 # Include{containerBasic}
 # Include{containerAdvanced}
-
 # Include{containerConfig}
 # Include{podOptions}
 # Include{serviceRoot}

--- a/charts/stable/kitchenowl/values.yaml
+++ b/charts/stable/kitchenowl/values.yaml
@@ -2,55 +2,88 @@ image:
   repository: tccr.io/truecharts/kitchenowl-web
   pullPolicy: IfNotPresent
   tag: latest@sha256:eff15b745cb2589c3ce0d0ba6a30ba0d949c298f7cedf5b4214b4a4fedb424a6
+
 backendImage:
   repository: tccr.io/truecharts/kitchenowl-backend
   pullPolicy: IfNotPresent
   tag: latest@sha256:903c6339426e0fe7d96245b477b9706db58b27e4851d92f92164e305bd8cd56d
+
 service:
   main:
+    enabled: true
+    targetSelector: main
     ports:
       main:
+        enabled: true
         protocol: http
         targetPort: 80
         port: 10246
-additionalContainers:
-  backend:
-    name: backend
-    image: "{{ .Values.backendImage.repository }}:{{ .Values.backendImage.tag }}"
-    env:
-      - name: FRONT_URL
-        value: "{{ .Values.workload.main.podSpec.containers.main.env.FRONT_URL }}"
-        # Backend also listens on 80, but afaik there is no use as of now
-        # Changed port to 81 to avoid conflict with frontend
-      - name: HTTP_PORT
-        value: "81"
-      - name: JWT_SECRET_KEY
-        valueFrom:
-          secretKeyRef:
-            name: kitchenowl-secrets
-            key: JWT_SECRET_KEY
-    volumeMounts:
-      - name: data
-        mountPath: "/data"
+        targetSelector: main
+
 persistence:
   data:
     enabled: true
-    mountPath: "/data"
+    targetSelector:
+      main:
+        backend:
+          mountPath: /data
+
 portal:
   open:
     enabled: true
+
 securityContext:
   container:
     readOnlyRootFilesystem: false
     runAsNonRoot: false
     runAsUser: 0
     runAsGroup: 0
+
 workload:
   main:
+    enabled: true
+    type: Deployment
+    strategy: RollingUpdate
     podSpec:
       containers:
         main:
+          enabled: true
+          primary: true
+          imageSelector: image
           env:
-            FRONT_URL: "http://localhost:10246"
-            # Backend listens on 5000 websockets.
+            FRONT_URL: "{{ .Values.workload.main.podSpec.containers.main.kitchenowl.FRONT_URL }}"
+            # As we have two Containers in the same Pod, we can use localhost to reach WS Port
+            # This is a temporary fix, separating containers is the longterm solution
             BACK_URL: "localhost:5000"
+          probes:
+            liveness:
+              type: http
+              path: /
+              port: "{{ .Values.service.main.ports.main.targetPort }}"
+            readiness:
+              type: http
+              path: /
+              port: "{{ .Values.service.main.ports.main.targetPort }}"
+            startup:
+              type: http
+              path: /
+              port: "{{ .Values.service.main.ports.main.targetPort }}"
+        backend:
+          enabled: true
+          imageSelector: backendImage
+          env:
+            FRONT_URL: "{{ .Values.workload.main.podSpec.containers.main.kitchenowl.FRONT_URL }}"
+            # As we have two Containers in the same Pod, we can use localhost to reach WS Port
+            # This is a temporary fix, separating containers is the longterm solution
+            BACK_URL: "localhost:5000"
+            # Next to Port 5000 Backend listens on Port 80 as well
+            # Changed port to 81 to avoid conflict with frontend, separating containers is the longterm solution
+            HTTP_PORT: "81"
+            JWT_SECRET_KEY: "{{ .Values.workload.main.podSpec.containers.main.kitchenowl.JWT_SECRET_KEY }}"
+          probes:
+            liveness:
+              enabled: false
+            readiness:
+              enabled: false
+            startup:
+              enabled: false


### PR DESCRIPTION
**Description**
Kitchenowl was migrated to new common, but deploying ended in "Hmmmm... couldn't reach server" error and "(111: Connection refused) while connecting to upstream" log entries. This PR: 
* removes the deprecated additionalContainer section and deploys the backend container in the same Pod as the frontend
* asks user for a JWT secret (reason: Kitchenowl seems to support postgres, so mid-/long-term cnpg can be added and user might deploy with same JWT in case of a DB restore)

⚒️ Fixes  #8804

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Tested on TrueNAS Scale 22.12.3.2 with all operators and best practises according docs

**📃 Notes:**
This is a short-term fix. long-term topics to look at:
* separate frontend and backend containers to resolve BACK_URL hardcoded value and deprecate HTTP_PORT var
* add cnpg support

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
