### PR TITLE
fix(minecraft-bedrock) fix minecraft-bedrock eula gui option

### DIFF
--- a/charts/stable/minecraft-bedrock/Chart.yaml
+++ b/charts/stable/minecraft-bedrock/Chart.yaml
@@ -20,7 +20,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/minecraft-bedrock
   - https://github.com/itzg/docker-minecraft-server
 type: application
-version: 5.0.2
+version: 5.0.3
 annotations:
   truecharts.org/catagories: |
     - games

--- a/charts/stable/minecraft-bedrock/questions.yaml
+++ b/charts/stable/minecraft-bedrock/questions.yaml
@@ -18,10 +18,11 @@ questions:
                                     attrs:
                                       - variable: EULA
                                         label: Minecraft Eula
+                                        description: "Must be enabled to accept the Minecraft End User License Agreement."
                                         schema:
                                           type: boolean
                                           required: true
-                                          default: false
+                                          default: true
                                       - variable: ENABLE_LAN_VISIBILITY
                                         label: Enable Lan Visibility
                                         schema:


### PR DESCRIPTION
**Description**
Make the gui option eula default to true so users are not forced to reinstall their app from the previous PR/ app version

⚒️ Fixes  #12970

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
