### PR TITLE
fix(scrypted): Remove deprecated Thin image selection and uses upstream latest (full image) as default

### DIFF
--- a/charts/stable/scrypted/Chart.yaml
+++ b/charts/stable/scrypted/Chart.yaml
@@ -1,7 +1,7 @@
 kubeVersion: ">=1.24.0-0"
 apiVersion: v2
 name: scrypted
-version: 1.4.1
+version: 1.5.0
 appVersion: 0.68.0
 description:
   Scrypted is a high performance home video integration and automation

--- a/charts/stable/scrypted/ci/full-values.yaml
+++ b/charts/stable/scrypted/ci/full-values.yaml
@@ -1,1 +1,0 @@
-imageSelector: fullImage

--- a/charts/stable/scrypted/questions.yaml
+++ b/charts/stable/scrypted/questions.yaml
@@ -18,11 +18,9 @@ questions:
                                     default: image
                                     enum:
                                       - value: image
-                                        description: Thin
+                                        description: Full (Upstream default)
                                       - value: liteImage
                                         description: Lite
-                                      - value: fullImage
-                                        description: Full
 
                                 - variable: env
                                   label: Image Environment

--- a/charts/stable/scrypted/values.yaml
+++ b/charts/stable/scrypted/values.yaml
@@ -1,14 +1,10 @@
 image:
   repository: koush/scrypted
-  pullPolicy: IfNotPresent
-  tag: 20-jammy-thin-v0.59.0@sha256:067116150b465690ca2792e53139b2b59a4682717599840cb2445a799f1bba90
+  tag: 18-jammy-full-v0.68.0@sha256:c95bd5a65edd8ba132fd9425c7052ea88bd82936afc50391e21d66a671c48329
+  pullPolicy: Always
 liteImage:
   repository: koush/scrypted
   tag: 18-jammy-lite-v0.68.0@sha256:adaed0c9d08f2b4ccfb1369548c65104787e1b8db04a550e6ea7909145d400bc
-  pullPolicy: Always
-fullImage:
-  repository: koush/scrypted
-  tag: 18-jammy-full-v0.68.0@sha256:c95bd5a65edd8ba132fd9425c7052ea88bd82936afc50391e21d66a671c48329
   pullPolicy: Always
 
 securityContext:


### PR DESCRIPTION
**Description**

Removes deprecated default that the catalog selects

⚒️ Fixes  #16305 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
