### PR TITLE
[feat] Add "nvidia" variant for dizqueTV

### DIFF
--- a/charts/stable/dizquetv/CHANGELOG.md
+++ b/charts/stable/dizquetv/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [dizquetv-8.1.0](https://github.com/truecharts/charts/compare/dizquetv-8.0.0...dizquetv-8.1.0) (2023-12-14)
+
+### Chore
+
+- Add "nvidia" variant
 
 
 ## [dizquetv-8.0.0](https://github.com/truecharts/charts/compare/dizquetv-7.0.43...dizquetv-8.0.0) (2022-11-10)

--- a/charts/stable/dizquetv/Chart.yaml
+++ b/charts/stable/dizquetv/Chart.yaml
@@ -1,7 +1,7 @@
 kubeVersion: ">=1.24.0-0"
 apiVersion: v2
 name: dizquetv
-version: 11.0.12
+version: 11.1.0
 appVersion: 1.5.3
 description: Create live TV channel streams from media on your Plex servers.
 home: https://truecharts.org/charts/stable/dizquetv

--- a/charts/stable/dizquetv/questions.yaml
+++ b/charts/stable/dizquetv/questions.yaml
@@ -4,6 +4,17 @@ portals:
 # Include{portalLink}
 questions:
 # Include{global}
+  - variable: imageSelector
+    group: Container Image
+    label: Select Image
+    schema:
+      type: string
+      default: image
+      enum:
+        - value: image
+          description: Default
+        - value: nvidiaImage
+          description: Nvidia
 # Include{workload}
 # Include{workloadDeployment}
 

--- a/charts/stable/dizquetv/values.yaml
+++ b/charts/stable/dizquetv/values.yaml
@@ -1,7 +1,19 @@
 image:
-  repository: vexorian/dizquetv
   pullPolicy: IfNotPresent
+  repository: vexorian/dizquetv
   tag: 1.5.3@sha256:f93b5ba851fcd9ce120588abe3108bac30afd63921178870f646ed1258b64f35
+imageSelector: image
+nvidiaImage:
+  pullPolicy: Always
+  repository: vexorian/dizquetv
+  tag: 1.5.3-nvidia@sha256:883f5ebc532acfdd64aed8ee89d53ac81794edb49bbb2adfca5b274ff37ae389
+persistence:
+  config:
+    enabled: true
+    mountPath: /home/node/app/.dizquetv
+portal:
+  open:
+    enabled: true
 service:
   main:
     ports:
@@ -24,10 +36,3 @@ workload:
               type: http
               path: /
           env: {}
-persistence:
-  config:
-    enabled: true
-    mountPath: /home/node/app/.dizquetv
-portal:
-  open:
-    enabled: true


### PR DESCRIPTION
**Description**
Add "nvidia" variant option for dizquetv

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Not a TrueNAS user, so has not been tested.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
