### PR TITLE
fix(plex-playlist-sync) fix plex-playlist-sync tag and add the sha256

### DIFF
--- a/charts/stable/plex-playlist-sync/Chart.yaml
+++ b/charts/stable/plex-playlist-sync/Chart.yaml
@@ -1,7 +1,7 @@
 kubeVersion: '>=1.24.0-0'
 apiVersion: v2
 name: plex-playlist-sync
-version: 2.1.7
+version: 2.1.8
 appVersion: latest
 description: Sync your Spotify and Deezer playlists to your Plex server.
 home: https://truecharts.org/charts/incubator/plex-playlist-sync

--- a/charts/stable/plex-playlist-sync/values.yaml
+++ b/charts/stable/plex-playlist-sync/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rnagabhyrava/plexplaylistsync
-  tag: latest@68b580ff05514eab0735a83adb1b8873427435714c8b303c08cf335ce4e892dc
+  tag: latest@sha256:68b580ff05514eab0735a83adb1b8873427435714c8b303c08cf335ce4e892dc
   pullPolicy: IfNotPresent
 
 securityContext:


### PR DESCRIPTION
**Description**
Fix plex-playlist-sync tag by adding the sha256 section.
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
