### PR TITLE
feat(SCALE): Add codeserver ingress GUI

### DIFF
--- a/templates/questions/addons/codeserver.yaml
+++ b/templates/questions/addons/codeserver.yaml
@@ -54,6 +54,157 @@
                                         schema:
                                           type: int
                                           default: 36107
+                    - variable: ingress
+                      label:  "Ingress"
+                      schema:
+                        additional_attrs: true
+                        type: dict
+                        attrs:
+                          - variable: enabled
+                            label: Enable Ingress
+                            schema:
+                              type: boolean
+                              default: false
+                              show_subquestions_if: true
+                              subquestions:
+                                - variable: hosts
+                                  label: Hosts
+                                  schema:
+                                    type: list
+                                    default: []
+                                    items:
+                                      - variable: hostEntry
+                                        label: Host
+                                        schema:
+                                          additional_attrs: true
+                                          type: dict
+                                          attrs:
+                                            - variable: host
+                                              label: HostName
+                                              schema:
+                                                type: string
+                                                default: ""
+                                                required: true
+                                            - variable: paths
+                                              label: Paths
+                                              schema:
+                                                type: list
+                                                default: [{path: "/", pathType: "Prefix"}]
+                                                items:
+                                                  - variable: pathEntry
+                                                    label: Host
+                                                    schema:
+                                                      additional_attrs: true
+                                                      type: dict
+                                                      attrs:
+                                                        - variable: path
+                                                          label: Path
+                                                          schema:
+                                                            type: string
+                                                            required: true
+                                                            default: "/"
+                                                        - variable: pathType
+                                                          label: Path Type
+                                                          schema:
+                                                            type: string
+                                                            required: true
+                                                            default: Prefix
+                                - variable: certificateIssuer
+                                  label: Cert-Manager clusterIssuer
+                                  description: 'add the name of your cert-manager clusterIssuer here for automatic tls certificates. Cannot be used combined with tls option below'
+                                  schema:
+                                    type: string
+                                    default: ""
+                                - variable: middlewares
+                                  label: Traefik Middlewares
+                                  description: Add previously created Traefik Middlewares to this Ingress
+                                  schema:
+                                    type: list
+                                    default: []
+                                    items:
+                                      - variable: name
+                                        label: Name
+                                        schema:
+                                          type: string
+                                          default: ""
+                                          required: true
+                                - variable: advanced
+                                  label: Show Advanced Settings
+                                  description: Advanced settings are not covered by TrueCharts Support
+                                  schema:
+                                    type: boolean
+                                    default: false
+                                - variable: entrypoint
+                                  label: (Advanced) Traefik Entrypoint
+                                  description: Entrypoint used by Traefik when using Traefik as Ingress Provider
+                                  schema:
+                                    type: string
+                                    default: websecure
+                                    show_if: [["advanced", "=", true]]
+                                    required: true
+                                - variable: allowCors
+                                  label: "Allow Cross Origin Requests"
+                                  schema:
+                                    type: boolean
+                                    show_if: [["advanced", "=", true]]
+                                    default: false
+                                - variable: ingressClassName
+                                  label: (Advanced/Optional) IngressClass Name
+                                  schema:
+                                    type: string
+                                    show_if: [["advanced", "=", true]]
+                                    default: ""
+                                - variable: tls
+                                  label: TLS-Settings
+                                  schema:
+                                    type: list
+                                    show_if: [["advanced", "=", true]]
+                                    default: []
+                                    items:
+                                      - variable: tlsEntry
+                                        label: Host
+                                        schema:
+                                          additional_attrs: true
+                                          type: dict
+                                          attrs:
+                                            - variable: hosts
+                                              label: Certificate Hosts
+                                              schema:
+                                                type: list
+                                                default: []
+                                                items:
+                                                  - variable: host
+                                                    label: Host
+                                                    schema:
+                                                      type: string
+                                                      default: ""
+                                                      required: true
+                                            - variable: certificateIssuer
+                                              label: Use Cert-Manager clusterIssuer
+                                              description: 'add the name of your cert-manager clusterIssuer here for automatic tls certificates.'
+                                              schema:
+                                                type: string
+                                                default: ""
+                                            - variable: clusterCertificate
+                                              label:  'Cluster Certificate (Advanced)'
+                                              description: 'Add the name of your cluster-wide certificate, that you set up in the ClusterIssuer chart.'
+                                              schema:
+                                                type: string
+                                                show_if: [["certificateIssuer", "=", ""]]
+                                                default: ""
+                                            - variable: secretName
+                                              label: 'Use Custom Certificate Secret (Advanced)'
+                                              schema:
+                                                show_if: [["certificateIssuer", "=", ""]]
+                                                type: string
+                                                default: ""
+                                            - variable: scaleCert
+                                              label: 'Use TrueNAS SCALE Certificate (Deprecated)'
+                                              schema:
+                                                show_if: [["certificateIssuer", "=", ""]]
+                                                type: int
+                                                $ref:
+                                                  - "definitions/certificate"
                     - variable: envList
                       label: Codeserver Environment Variables
                       schema:


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

Adds ingress GUI for Codeserver.

I pretty much generated a chart's `questions.yaml` and copied over the main ingress section (with some small modifications). Let me know if there is a 'smarter' way to do this.

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Tested this on a SCALE system, with the Recyclarr chart (see notes). Overall seems to work fine. I managed to add an ingress to the Codeserver addon and use it to access its service.

I also compared the YAML of the created addon ingress against the YAML of the main ingress of another chart. They seem identical (minus expected differences such as names and such).

**📃 Notes:**
<!-- Please enter any other relevant information here -->
A few caveats worth mentioning (not related to but affecting this PR):

1. There is a fairly recent patch fixing a bug with the Codeserver addon ingress (https://github.com/truecharts/library-charts/pull/615). Some charts have not received the Common update yet (Recyclarr hasn't). I had to manually change the Common version in Recyclarr's `Chart.yaml` and do a `helm dep update` in order to test my changes. So it is probably a good idea to wait until all apps get the Common update before we merge this.

2.  I am not sure if this is a bug or a feature, but when I enabled the Codeserver addon for Recyclarr, and checked the service name with `kubectl` I got this:
```bash
# k3s kubectl get service -n ix-recyclarr
NAME             TYPE           CLUSTER-IP      EXTERNAL-IP       PORT(S)     AGE
recyclarr        LoadBalancer   172.17.57.246   192.168.123.123   36107/TCP   71s
```
However, the Codeserver ingress assumes the name of the service to be `$APPNAME-codeserver`:

https://github.com/truecharts/library-charts/blob/9a1f204c501500d75fe76ec82cb9ee4182f2aa94/library/common/templates/addons/code-server/_codeserver.tpl#L43

So to test my changes I had to manually edit the service name in the created ingress to match. 

I believe this is a bug with common but I am not sure.

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
