### PR TITLE
feat(SCALE-GUI): add iscsi support to storage GUI

### DIFF
--- a/charts/stable/jackett/Chart.yaml
+++ b/charts/stable/jackett/Chart.yaml
@@ -21,7 +21,7 @@ keywords:
   - usenet
 dependencies:
   - name: common
-    version: 14.3.5
+    version: 14.3.6
     repository: https://library-charts.truecharts.org
     condition: ""
     alias: ""

--- a/templates/questions/persistence/persistenceBasic.yaml
+++ b/templates/questions/persistence/persistenceBasic.yaml
@@ -13,6 +13,8 @@
                       description: emptyDir
                     - value: nfs
                       description: NFS Share
+                    - value: iscsi
+                      description: iSCSI Share
               - variable: server
                 label: NFS Server
                 schema:
@@ -25,6 +27,83 @@
                   show_if: [["type", "=", "nfs"]]
                   type: string
                   default: ""
+              - variable: iscsi
+                label: iSCSI Options
+                schema:
+                  show_if: [["type", "=", "iscsi"]]
+                  type: dict
+                  additional_attrs: true
+                  attrs:
+                    - variable: targetPortal
+                      label: targetPortal
+                      schema:
+                        type: string
+                        required: true
+                        default: ""
+                    - variable: iqn
+                      label: iqn
+                      schema:
+                        type: string
+                        required: true
+                        default: ""
+                    - variable: lun
+                      label: lun
+                      schema:
+                        type: int
+                        default: 0
+                    - variable: authSession
+                      label: authSession
+                      schema:
+                        type: dict
+                        additional_attrs: true
+                        attrs:
+                          - variable: username
+                            label: username
+                            schema:
+                              type: string
+                              default: ""
+                          - variable: password
+                            label: password
+                            schema:
+                              type: string
+                              default: ""
+                          - variable: usernameInitiator
+                            label: usernameInitiator
+                            schema:
+                              type: string
+                              default: ""
+                          - variable: passwordInitiator
+                            label: passwordInitiator
+                            schema:
+                              type: string
+                              default: ""
+                    - variable: authDiscovery
+                      label: authDiscovery
+                      schema:
+                        type: dict
+                        additional_attrs: true
+                        attrs:
+                          - variable: username
+                            label: username
+                            schema:
+                              type: string
+                              default: ""
+                          - variable: password
+                            label: password
+                            schema:
+                              type: string
+                              default: ""
+                          - variable: usernameInitiator
+                            label: usernameInitiator
+                            schema:
+                              type: string
+                              default: ""
+                          - variable: passwordInitiator
+                            label: passwordInitiator
+                            schema:
+                              type: string
+                              default: ""
+
               - variable: autoPermissions
                 label: Automatic Permissions Configuration
                 description: Automatically set permissions
@@ -117,7 +196,7 @@
                         type: string
                         default: "disabled"
                         enum:
-                          - value: "disabled"
+                          - value: disabled
                             description: disabled
                           - value: smb
                             description: smb

--- a/templates/questions/persistence/persistenceList.yaml
+++ b/templates/questions/persistence/persistenceList.yaml
@@ -44,6 +44,82 @@
                   show_if: [["type", "=", "nfs"]]
                   type: string
                   default: ""
+              - variable: iscsi
+                label: iSCSI Options
+                schema:
+                  show_if: [["type", "=", "iscsi"]]
+                  type: dict
+                  additional_attrs: true
+                  attrs:
+                    - variable: targetPortal
+                      label: targetPortal
+                      schema:
+                        type: string
+                        required: true
+                        default: ""
+                    - variable: iqn
+                      label: iqn
+                      schema:
+                        type: string
+                        required: true
+                        default: ""
+                    - variable: lun
+                      label: lun
+                      schema:
+                        type: int
+                        default: 0
+                    - variable: authSession
+                      label: authSession
+                      schema:
+                        type: dict
+                        additional_attrs: true
+                        attrs:
+                          - variable: username
+                            label: username
+                            schema:
+                              type: string
+                              default: ""
+                          - variable: password
+                            label: password
+                            schema:
+                              type: string
+                              default: ""
+                          - variable: usernameInitiator
+                            label: usernameInitiator
+                            schema:
+                              type: string
+                              default: ""
+                          - variable: passwordInitiator
+                            label: passwordInitiator
+                            schema:
+                              type: string
+                              default: ""
+                    - variable: authDiscovery
+                      label: authDiscovery
+                      schema:
+                        type: dict
+                        additional_attrs: true
+                        attrs:
+                          - variable: username
+                            label: username
+                            schema:
+                              type: string
+                              default: ""
+                          - variable: password
+                            label: password
+                            schema:
+                              type: string
+                              default: ""
+                          - variable: usernameInitiator
+                            label: usernameInitiator
+                            schema:
+                              type: string
+                              default: ""
+                          - variable: passwordInitiator
+                            label: passwordInitiator
+                            schema:
+                              type: string
+                              default: ""
               - variable: autoPermissions
                 label: Automatic Permissions Configuration
                 description: Automatically set permissions


### PR DESCRIPTION
**Description**
This adds iSCSI mountpoints as a storage option to the SCALE GUI.
Though there is no common support merged yet.

Will become functional in january.

⚒️ Fixes  #14845

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
