### PR TITLE
fix(website-shot): Set correct runAsUser

### DIFF
--- a/charts/stable/website-shot/Chart.yaml
+++ b/charts/stable/website-shot/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "latest"
 dependencies:
   - name: common
     repository: https://library-charts.truecharts.org
-    version: 14.0.9
+    version: 14.0.14
 description: Generate a full web-page screenshot with our service, that provides rich interface to make any kind of web screenshots online for free with no limits. The simplest way to take a full page screenshot.
 home: https://truecharts.org/charts/stable/website-shot
 icon: https://truecharts.org/img/hotlink-ok/chart-icons/website-shot.png
@@ -18,7 +18,7 @@ name: website-shot
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/website-shot
   - https://github.com/Flowko/website-shot
-version: 6.0.1
+version: 7.0.0
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/website-shot/questions.yaml
+++ b/charts/stable/website-shot/questions.yaml
@@ -66,13 +66,13 @@ questions:
                 description: "The UserID of the user running the application"
                 schema:
                   type: int
-                  default: 568
+                  default: 0
               - variable: runAsGroup
                 label: "runAsGroup"
                 description: "The groupID this App of the user running the application"
                 schema:
                   type: int
-                  default: 568
+                  default: 0
 # Include{securityContextContainer}
 # Include{securityContextAdvanced}
 # Include{securityContextPod}

--- a/charts/stable/website-shot/questions.yaml
+++ b/charts/stable/website-shot/questions.yaml
@@ -66,13 +66,13 @@ questions:
                 description: "The UserID of the user running the application"
                 schema:
                   type: int
-                  default: 0
+                  default: 1000
               - variable: runAsGroup
                 label: "runAsGroup"
                 description: "The groupID this App of the user running the application"
                 schema:
                   type: int
-                  default: 0
+                  default: 1000
 # Include{securityContextContainer}
 # Include{securityContextAdvanced}
 # Include{securityContextPod}

--- a/charts/stable/website-shot/values.yaml
+++ b/charts/stable/website-shot/values.yaml
@@ -5,6 +5,7 @@ image:
 
 securityContext:
   container:
+    readOnlyRootFilesystem: false
     runAsGroup: 1000
     runAsUser: 1000
 

--- a/charts/stable/website-shot/values.yaml
+++ b/charts/stable/website-shot/values.yaml
@@ -6,9 +6,9 @@ image:
 securityContext:
   container:
     readOnlyRootFilesystem: false
-    runAsNonRoot: false
-    runAsGroup: 0
-    runAsUser: 0
+    runAsNonRoot: true
+    runAsGroup: 1000
+    runAsUser: 1000
 
 service:
   main:

--- a/charts/stable/website-shot/values.yaml
+++ b/charts/stable/website-shot/values.yaml
@@ -5,8 +5,6 @@ image:
 
 securityContext:
   container:
-    readOnlyRootFilesystem: false
-    runAsNonRoot: true
     runAsGroup: 1000
     runAsUser: 1000
 

--- a/charts/stable/website-shot/values.yaml
+++ b/charts/stable/website-shot/values.yaml
@@ -2,16 +2,26 @@ image:
   repository: tccr.io/truecharts/website-shot
   tag: latest@sha256:47d12e7af8330ae487d07a69500082b7c59182c6d9053a872169456ec337b017
   pullPolicy: IfNotPresent
+
+securityContext:
+  container:
+    readOnlyRootFilesystem: false
+    runAsNonRoot: false
+    runAsGroup: 0
+    runAsUser: 0
+
 service:
   main:
     ports:
       main:
         port: 10221
         targetPort: 3000
+
 persistence:
   screenshots:
     enabled: true
     mountPath: "/usr/src/website-shot/screenshots"
+
 portal:
   open:
     enabled: true


### PR DESCRIPTION
**Description**

As discord and verified by @ZasX it seems to need root privs to run

⚒️ Fixes  #13759

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [X] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
