### PR TITLE
feat(plex): default to ram transcodes

### DIFF
--- a/charts/stable/plex/Chart.yaml
+++ b/charts/stable/plex/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/plex
   - https://github.com/k8s-at-home/container-images/pkgs/container/plex
 type: application
-version: 14.0.13
+version: 14.1.0
 annotations:
   truecharts.org/category: media
   truecharts.org/SCALE-support: "true"

--- a/charts/stable/plex/values.yaml
+++ b/charts/stable/plex/values.yaml
@@ -14,6 +14,13 @@ persistence:
   config:
     enabled: true
     mountPath: "/config"
+  transcode:
+    enabled: true
+    mountPath: "/transcode"
+    type: emptyDir
+    medium: Memory
+    size: "{{ $.Values.resources.limits.memory }}"
+    targetSelectAll: true
 
 plex:
   # User Defined


### PR DESCRIPTION
**Description**
Currently we transcode to... somewhere, not really clear as `/transcode` shouldn't even be writeable.
With this we make `/transcode` writeable and put all data there into ram.

Plex should be able to handle detecting the size of `/transcode` and start eviciting chunks when it nears max size, hence the max size is set the the ram limit specified in `.Values.resources`

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**

Not making this configurable on SCALE, SCALE machines should have plenty of ram and just should start evicing a bit of ARC when this ramdisk start to grow.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [x] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [x] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
