### PR TITLE
fix(authentik): Make http ports match values

### DIFF
--- a/charts/stable/authentik/Chart.yaml
+++ b/charts/stable/authentik/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/authentik
   - https://github.com/goauthentik/authentik
   - https://goauthentik.io/docs/
-version: 15.0.0
+version: 15.0.1
 annotations:
   truecharts.org/catagories: |
     - authentication

--- a/charts/stable/authentik/questions.yaml
+++ b/charts/stable/authentik/questions.yaml
@@ -479,7 +479,7 @@ questions:
                             description: This port exposes the container port on the service
                             schema:
                               type: int
-                              default: 10227
+                              default: 10230
                               required: true
                     - variable: https
                       label: HTTPS Service Port Configuration


### PR DESCRIPTION
**Description**

As per -> https://discord.com/channels/830763548678291466/1138238681027715153/1138298504813498442, the service ports in `values.yaml` and `questions.yaml` didn't match so this fixes it

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
