### PR TITLE
feat(SCALE GUI): add GUI for Static PV PVC bindings and readd storageClass option

### DIFF
--- a/templates/questions/persistence/persistenceBasic.yaml
+++ b/templates/questions/persistence/persistenceBasic.yaml
@@ -93,7 +93,7 @@
                   type: string
                   default: 256Gi
               - variable: static
-                label: Static Fixed PVC Bindings
+                label: Static Fixed PVC Bindings (Experimental)
                 description: Link a PVC to a specific storage location
                 schema:
                   show_if: [["type", "=", "pvc"]]

--- a/templates/questions/persistence/persistenceBasic.yaml
+++ b/templates/questions/persistence/persistenceBasic.yaml
@@ -92,3 +92,62 @@
                   show_if: [["type", "=", "pvc"]]
                   type: string
                   default: 256Gi
+              - variable: static
+                label: Static Fixed PVC Bindings
+                description: Link a PVC to a specific storage location
+                schema:
+                  show_if: [["type", "=", "pvc"]]
+                  type: dict
+                  additional_attrs: true
+                  attrs:
+                    - variable: mode
+                      label: mode
+                      description: |
+                        disabled: use normal dynamic PVCs
+                        smb: connect to an SMB share
+                        nfs: connect to an NFS share
+                      schema:
+                        type: string
+                        default: "disabled"
+                        enum:
+                          - value: "disabled"
+                            description: disabled
+                          - value: smb
+                            description: smb
+                          - variable: nfs
+                            label: nfs
+                    - variable: server
+                      label: Server
+                      description: server to connect to
+                      schema:
+                        type: string
+                        show_if: [["mode", "!=", "disabled"]]
+                        default: "myserver"
+                    - variable: share
+                      label: Share
+                      description: share to connect to
+                      schema:
+                        type: string
+                        show_if: [["mode", "!=", "disabled"]]
+                        default: "/myshare"
+                    - variable: user
+                      label: User
+                      description: connecting user
+                      schema:
+                        type: string
+                        show_if: [["mode", "=", "smb"]]
+                        default: "myuser"
+                    - variable: domain
+                      label: Domain
+                      description: user domain
+                      schema:
+                        type: string
+                        show_if: [["mode", "=", "smb"]]
+                        default: ""
+                    - variable: password
+                      label: Password
+                      description: connecting password
+                      schema:
+                        type: string
+                        show_if: [["mode", "=", "smb"]]
+                        default: ""

--- a/templates/questions/persistence/persistenceBasic.yaml
+++ b/templates/questions/persistence/persistenceBasic.yaml
@@ -92,6 +92,13 @@
                   show_if: [["type", "=", "pvc"]]
                   type: string
                   default: 256Gi
+              - variable: storageClass
+                label: storageClass (Advanced)
+                description: sets the storageClass to something other than iX default. Only for advanced usecases!
+                schema:
+                  show_if: [["type", "=", "pvc"]]
+                  type: string
+                  default: ""
               - variable: static
                 label: Static Fixed PVC Bindings (Experimental)
                 description: Link a PVC to a specific storage location

--- a/templates/questions/persistence/persistenceList.yaml
+++ b/templates/questions/persistence/persistenceList.yaml
@@ -118,3 +118,69 @@
                   show_if: [["type", "=", "pvc"]]
                   type: string
                   default: 256Gi
+              - variable: storageClass
+                label: storageClass (Advanced)
+                description: sets the storageClass to something other than iX default. Only for advanced usecases!
+                schema:
+                  show_if: [["type", "=", "pvc"]]
+                  type: string
+                  default: ""
+              - variable: static
+                label: Static Fixed PVC Bindings (Experimental)
+                description: Link a PVC to a specific storage location
+                schema:
+                  show_if: [["type", "=", "pvc"]]
+                  type: dict
+                  additional_attrs: true
+                  attrs:
+                    - variable: mode
+                      label: mode
+                      description: |
+                        disabled: use normal dynamic PVCs
+                        smb: connect to an SMB share
+                        nfs: connect to an NFS share
+                      schema:
+                        type: string
+                        default: "disabled"
+                        enum:
+                          - value: "disabled"
+                            description: disabled
+                          - value: smb
+                            description: smb
+                          - variable: nfs
+                            label: nfs
+                    - variable: server
+                      label: Server
+                      description: server to connect to
+                      schema:
+                        type: string
+                        show_if: [["mode", "!=", "disabled"]]
+                        default: "myserver"
+                    - variable: share
+                      label: Share
+                      description: share to connect to
+                      schema:
+                        type: string
+                        show_if: [["mode", "!=", "disabled"]]
+                        default: "/myshare"
+                    - variable: user
+                      label: User
+                      description: connecting user
+                      schema:
+                        type: string
+                        show_if: [["mode", "=", "smb"]]
+                        default: "myuser"
+                    - variable: domain
+                      label: Domain
+                      description: user domain
+                      schema:
+                        type: string
+                        show_if: [["mode", "=", "smb"]]
+                        default: ""
+                    - variable: password
+                      label: Password
+                      description: connecting password
+                      schema:
+                        type: string
+                        show_if: [["mode", "=", "smb"]]
+                        default: ""


### PR DESCRIPTION
**Description**
This adds gui options to use the future static pv-pvc bindings on TrueNAS SCALE

⚒️ Fixes  #14528

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [x] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [x] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
