### PR TITLE
Adding option for Certissuer cabundle with custom ACME Server.

### DIFF
--- a/charts/enterprise/clusterissuer/questions.yaml
+++ b/charts/enterprise/clusterissuer/questions.yaml
@@ -73,6 +73,12 @@ questions:
                         type: string
                         show_if: [["server", "=", "custom"]]
                         default: 'https://acme-staging-v02.api.letsencrypt.org/directory'
+                    - variable: caBundle
+                      label: Trusted CA for private ACME server
+                      description: "CABundle for private ACME server, in base 64"
+                      schema:
+                        type: string
+                        show_if: [["server", "=", "custom"]]
                     - variable: email
                       label: Email
                       description: "Email adress to use for certificate issuing must match your DNS provider email when required"

--- a/charts/enterprise/clusterissuer/questions.yaml
+++ b/charts/enterprise/clusterissuer/questions.yaml
@@ -74,8 +74,8 @@ questions:
                         show_if: [["server", "=", "custom"]]
                         default: 'https://acme-staging-v02.api.letsencrypt.org/directory'
                     - variable: caBundle
-                      label: Trusted CA for private ACME server
-                      description: "CABundle for private ACME server, in base 64"
+                      label: Trusted CABundle for private ACME server
+                      description: "Trusted CABundle for private ACME server, encoded in base64"
                       schema:
                         type: string
                         show_if: [["server", "=", "custom"]]

--- a/charts/enterprise/clusterissuer/templates/clusterissuer/_ACME.tpl
+++ b/charts/enterprise/clusterissuer/templates/clusterissuer/_ACME.tpl
@@ -35,6 +35,9 @@ spec:
   acme:
     email: {{ .email }}
     server: {{ if eq .server "custom" }}{{ .customServer }}{{ else }}{{ .server }}{{ end }}
+    {{- if .caBundle }}
+    caBundle: {{ .caBundle }}
+    {{- end }}
     privateKeySecretRef:
       name: {{ .name }}-acme-clusterissuer-account-key
     solvers:


### PR DESCRIPTION
**Description**

⚒️ Fixes  #11300

I've added a string field to specify the CABundle when using a custom private ACME server.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I've deployed the change on my truenas k8s cluster and tested it with success.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
