### PR TITLE
Add NET_RAW capability to pihole

### DIFF
--- a/charts/stable/pihole/Chart.yaml
+++ b/charts/stable/pihole/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/pi-hole
   - https://github.com/pi-hole/docker-pi-hole
 type: application
-version: 11.0.0
+version: 11.0.1
 annotations:
   truecharts.org/catagories: |
     - networking

--- a/charts/stable/pihole/values.yaml
+++ b/charts/stable/pihole/values.yaml
@@ -19,6 +19,7 @@ securityContext:
     capabilities:
       add:
         - NET_ADMIN
+        - NET_RAW
         - SETFCAP
         - SETPCAP
         - KILL


### PR DESCRIPTION
**Description**
Pi-hole DNS requires the `NET_RAW` capability, as listed here: https://github.com/pi-hole/docker-pi-hole#note-on-capabilities

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Tested locally using TrueNAS SCALE.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
