### PR TITLE
feat(SCALE-GUI): add support for imagepullsecrets

### DIFF
--- a/charts/stable/jackett/Chart.yaml
+++ b/charts/stable/jackett/Chart.yaml
@@ -21,7 +21,7 @@ keywords:
   - usenet
 dependencies:
   - name: common
-    version: 14.3.5
+    version: 14.3.6
     repository: https://library-charts.truecharts.org
     condition: ""
     alias: ""

--- a/templates/questions/general/podOptions.yaml
+++ b/templates/questions/general/podOptions.yaml
@@ -66,3 +66,41 @@
                             schema:
                               type: string
                               required: true
+
+  - variable: imagePullSecretList
+    group: "General Settings"
+    label: "Image Pull Secrets"
+    schema:
+      type: list
+      default: []
+      items:
+        - variable: pullsecretentry
+          label: "Pull Secret"
+          schema:
+            type: dict
+            additional_attrs: true
+            attrs:
+              - variable: registry
+                label: "Registry"
+                schema:
+                  type: string
+                  required: true
+                  default: "https://index.docker.io/v1/"
+              - variable: username
+                label: "Username"
+                schema:
+                  type: string
+                  required: true
+                  default: ""
+              - variable: password
+                label: "Password"
+                schema:
+                  type: string
+                  required: true
+                  default: ""
+              - variable: email
+                label: "Email"
+                schema:
+                  type: string
+                  required: true
+                  default: ""


### PR DESCRIPTION
**Description**
With moving to directly referencing dockerhub images, we really need to add imagepullsecrets in the GUI to prevent users from hitting rate limits.

Will start working next common release in januari 2024, not working yet atm.

⚒️ Fixes  #14811

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
