### PR TITLE
feat(immich) add support for external library

### DIFF
--- a/charts/stable/immich/Chart.yaml
+++ b/charts/stable/immich/Chart.yaml
@@ -22,7 +22,7 @@ name: immich
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/immich
   - https://github.com/immich-app/immich
-version: 8.0.16
+version: 8.1.16
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/immich/questions.yaml
+++ b/charts/stable/immich/questions.yaml
@@ -137,6 +137,14 @@ questions:
             type: dict
             attrs:
 # Include{persistenceBasic}
+        - variable: externalLibrary
+          label: App External Library Storage
+          description: Stores the External Library.
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{persistenceBasic}
 # Include{persistenceList}
 # Include{ingressRoot}
         - variable: main

--- a/charts/stable/immich/questions.yaml
+++ b/charts/stable/immich/questions.yaml
@@ -137,7 +137,7 @@ questions:
             type: dict
             attrs:
 # Include{persistenceBasic}
-        - variable: externalLibrary
+        - variable: externallibrary
           label: App External Library Storage
           description: Stores the External Library.
           schema:

--- a/charts/stable/immich/values.yaml
+++ b/charts/stable/immich/values.yaml
@@ -168,7 +168,7 @@ persistence:
         main: {}
       microservices:
         microservices: {}
-  externalLibrary:
+  externallibrary:
     enabled: true
     mountPath: /mnt/media
     readOnly: true

--- a/charts/stable/immich/values.yaml
+++ b/charts/stable/immich/values.yaml
@@ -168,6 +168,16 @@ persistence:
         main: {}
       microservices:
         microservices: {}
+  externalLibrary:
+    enabled: true
+    mountPath: /mnt/media
+    readOnly: true
+    targetSelector:
+      # Main pod/container is server
+      main:
+        main: {}
+      microservices:
+        microservices: {}
 
 cnpg:
   main:

--- a/charts/stable/immich/values.yaml
+++ b/charts/stable/immich/values.yaml
@@ -170,8 +170,7 @@ persistence:
         microservices: {}
   externallibrary:
     enabled: true
-    mountPath: /mnt/media
-    readOnly: true
+    mountPath: /media
     targetSelector:
       # Main pod/container is server
       main:


### PR DESCRIPTION
**Description**
Immich provides the ability to add a readonly library instead of uploading each photo.
I just added an additional persistance config that gives the ability to mount into main and microservices simultaneously.
Here is the doc from immich for that feature (https://immich.app/docs/features/libraries)

⚒️ Fixes (https://github.com/truecharts/charts/issues/10202)

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

**📃 Notes:**

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`