### PR TITLE
fix(minecraft-java): remove query port question

### DIFF
--- a/charts/stable/minecraft-java/Chart.yaml
+++ b/charts/stable/minecraft-java/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/minecraft-java
   - https://github.com/itzg/docker-minecraft-server
 type: application
-version: 5.0.11
+version: 5.0.12
 annotations:
   truecharts.org/category: games
   truecharts.org/SCALE-support: "true"

--- a/charts/stable/minecraft-java/questions.yaml
+++ b/charts/stable/minecraft-java/questions.yaml
@@ -647,19 +647,6 @@ questions:
                               type: int
                               default: 25565
                               required: true
-                    - variable: query
-                      label: Query Service Port Configuration
-                      schema:
-                        additional_attrs: true
-                        type: dict
-                        attrs:
-                          - variable: port
-                            label: Port
-                            description: This port exposes the container port on the service
-                            schema:
-                              type: int
-                              default: 25565
-                              required: true
         - variable: rcon
           label: RCON Service
           description: The RCON service.

--- a/charts/stable/minecraft-java/values.yaml
+++ b/charts/stable/minecraft-java/values.yaml
@@ -65,7 +65,7 @@ service:
       query:
         enabled: true
         protocol: udp
-        port: 25565
+        port: "{{ .Values.service.main.ports.main.port }}"
   rcon:
     enabled: true
     ports:


### PR DESCRIPTION
**Description**
Removes query port question. Sets automatically with main service port. @xstar97 confirms both ports should be set the same.

⚒️ Fixes  # 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

**📃 Notes:**

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
