### PR TITLE
fix(docs): Add upstream repo to Docs generator

### DIFF
--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -206,6 +206,8 @@ jobs:
                 echo "" >> website/docs/charts/${train}/${chart}/index.md
                 cat charts/${train}/${chart}/Chart.yaml | yq .description -r >> website/docs/charts/${train}/${chart}/index.md
                 echo "" >> website/docs/charts/${train}/${chart}/index.md
+                cat charts/${train}/${chart}/Chart.yaml | yq .sources -r >> website/docs/charts/${train}/${chart}/index.md
+                echo "" >> website/docs/charts/${train}/${chart}/index.md
                 echo "## Available Documentation" >> website/docs/charts/${train}/${chart}/index.md
                 echo "" >> website/docs/charts/${train}/${chart}/index.md
 

--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -206,6 +206,8 @@ jobs:
                 echo "" >> website/docs/charts/${train}/${chart}/index.md
                 cat charts/${train}/${chart}/Chart.yaml | yq .description -r >> website/docs/charts/${train}/${chart}/index.md
                 echo "" >> website/docs/charts/${train}/${chart}/index.md
+                echo "## Chart Sources" >> website/docs/charts/${train}/${chart}/index.md
+                echo "" >> website/docs/charts/${train}/${chart}/index.md
                 cat charts/${train}/${chart}/Chart.yaml | yq .sources -r >> website/docs/charts/${train}/${chart}/index.md
                 echo "" >> website/docs/charts/${train}/${chart}/index.md
                 echo "## Available Documentation" >> website/docs/charts/${train}/${chart}/index.md


### PR DESCRIPTION
**Description**

Our docs are missing the container source, so instead of searching GitHub for upstream containers/docs this at least points website users to what we have documented inside `Chart.yaml` as `sources

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
