### PR TITLE
minecraft-java fix issue

### DIFF
--- a/charts/stable/minecraft-java/Chart.yaml
+++ b/charts/stable/minecraft-java/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/minecraft-java
   - https://github.com/itzg/docker-minecraft-server
 type: application
-version: 5.0.1
+version: 5.0.2
 annotations:
   truecharts.org/catagories: |
     - games

--- a/charts/stable/minecraft-java/values.yaml
+++ b/charts/stable/minecraft-java/values.yaml
@@ -86,16 +86,25 @@ workload:
               type: exec
               command:
                 - mc-health
+              initialDelaySeconds: 20
+              periodSeconds: 10
+              failureThreshold: 12
             readiness:
               enabled: true
               type: exec
               command:
                 - mc-health
+              initialDelaySeconds: 20
+              periodSeconds: 10
+              failureThreshold: 12
             startup:
               enabled: true
               type: exec
               command:
                 - mc-health
+              initialDelaySeconds: 20
+              periodSeconds: 10
+              failureThreshold: 12
           env:
             SERVER_PORT: "{{ .Values.service.main.ports.main.port }}"
             QUERY_PORT: "{{ .Values.service.main.ports.query.port }}"


### PR DESCRIPTION
**Description**
`minecraft-java` cannot start due to the fact that the server opens the port later than the port availability is checked by the script `mc-health`
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I made a copy of your [charts](https://github.com/Dmitiry1921/catalog), manually changed the configuration in the right place as indicated by the author of the container in his discussion on [github](https://github.com/itzg/docker -minecraft-server/discussions/1591), added it to charts in my truenas scale.
I installed the application and the problem with endless deployment was solved.

**📃 Notes:**
bug [fix](https://github.com/itzg/docker-minecraft-server/discussions/1591)
**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

I may have upvoted the version of `minecraft-java` in the wrong place, if you see this when viewing the PR, please let me know and I'll fix it.


**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
