### PR TITLE
Adding delay for startup probe in values.yaml of nginx_proxy_manager

### DIFF
--- a/charts/stable/nginx-proxy-manager/values.yaml
+++ b/charts/stable/nginx-proxy-manager/values.yaml
@@ -75,6 +75,8 @@ workload:
                 exec:
                   command:
                     - /bin/check-health
+                  initialDelaySeconds: 300
+                  periodSeconds: 30
           env:
             DISABLE_IPV6: true
             DB_MYSQL_PORT: 3306


### PR DESCRIPTION
**Description**
When the current version of nginx_proxy_manager is deployed as TrueNAS Scale App the bootup fails due to the fail of the startup probe. Probably the startup time of either the maridb or the nginx proxy manager itself is too long leading to a failure of the startup probe script. Adding an initialDelaySeconds of 300 leads to a successful boot of the app.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Changes were made locally on a TrueNAS-SCALE-22.12.3.3 machine until the App started. 

App Config:
WebUi port 10582 Service Type Loadbalancer
Webservice port 80 Service Type Loadbalancer
Websecure port 443 Service Type Loadbalancer
All other Config options default.

Webui of TrueNAS scale was set to 81 and 444. 
-->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas 
- [ ] 📄 I have made corresponding changes to the documentation (I think not necessary as no documentation exists)
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
