### PR TITLE
fix(pgadmin): fix probes

### DIFF
--- a/charts/stable/pgadmin/Chart.yaml
+++ b/charts/stable/pgadmin/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/pgadmin
   - https://www.pgadmin.org/
 type: application
-version: 11.0.4
+version: 11.0.5
 annotations:
   truecharts.org/catagories: |
     - management

--- a/charts/stable/pgadmin/questions.yaml
+++ b/charts/stable/pgadmin/questions.yaml
@@ -22,14 +22,14 @@ questions:
                                         schema:
                                           type: string
                                           required: true
-                                          default: "REPLACETHIS"
+                                          default: "replace@this.now"
                                       - variable: PGADMIN_DEFAULT_PASSWORD
                                         label: "PGADMIN_DEFAULT_PASSWORD"
                                         schema:
                                           type: string
                                           required: true
                                           private: true
-                                          default: "REPLACETHIS"
+                                          default: "changeme"
 # Include{containerBasic}
 # Include{containerAdvanced}
 

--- a/charts/stable/pgadmin/values.yaml
+++ b/charts/stable/pgadmin/values.yaml
@@ -17,7 +17,7 @@ portal:
     enabled: true
 securityContext:
   container:
-    runAsNonRoot: false
+    runAsNonRoot: true
     readOnlyRootFilesystem: false
     runAsUser: 5050
     runAsGroup: 5050
@@ -27,6 +27,19 @@ workload:
     podSpec:
       containers:
         main:
+          probes:
+            liveness:
+              enabled: true
+              type: http
+              path: /misc/ping
+            readiness:
+              enabled: true
+              type: http
+              path: /misc/ping
+            startup:
+              enabled: true
+              type: http
+              path: /misc/ping
           env:
             PGADMIN_DEFAULT_EMAIL: "replace@this.now"
             PGADMIN_DEFAULT_PASSWORD: "changeme"


### PR DESCRIPTION
**Description**
The probes created a session file in the sessions folder every probe, so multiple files per minute. Over the course of a few months, it great to a few gigabytes for my install. Changing the probes to /misc/ping is the solution for kubernetes, as I read in a pgadmin github issue.

I changed runAsNonRoot to true, I don't know why it was set to false.

I also changed the defaults in questions.yaml to correspond to the placeholders in values.yaml.
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
