### PR TITLE
fix(clusterissuer): Fix http01 resource creation

### DIFF
--- a/charts/enterprise/clusterissuer/Chart.yaml
+++ b/charts/enterprise/clusterissuer/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/enterprise/clusterissuer
   - https://cert-manager.io/
 type: application
-version: 4.2.3
+version: 4.2.4
 annotations:
   truecharts.org/category: core
   truecharts.org/SCALE-support: "true"

--- a/charts/enterprise/clusterissuer/templates/clusterissuer/_ACME.tpl
+++ b/charts/enterprise/clusterissuer/templates/clusterissuer/_ACME.tpl
@@ -40,7 +40,7 @@ spec:
     solvers:
     {{- if eq .type "HTTP01" }}
     - http01:
-        ingress:
+        ingress: {}
     {{- else }}
     - dns01:
       {{- if eq .type "cloudflare" }}


### PR DESCRIPTION
Set {} for explicit empty yaml object

**Description**

Creation of clusterissuer with type http01 fails currently because of "...http01: Required value: no HTTP01 solver type configured."
This is fixed by this PR.

⚒️ Fixes  #10123

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

I created the resource manually, with "{}" it worked, otherwise not:
```yaml
---
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: letsencrypt-prod
spec:
  acme:
    email: dummy@dummy.de
    privateKeySecretRef:
      name: mv-letsencrypt
    server: https://acme-v02.api.letsencrypt.org/directory
    solvers:
      - http01:
          ingress: {}
````
Certificate was issued correctly afterwards, when I set cluster issuer e.g. in nextcloud app.


**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
