### PR TITLE
fix(vaultwarden): Update SMTP deprecated variable - user must reassign the smtp security setting

### DIFF
--- a/charts/enterprise/vaultwarden/Chart.yaml
+++ b/charts/enterprise/vaultwarden/Chart.yaml
@@ -25,7 +25,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/enterprise/vaultwarden
   - https://github.com/dani-garcia/vaultwarden
 type: application
-version: 22.0.0
+version: 23.0.0
 annotations:
   truecharts.org/catagories: |
     - security

--- a/charts/enterprise/vaultwarden/questions.yaml
+++ b/charts/enterprise/vaultwarden/questions.yaml
@@ -200,7 +200,7 @@ questions:
                       schema:
                         type: string
                         default: ""
-                    - variable: tls
+                    - variable: security
                       label: "Enable SSL connection"
                       schema:
                         type: string

--- a/charts/enterprise/vaultwarden/questions.yaml
+++ b/charts/enterprise/vaultwarden/questions.yaml
@@ -203,11 +203,18 @@ questions:
                     - variable: ssl
                       label: "Enable SSL connection"
                       schema:
-                        type: boolean
-                        default: true
+                        type: string
+                        default: "starttls"
+                        enum:
+                          - value: "starttls"
+                           description: "STARTTLS (587)"
+                           - value: "force_tls"
+                           description: "FORCE_TLS (465)"
+                          - value: "off"
+                           description: "OFF (25)"
                     - variable: port
                       label: "SMTP port"
-                      description: "Usually: 25 without SSL, 587 with SSL"
+                      description: "Usually: 587 with STARTTLS, 465 with FORCE_TLS, and 25 without SSL"
                       schema:
                         type: int
                         default: 587

--- a/charts/enterprise/vaultwarden/questions.yaml
+++ b/charts/enterprise/vaultwarden/questions.yaml
@@ -207,11 +207,11 @@ questions:
                         default: "starttls"
                         enum:
                           - value: "starttls"
-                           description: "STARTTLS (587)"
-                           - value: "force_tls"
-                           description: "FORCE_TLS (465)"
+                            description: "STARTTLS (587)"
+                          - value: "force_tls"
+                            description: "FORCE_TLS (465)"
                           - value: "off"
-                           description: "OFF (25)"
+                            description: "OFF (25)"
                     - variable: port
                       label: "SMTP port"
                       description: "Usually: 587 with STARTTLS, 465 with FORCE_TLS, and 25 without SSL"

--- a/charts/enterprise/vaultwarden/questions.yaml
+++ b/charts/enterprise/vaultwarden/questions.yaml
@@ -200,7 +200,7 @@ questions:
                       schema:
                         type: string
                         default: ""
-                    - variable: ssl
+                    - variable: tls
                       label: "Enable SSL connection"
                       schema:
                         type: string

--- a/charts/enterprise/vaultwarden/templates/_configmap.tpl
+++ b/charts/enterprise/vaultwarden/templates/_configmap.tpl
@@ -47,7 +47,7 @@ data:
   SMTP_FROM_NAME: {{ .Values.vaultwarden.smtp.fromName | quote }}
   {{- end }}
   {{- if .Values.vaultwarden.smtp.ssl }}
-  SMTP_SECURITY: {{ .Values.vaultwarden.smtp.ssl | quote }}
+  SMTP_SECURITY: {{ .Values.vaultwarden.smtp.tls | quote }}
   {{- end }}
   {{- if .Values.vaultwarden.smtp.port }}
   SMTP_PORT: {{ .Values.vaultwarden.smtp.port | quote }}

--- a/charts/enterprise/vaultwarden/templates/_configmap.tpl
+++ b/charts/enterprise/vaultwarden/templates/_configmap.tpl
@@ -47,7 +47,7 @@ data:
   SMTP_FROM_NAME: {{ .Values.vaultwarden.smtp.fromName | quote }}
   {{- end }}
   {{- if .Values.vaultwarden.smtp.ssl }}
-  SMTP_SECURITY: {{ .Values.vaultwarden.smtp.tls | quote }}
+  SMTP_SECURITY: {{ .Values.vaultwarden.smtp.security | quote }}
   {{- end }}
   {{- if .Values.vaultwarden.smtp.port }}
   SMTP_PORT: {{ .Values.vaultwarden.smtp.port | quote }}

--- a/charts/enterprise/vaultwarden/templates/_configmap.tpl
+++ b/charts/enterprise/vaultwarden/templates/_configmap.tpl
@@ -47,7 +47,7 @@ data:
   SMTP_FROM_NAME: {{ .Values.vaultwarden.smtp.fromName | quote }}
   {{- end }}
   {{- if .Values.vaultwarden.smtp.ssl }}
-  SMTP_SSL: {{ .Values.vaultwarden.smtp.ssl | quote }}
+  SMTP_SECURITY: {{ .Values.vaultwarden.smtp.ssl | quote }}
   {{- end }}
   {{- if .Values.vaultwarden.smtp.port }}
   SMTP_PORT: {{ .Values.vaultwarden.smtp.port | quote }}

--- a/charts/enterprise/vaultwarden/values.yaml
+++ b/charts/enterprise/vaultwarden/values.yaml
@@ -95,7 +95,7 @@ vaultwarden:
     ## SMTP sender name, defaults to 'Bitwarden_RS'.
     # fromName: ""
     ## Enable SSL connection.
-    # tls: starttls
+    # security: starttls
     ## SMTP port. Defaults to 587 with STARTTLS, 465 with FORCE_TLS, and 25 without SSL.
     # port: 587
     ## SMTP Authentication Mechanisms. Comma-separated options: 'Plain', 'Login' and 'Xoauth2'. Defaults to 'Plain'.

--- a/charts/enterprise/vaultwarden/values.yaml
+++ b/charts/enterprise/vaultwarden/values.yaml
@@ -95,8 +95,8 @@ vaultwarden:
     ## SMTP sender name, defaults to 'Bitwarden_RS'.
     # fromName: ""
     ## Enable SSL connection.
-    # ssl: true
-    ## SMTP port. Defaults to 25 without SSL, 587 with SSL.
+    # ssl: starttls
+    ## SMTP port. Defaults to 587 with STARTTLS, 465 with FORCE_TLS, and 25 without SSL.
     # port: 587
     ## SMTP Authentication Mechanisms. Comma-separated options: 'Plain', 'Login' and 'Xoauth2'. Defaults to 'Plain'.
     # authMechanism: Plain

--- a/charts/enterprise/vaultwarden/values.yaml
+++ b/charts/enterprise/vaultwarden/values.yaml
@@ -95,7 +95,7 @@ vaultwarden:
     ## SMTP sender name, defaults to 'Bitwarden_RS'.
     # fromName: ""
     ## Enable SSL connection.
-    # ssl: starttls
+    # tls: starttls
     ## SMTP port. Defaults to 587 with STARTTLS, 465 with FORCE_TLS, and 25 without SSL.
     # port: 587
     ## SMTP Authentication Mechanisms. Comma-separated options: 'Plain', 'Login' and 'Xoauth2'. Defaults to 'Plain'.


### PR DESCRIPTION
**Description**
Old SMTP variable "SMTP_SSL" has been depreciated in favor of "SMTP_SECURITY"

⚒️ Fixes  #11967 

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [X] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

**📃 Notes:**

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
