### PR TITLE
fix(SCALEGUI): set default path and prefix for ingress

### DIFF
--- a/charts/stable/jackett/Chart.yaml
+++ b/charts/stable/jackett/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/jackett
   - https://github.com/Jackett/Jackett
 type: application
-version: 16.0.2
+version: 16.0.3
 annotations:
   truecharts.org/category: media
   truecharts.org/SCALE-support: "true"

--- a/templates/questions/ingress/ingressDefault.yaml
+++ b/templates/questions/ingress/ingressDefault.yaml
@@ -27,7 +27,7 @@
                                   label: Paths
                                   schema:
                                     type: list
-                                    default: []
+                                    default: [{path: "/", pathType: "Prefix"}]
                                     items:
                                       - variable: pathEntry
                                         label: Host


### PR DESCRIPTION
**Description**
SCALE GUI now supports proper list defaults.
This should fill it correctly for ingress paths

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
