### PR TITLE
refactor(kitchenowl): resolve issue #8804

### DIFF
--- a/charts/stable/kitchenowl/Chart.yaml
+++ b/charts/stable/kitchenowl/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/kitchenowl
   - https://tombursch.github.io/kitchenowl
 type: application
-version: 5.0.1
+version: 6.0.0
 annotations:
   truecharts.org/catagories: |
     - utilities

--- a/charts/stable/kitchenowl/templates/_configmap.tpl
+++ b/charts/stable/kitchenowl/templates/_configmap.tpl
@@ -3,8 +3,9 @@
 
 {{- $fullname := (include "tc.v1.common.lib.chart.names.fullname" $) -}}
 
-enabled: true
-data:
-  BACK_URL: {{ printf "%v-backend:%v" $fullname .Values.service.backend.ports.backend.port }}
+backend:
+  enabled: true
+  data:
+    BACK_URL: {{ printf "%v-backend:%v" $fullname .Values.service.backend.ports.backend.port }}
 
 {{- end -}}

--- a/charts/stable/kitchenowl/templates/_configmap.tpl
+++ b/charts/stable/kitchenowl/templates/_configmap.tpl
@@ -1,0 +1,10 @@
+{{/* Define the configmap */}}
+{{- define "kitchenowl.configmaps" -}}
+
+{{- $fullname := (include "tc.v1.common.lib.chart.names.fullname" $) -}}
+
+enabled: true
+data:
+  BACK_URL: {{ printf "%v-backend:%v" $fullname .Values.service.backend.ports.backend.port }}
+
+{{- end -}}

--- a/charts/stable/kitchenowl/templates/_configmap.tpl
+++ b/charts/stable/kitchenowl/templates/_configmap.tpl
@@ -1,11 +1,10 @@
 {{/* Define the configmap */}}
-{{- define "kitchenowl.configmaps" -}}
+{{- define "kitchenowl.configmap" -}}
 
 {{- $fullname := (include "tc.v1.common.lib.chart.names.fullname" $) -}}
 
-backend:
-  enabled: true
-  data:
-    BACK_URL: {{ printf "%v-backend:%v" $fullname .Values.service.backend.ports.backend.port }}
+enabled: true
+data:
+  BACK_URL: {{ printf "%v-backend:%v" $fullname .Values.service.backend.ports.backend.port }}
 
 {{- end -}}

--- a/charts/stable/kitchenowl/templates/_secrets.tpl
+++ b/charts/stable/kitchenowl/templates/_secrets.tpl
@@ -1,20 +1,15 @@
 {{/* Define the secrets */}}
 {{- define "kitchenowl.secrets" -}}
----
+{{- $secretName := (printf "%s-secrets" (include "tc.v1.common.lib.chart.names.fullname" $)) }}
+{{- $kitchenowlprevious := lookup "v1" "Secret" .Release.Namespace $secretName }}
 
-apiVersion: v1
-kind: Secret
-type: Opaque
-metadata:
-  name: kitchenowl-secrets
-{{- $kitchenowlprevious := lookup "v1" "Secret" .Release.Namespace "kitchenowl-secrets" }}
-{{- $jwt_secret := "" }}
+enabled: true
 data:
-  {{- if $kitchenowlprevious}}
-  JWT_SECRET_KEY: {{ index $kitchenowlprevious.data "JWT_SECRET_KEY" }}
+  {{- if $kitchenowlprevious }}
+  JWT_SECRET_KEY: {{ index $kitchenowlprevious.data "JWT_SECRET_KEY" | b64dec }}
   {{- else }}
-  {{- $jwt_secret := randAlphaNum 32 }}
-  JWT_SECRET_KEY: {{ $jwt_secret | b64enc }}
+  {{- $jwtsecret := randAlphaNum 50 }}
+  JWT_SECRET_KEY: {{ $jwtsecret }}
   {{- end }}
 
 {{- end -}}

--- a/charts/stable/kitchenowl/templates/common.yaml
+++ b/charts/stable/kitchenowl/templates/common.yaml
@@ -6,4 +6,10 @@
   {{- $_ := set .Values.secret "kitchenowl-secrets" $secrets -}}
 {{- end -}}
 
+{{/* Render configmap for Kitchenowl */}}
+{{- $configmaps := include "kitchenowl.configmaps" . | fromYaml -}}
+{{- if $configmaps -}}
+  {{- $_ := set .Values.configmap "kitchenowl-config" $configmaps -}}
+{{- end -}}
+
 {{ include "tc.v1.common.loader.apply" . }}

--- a/charts/stable/kitchenowl/templates/common.yaml
+++ b/charts/stable/kitchenowl/templates/common.yaml
@@ -1,5 +1,9 @@
 {{- include "tc.v1.common.loader.init" . }}
 
-{{ include "kitchenowl.secrets" . }}
+{{/* Render secrets for Kitchenowl */}}
+{{- $secrets := include "kitchenowl.secrets" . | fromYaml -}}
+{{- if $secrets -}}
+  {{- $_ := set .Values.secret "kitchenowl-secrets" $secrets -}}
+{{- end -}}
 
 {{ include "tc.v1.common.loader.apply" . }}

--- a/charts/stable/kitchenowl/templates/common.yaml
+++ b/charts/stable/kitchenowl/templates/common.yaml
@@ -7,9 +7,9 @@
 {{- end -}}
 
 {{/* Render configmap for Kitchenowl */}}
-{{- $configmaps := include "kitchenowl.configmaps" . | fromYaml -}}
-{{- if $configmaps -}}
-  {{- $_ := set .Values.configmap "kitchenowl-config" $configmaps -}}
+{{- $configmap := include "kitchenowl.configmap" . | fromYaml -}}
+{{- if $configmap -}}
+  {{- $_ := set .Values.configmap "kitchenowl-config" $configmap -}}
 {{- end -}}
 
 {{ include "tc.v1.common.loader.apply" . }}

--- a/charts/stable/kitchenowl/values.yaml
+++ b/charts/stable/kitchenowl/values.yaml
@@ -58,13 +58,11 @@ workload:
         main:
           enabled: true
           primary: true
+          envFrom:
+            - configMapRef:
+                name: kitchenowl-config
           env:
             FRONT_URL: "{{ .Values.workload.main.podSpec.containers.main.env.FRONT_URL }}"
-          envFrom:
-            BACK_URL:
-              configMapRef:
-                name: kitchenowl-config
-                key: BACK_URL
           probes:
             liveness:
               type: http

--- a/charts/stable/kitchenowl/values.yaml
+++ b/charts/stable/kitchenowl/values.yaml
@@ -60,6 +60,7 @@ workload:
           primary: true
           env:
             FRONT_URL: "{{ .Values.workload.main.podSpec.containers.main.env.FRONT_URL }}"
+          envFrom:
             BACK_URL:
               configMapKeyRef:
                 name: kitchenowl-config

--- a/charts/stable/kitchenowl/values.yaml
+++ b/charts/stable/kitchenowl/values.yaml
@@ -6,51 +6,119 @@ backendImage:
   repository: tccr.io/truecharts/kitchenowl-backend
   pullPolicy: IfNotPresent
   tag: latest@sha256:ded34fe79a363d6a098f97f81a546bc991f7d1cb4cab0c4236ff170f49b58063
+
 service:
   main:
+    enabled: true
+    targetSelector: main
     ports:
       main:
+        enabled: true
+        targetSelector: main
         protocol: http
         targetPort: 80
         port: 10246
-additionalContainers:
   backend:
-    name: backend
-    image: "{{ .Values.backendImage.repository }}:{{ .Values.backendImage.tag }}"
-    env:
-      - name: FRONT_URL
-        value: "{{ .Values.workload.main.podSpec.containers.main.env.FRONT_URL }}"
-        # Backend also listens on 80, but afaik there is no use as of now
-        # Changed port to 81 to avoid conflict with frontend
-      - name: HTTP_PORT
-        value: "81"
-      - name: JWT_SECRET_KEY
-        valueFrom:
-          secretKeyRef:
-            name: kitchenowl-secrets
-            key: JWT_SECRET_KEY
-    volumeMounts:
-      - name: data
-        mountPath: "/data"
+    enabled: true
+    targetSelector: backend
+    ports:
+      backend:
+        enabled: true
+        targetSelector: backend
+        protocol: http
+        targetPort: 5000
+        port: 10247
+
 persistence:
   data:
     enabled: true
-    mountPath: "/data"
+    targetSelector:
+      backend:
+        backend:
+          mountPath: /data
+
 portal:
   open:
     enabled: true
+
 securityContext:
   container:
     readOnlyRootFilesystem: false
     runAsNonRoot: false
     runAsUser: 0
     runAsGroup: 0
+
 workload:
   main:
+    type: Deployment
+    strategy: RollingUpdate
+    replicas: 1
     podSpec:
       containers:
         main:
+          enabled: true
+          primary: true
           env:
-            FRONT_URL: "http://localhost:10246"
-            # Backend listens on 5000 websockets.
-            BACK_URL: "localhost:5000"
+            FRONT_URL: "{{ .Values.workload.main.podSpec.containers.main.env.FRONT_URL }}"
+            BACK_URL: "kitchenowl-backend:{{ .Values.service.backend.ports.backend.port }}"
+          probes:
+            liveness:
+              type: http
+              path: /
+              port: "{{ .Values.service.main.ports.main.targetPort }}"
+            readiness:
+              type: http
+              path: /
+              port: "{{ .Values.service.main.ports.main.targetPort }}"
+            startup:
+              type: http
+              path: /
+              port: "{{ .Values.service.main.ports.main.targetPort }}"
+  backend:
+    enabled: true
+    type: Deployment
+    podSpec:
+      containers:
+        backend:
+          enabled: true
+          primary: true
+          imageSelector: backendImage
+          env:
+            FRONT_URL: "{{ .Values.workload.main.podSpec.containers.main.env.FRONT_URL }}"
+            # Changed port to 10248 to avoid conflict with frontend
+            HTTP_PORT: "10248"
+            JWT_SECRET_KEY:
+              secretKeyRef:
+                name: kitchenowl-secrets
+                key: JWT_SECRET_KEY
+            DB_DRIVER: "postgresql"
+            DB_HOST:
+              secretKeyRef:
+                name: cnpg-main-urls
+                key: host
+            DB_NAME: "{{ .Values.cnpg.main.database }}"
+            DB_USER: "{{ .Values.cnpg.main.user }}"
+            DB_PASSWORD:
+              secretKeyRef:
+                name: cnpg-main-user
+                key: password
+          probes:
+            liveness:
+              enabled: true
+              type: tcp
+              port: "{{ .Values.service.backend.ports.backend.targetPort }}"
+            readiness:
+              enabled: true
+              type: tcp
+              port: "{{ .Values.service.backend.ports.backend.targetPort }}"
+            startup:
+              enabled: true
+              type: tcp
+              port: "{{ .Values.service.backend.ports.backend.targetPort }}"
+
+# Enabled postgres
+cnpg:
+  main:
+    enabled: true
+    user: kitchenowl
+    database: kitchenowl

--- a/charts/stable/kitchenowl/values.yaml
+++ b/charts/stable/kitchenowl/values.yaml
@@ -60,7 +60,10 @@ workload:
           primary: true
           env:
             FRONT_URL: "{{ .Values.workload.main.podSpec.containers.main.env.FRONT_URL }}"
-            BACK_URL: "kitchenowl-backend:{{ .Values.service.backend.ports.backend.port }}"
+            BACK_URL:
+              configMapKeyRef:
+                name: kitchenowl-config
+                key: BACK_URL
           probes:
             liveness:
               type: http

--- a/charts/stable/kitchenowl/values.yaml
+++ b/charts/stable/kitchenowl/values.yaml
@@ -62,7 +62,7 @@ workload:
             FRONT_URL: "{{ .Values.workload.main.podSpec.containers.main.env.FRONT_URL }}"
           envFrom:
             BACK_URL:
-              configMapKeyRef:
+              configMapRef:
                 name: kitchenowl-config
                 key: BACK_URL
           probes:


### PR DESCRIPTION
**Description**
Kitchenowl was migrated to new common, but deploying ended in "Hmmmm... couldn't reach server" error and "(111: Connection refused) while connecting to upstream" log entries. 
This PR removes the deprecated "additionalContainer" section and deploys the backend as a Deployment. Furthermore the secrets template was refactored to render it instead of hardcoding. Additionally cnpg was added as it is supported by the upstream project.
As the current chart is not deployable and due to the refactoring of several parts I was not able to test, but I expect it to be a breaking change for old deployments as the data is now stored in cnpg instead of sqlite.

⚒️ Fixes  #8804

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Tested on TrueNAS Scale 22.12.3.2 with all operators and best practises according getting started docs (including Ingress).
After deployment all pods including cnpg are running, no errors in the logs and application events

**📃 Notes:**

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
