### PR TITLE
chore(youtubedl-material): manual version bump

### DIFF
--- a/charts/stable/youtubedl-material/Chart.yaml
+++ b/charts/stable/youtubedl-material/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "4.3"
+appVersion: "4.3.2"
 dependencies:
   - name: common
     repository: https://library-charts.truecharts.org
@@ -22,7 +22,7 @@ name: youtubedl-material
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/youtubedl-material
   - https://github.com/Tzahi12345/YoutubeDL-Material
-version: 6.0.4
+version: 6.0.5
 annotations:
   truecharts.org/category: media
   truecharts.org/SCALE-support: "true"

--- a/charts/stable/youtubedl-material/values.yaml
+++ b/charts/stable/youtubedl-material/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: tccr.io/truecharts/youtubedl-material
-  tag: v4.3@sha256:52ea916289823f2d239f1b375f9afbe4a075416c22020fc9e9765422ef58f7c9
+  tag: v4.3.2@sha256:a597f0411a3e34998fc87fc1f9a7bf94ba5e37db071c778cf60b032f34575a25
   pullPolicy: IfNotPresent
 security:
   PUID: 1000


### PR DESCRIPTION
**Description**
Chart seems stuck still after https://github.com/truecharts/containers/pull/33090 

⚒️ Fixes  #13749 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

**📃 Notes:**

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
