### PR TITLE
Fixing metrics

### DIFF
--- a/charts/stable/lidarr/Chart.yaml
+++ b/charts/stable/lidarr/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/lidarr
   - https://github.com/Lidarr/Lidarr
 type: application
-version: 17.0.20
+version: 17.0.21
 annotations:
   truecharts.org/category: media
   truecharts.org/SCALE-support: "true"

--- a/charts/stable/lidarr/values.yaml
+++ b/charts/stable/lidarr/values.yaml
@@ -105,6 +105,7 @@ metrics:
     endpoints:
       - port: metrics
         path: /metrics
+    targetSelector: metrics
     prometheusRule:
       enabled: false
 

--- a/charts/stable/prowlarr/Chart.yaml
+++ b/charts/stable/prowlarr/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/prowlarr
   - https://github.com/Prowlarr/Prowlarr
   - https://github.com/k8s-at-home/container-images
-version: 12.0.24
+version: 12.0.25
 annotations:
   truecharts.org/category: media
   truecharts.org/SCALE-support: "true"

--- a/charts/stable/prowlarr/values.yaml
+++ b/charts/stable/prowlarr/values.yaml
@@ -96,6 +96,7 @@ metrics:
     endpoints:
       - port: metrics
         path: /metrics
+    targetSelector: metrics
     prometheusRule:
       enabled: false
 

--- a/charts/stable/radarr/Chart.yaml
+++ b/charts/stable/radarr/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/radarr
   - https://github.com/Radarr/Radarr
 type: application
-version: 17.0.15
+version: 17.0.16
 annotations:
   truecharts.org/category: media
   truecharts.org/SCALE-support: "true"

--- a/charts/stable/radarr/values.yaml
+++ b/charts/stable/radarr/values.yaml
@@ -104,6 +104,7 @@ metrics:
     endpoints:
       - port: metrics
         path: /metrics
+    targetSelector: metrics
     prometheusRule:
       enabled: false
 

--- a/charts/stable/readarr/Chart.yaml
+++ b/charts/stable/readarr/Chart.yaml
@@ -25,7 +25,7 @@ sources:
   - https://github.com/Readarr/Readarr
   - https://readarr.com
 type: application
-version: 17.0.19
+version: 17.0.20
 annotations:
   truecharts.org/category: media
   truecharts.org/SCALE-support: "true"

--- a/charts/stable/readarr/values.yaml
+++ b/charts/stable/readarr/values.yaml
@@ -105,6 +105,7 @@ metrics:
     endpoints:
       - port: metrics
         path: /metrics
+    targetSelector: metrics
     prometheusRule:
       enabled: false
 

--- a/charts/stable/sonarr/Chart.yaml
+++ b/charts/stable/sonarr/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/sonarr
   - https://github.com/Sonarr/Sonarr
 type: application
-version: 16.0.9
+version: 16.0.10
 annotations:
   truecharts.org/category: media
   truecharts.org/SCALE-support: "true"

--- a/charts/stable/sonarr/values.yaml
+++ b/charts/stable/sonarr/values.yaml
@@ -120,6 +120,7 @@ metrics:
     endpoints:
       - port: metrics
         path: /metrics
+    targetSelector: metrics
     prometheusRule:
       enabled: false
 

--- a/charts/stable/uptime-kuma/Chart.yaml
+++ b/charts/stable/uptime-kuma/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/uptime-kuma
   - https://github.com/louislam/uptime-kuma
 type: application
-version: 7.0.13
+version: 7.0.14
 annotations:
   truecharts.org/category: monitoring
   truecharts.org/SCALE-support: "true"

--- a/charts/stable/uptime-kuma/values.yaml
+++ b/charts/stable/uptime-kuma/values.yaml
@@ -21,7 +21,7 @@ metrics:
     enabled: true
     type: "servicemonitor"
     endpoints:
-      - port: metrics
+      - port: main
         path: /metrics
     prometheusRule:
       enabled: false


### PR DESCRIPTION
**Description**
Several *arr applications support metrics. However, they were missing a `targetSelector` that points the `ServiceMonitor` resource to the correct `service` which is named `metrics`.

It also fixes a bug for uptime-kuma where the metrics configuration points to the port named `metrics` which does not exist. The metrics for uptime-kuma are exposed via the regular service on the `main` port.

⚒️ Fixes  #14468

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Manually applied the changes to the `ServiceMonitor` resources using `kubectl patch` to see if the metrics started working. They did, so these changes will ensure the `ServiceMonitor` resources will be deployed with the right `matchLabels` and `port` values.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
