### PR TITLE
feat(plex): add plex-amd image

### DIFF
--- a/charts/stable/plex/Chart.yaml
+++ b/charts/stable/plex/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/plex
   - https://github.com/k8s-at-home/container-images/pkgs/container/plex
 type: application
-version: 14.0.1
+version: 14.0.2
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/plex/docs/installation_notes.md
+++ b/charts/stable/plex/docs/installation_notes.md
@@ -56,3 +56,5 @@ Plex allows for the installation of plug-ins. Plug-ins can be added using the co
 
 5. Restart Plex
 
+## Plex-AMD Image
+If you would like to be able to enable hardware encoding for an AMD GPU, then please use the Plex-AMD image.

--- a/charts/stable/plex/questions.yaml
+++ b/charts/stable/plex/questions.yaml
@@ -10,6 +10,16 @@ questions:
 # Include{replicas1}
 # Include{podSpec}
 # Include{containerMain}
+                                - variable: imageSelector
+                                  label: Select Image
+                                  schema:
+                                    type: string
+                                    default: image
+                                    enum:
+                                      - value: image
+                                        description: Plex Image
+                                      - value: plex-amdImage
+                                        description: Plex-AMD Image
                                 - variable: env
                                   group: App Configuration
                                   label: Image Environment

--- a/charts/stable/plex/values.yaml
+++ b/charts/stable/plex/values.yaml
@@ -2,6 +2,10 @@ image:
   repository: tccr.io/truecharts/plex
   pullPolicy: IfNotPresent
   tag: v1.32.6.7468@sha256:16d282e87aac706aed2cc446585ddc98210fd773823c9651c248a55b4863db99
+plex-amdImage:
+  repository: tccr.io/truecharts/plex-amd
+  pullPolicy: IfNotPresent
+  tag: 1.32.5.7328-2632c9d3a@sha256:UPDATEME
 service:
   main:
     ports:
@@ -27,6 +31,7 @@ workload:
     podSpec:
       containers:
         main:
+          imageSelector: image
           probes:
             liveness:
               enabled: true


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #7821
Add plex-amd to as a selection option for the plex-amd chart. Suggested by @xstar97. I used the minecraft-java chart and looked at how that was setup to create this chart. The plex-amd image allows you to transcode using AMD GPUs. Not ready for merge until the plex-amd container ends up in TCCR.
⚒️ **Next steps:**
1. Wait for `plex-amd` to be added to TCCR / Quay. truecharts/containers#30484.
2. Grab the digest from Quay and update it in the values.yml file. (Currently the digest is UPDATEME as a placeholder.)

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Untested.
**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [X] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [X] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [X] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
