### PR TITLE
fix(docker-compose): postStart execution.

### DIFF
--- a/charts/stable/docker-compose/Chart.yaml
+++ b/charts/stable/docker-compose/Chart.yaml
@@ -20,7 +20,7 @@ name: docker-compose
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/docker-compose
 type: application
-version: 7.0.6
+version: 7.0.7
 annotations:
   truecharts.org/catagories: |
     - docker

--- a/charts/stable/docker-compose/questions.yaml
+++ b/charts/stable/docker-compose/questions.yaml
@@ -18,7 +18,7 @@ questions:
                                     attrs:
                                       - variable: COMPOSE_FILE
                                         label: Docker Compose File
-                                        description: Path on the host of the compose file you want to load. You MUST mount the storage yourself
+                                        description: Path of the compose file you want to load. You MUST mount the storage yourself
                                         schema:
                                           type: string
                                           default: ""

--- a/charts/stable/docker-compose/values.yaml
+++ b/charts/stable/docker-compose/values.yaml
@@ -61,7 +61,7 @@ workload:
                   fi
     type: StatefulSet
     replicas: 1
-    strategy: Recreate
+    strategy: RollingUpdate
 
 persistence:
   docker-certs-ca:

--- a/charts/stable/docker-compose/values.yaml
+++ b/charts/stable/docker-compose/values.yaml
@@ -23,25 +23,6 @@ service:
         port: 2376
         type: HTTPS
 
-lifecycle:
-  postStart:
-    exec:
-      command:
-        - /bin/bash
-        - -c
-        - |
-          if [ "${COMPOSE_FILE}" ]; then
-            counter=0;
-            while ! docker info > /dev/null 2>&1 && [[ ${counter} -lt 10 ]]; do
-              echo "docker not running yet. Waiting..." >> /proc/1/fd/1;
-              sleep 5;
-              counter=$((counter+1));
-            done
-            docker-compose -f "${COMPOSE_FILE}" up -d && echo "Loading COMPOSE_FILE at location ${COMPOSE_FILE}" >> /proc/1/fd/1;
-          else
-            echo "COMPOSE_FILE not set, not auto-loading compose-file" >> /proc/1/fd/1;
-          fi
-
 workload:
   main:
     podSpec:
@@ -60,7 +41,24 @@ workload:
           env:
             DOCKER_TLS_CERTDIR: /certs
             COMPOSE_FILE: ""
-
+          lifecycle:
+            postStart:
+              type: exec
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  if [ "${COMPOSE_FILE}" ]; then
+                    counter=0;
+                    while ! docker info > /dev/null 2>&1 && [[ ${counter} -lt 10 ]]; do
+                      echo "docker not running yet. Waiting..." >> /proc/1/fd/1;
+                      sleep 5;
+                      counter=$((counter+1));
+                    done
+                    docker-compose -f "${COMPOSE_FILE}" up -d && echo "Loading COMPOSE_FILE at location ${COMPOSE_FILE}" >> /proc/1/fd/1;
+                  else
+                    echo "COMPOSE_FILE not set, not auto-loading compose-file" >> /proc/1/fd/1;
+                  fi
     type: StatefulSet
     replicas: 1
     strategy: RollingUpdate

--- a/charts/stable/docker-compose/values.yaml
+++ b/charts/stable/docker-compose/values.yaml
@@ -21,7 +21,7 @@ service:
     ports:
       main:
         port: 2376
-        type: HTTPS
+        type: https
 
 workload:
   main:

--- a/charts/stable/docker-compose/values.yaml
+++ b/charts/stable/docker-compose/values.yaml
@@ -55,13 +55,13 @@ workload:
                       sleep 5;
                       counter=$((counter+1));
                     done
-                    docker-compose -f "${COMPOSE_FILE}" up -d && echo "Loading COMPOSE_FILE at location ${COMPOSE_FILE}" >> /proc/1/fd/1;
+                    docker-compose -f "${COMPOSE_FILE}" up -d && echo "Loaded COMPOSE_FILE at location ${COMPOSE_FILE}" >> /proc/1/fd/1;
                   else
                     echo "COMPOSE_FILE not set, not auto-loading compose-file" >> /proc/1/fd/1;
                   fi
     type: StatefulSet
     replicas: 1
-    strategy: RollingUpdate
+    strategy: Recreate
 
 persistence:
   docker-certs-ca:


### PR DESCRIPTION
**Description**
The docker-compose app is currently known to not properly launch on TrueNAS Scale. Discord is filled with suggestions to manually shell into the app and run `docker-compose up`. This is of course not a real solution.

Based on this documentation I have moved the `lifecycle` section in `values.yaml`: https://truecharts.org/manual/helm/common/container/lifecycle/

⚒️ Fixes  #6439 (possibly related issue)

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I have manually updated the `ix_values.yaml` in my `ix_applications` directory to test this change. The app now runs as expected.

**📃 Notes:**
I have very little knowledge of this entire system. I have only tested this on my "TrueNAS-SCALE-22.12.3.3" setup. If this app is supposed to run elsewhere, I haven't tested it, but I will mention that my changes are similar to what is already being done here in an unrelated app: https://github.com/truecharts/charts/blob/75ad318c2582cae175588c5b1741655ee73a6c32/charts/stable/piwigo/values.yaml#L31-L45

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning