### PR TITLE
fix(smokeping) Add net_raw capabilities as default

### DIFF
--- a/charts/stable/smokeping/Chart.yaml
+++ b/charts/stable/smokeping/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/smokeping
   - https://oss.oetiker.ch/smokeping/
 type: application
-version: 7.0.1
+version: 7.0.2
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/smokeping/values.yaml
+++ b/charts/stable/smokeping/values.yaml
@@ -24,6 +24,9 @@ portal:
     enabled: true
 securityContext:
   container:
+    capabilities:
+        add:
+          - NET_RAW
     readOnlyRootFilesystem: false
     runAsNonRoot: false
     allowPrivilegeEscalation: true


### PR DESCRIPTION
**Description**
I deployed the smokeping chart and didn't get any results.  After some digging, I realized it was because fping couldn't ping because it needs raw socket access.  To address this, I added the net_raw capabilitie to the chart
The underlying container capabilities issue is documented here: https://github.com/linuxserver/docker-smokeping/issues/99

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I ran this on my local k3s instance.

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [N/A] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [N/A] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning