### PR TITLE
fix(actualserver): update chart with the right image

### DIFF
--- a/charts/stable/actualserver/Chart.yaml
+++ b/charts/stable/actualserver/Chart.yaml
@@ -1,8 +1,8 @@
 kubeVersion: '>=1.24.0'
 apiVersion: v2
 name: actualserver
-version: 5.0.13
-appVersion: 23.10.0
+version: 5.0.14
+appVersion: 23.12.0
 description: Actual is a super fast privacy-focused app for managing your finances.
 home: https://truecharts.org/charts/stable/actualserver
 icon: https://truecharts.org/img/hotlink-ok/chart-icons/actualserver.png
@@ -10,7 +10,7 @@ deprecated: false
 sources:
 - https://github.com/Kippenhof/docker-templates
 - https://github.com/truecharts/charts/tree/master/charts/stable/actualserver
-- https://hub.docker.com/r/jlongster/actual-server
+- https://hub.docker.com/r/actualbudget/actual-server
 maintainers:
 - name: TrueCharts
   email: info@truecharts.org

--- a/charts/stable/actualserver/values.yaml
+++ b/charts/stable/actualserver/values.yaml
@@ -1,7 +1,7 @@
 image:
-  repository: jlongster/actual-server
+  repository: ghcr.io/actualbudget/actual-server
   pullPolicy: IfNotPresent
-  tag: 23.10.0@sha256:43f321864f98e7b9759507853e0e64908bb844305bbe72a3ffc893c42b962495
+  tag: 23.12.0@sha256:401774fad59c694946ba552763f52b725d4b2946f83f433191a26c30487e75b2
 securityContext:
   container:
     readOnlyRootFilesystem: false


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

The [`actualserver`](https://github.com/truecharts/charts/tree/master/charts/stable/actualserver) chart is using [this image](https://hub.docker.com/r/jlongster/actual-server), but releases are now done [here](https://github.com/actualbudget/actual-server/pkgs/container/actual-server) and [here](https://hub.docker.com/r/actualbudget/actual-server). As such, this PR updates the image to the correct one, as well as updating the app version.

⚒️ Fixes  #15628

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

I'm honestly unsure how to test chart modifications, but if needed, I'll figure out a way. I do know the new image is correct, as I have deployed it on my local machine for testing.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
