### PR TITLE
Update Version to SHORT hash due to K3S label limits

### DIFF
--- a/charts/enterprise/traefik/Chart.yaml
+++ b/charts/enterprise/traefik/Chart.yaml
@@ -1,8 +1,8 @@
 kubeVersion: '>=1.24.0-0'
 apiVersion: v2
 name: traefik
-version: 23.0.0
-appVersion: 2.10.5@sha256:b277733b5b8d7f9d2761813d97e161c1f64ec77960f9c06adde13868efbc8dce
+version: 23.0.1
+appVersion: 2.10.5@sha256:b277733b5b8d
 description: Traefik is a flexible reverse proxy and Ingress Provider.
 home: https://truecharts.org/charts/enterprise/traefik
 icon: https://truecharts.org/img/hotlink-ok/chart-icons/traefik.png

--- a/charts/enterprise/traefik/values.yaml
+++ b/charts/enterprise/traefik/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: tccr.io/truecharts/traefik
-  tag: v2.10.5@sha256:b277733b5b8d7f9d2761813d97e161c1f64ec77960f9c06adde13868efbc8dce
+  tag: v2.10.5@sha256:b277733b5b8d
   pullPolicy: IfNotPresent
 manifestManager:
   enabled: true


### PR DESCRIPTION
Simple version number fix to avoid label limits on the tag when installing on truenas Scale 23.10 (or any kube for that matter)
