### PR TITLE
fix(apps): fix unpackerr config storage

### DIFF
--- a/charts/stable/unpackerr/Chart.yaml
+++ b/charts/stable/unpackerr/Chart.yaml
@@ -1,7 +1,7 @@
 kubeVersion: ">=1.24.0-0"
 apiVersion: v2
 name: unpackerr
-version: 12.1.5
+version: 12.1.6
 appVersion: 0.12.0
 description: This application runs as a daemon on your download host. It checks for completed downloads and extracts them so Radarr, Lidarr, Sonarr, and Readarr may import them
 home: https://truecharts.org/charts/stable/unpackerr

--- a/charts/stable/unpackerr/Chart.yaml
+++ b/charts/stable/unpackerr/Chart.yaml
@@ -21,6 +21,7 @@ keywords:
   - radarr
   - lidarr
   - readarr
+  - whisparr
 dependencies:
   - name: common
     version: 17.2.21

--- a/charts/stable/unpackerr/questions.yaml
+++ b/charts/stable/unpackerr/questions.yaml
@@ -17,7 +17,14 @@ questions:
 # Include{persistenceRoot}
         - variable: config
           label: "App Config Storage"
-          description: "Stores the Application Configuration"
+          description: "Stores the App Configuration (/config)"
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+        - variable: downloads
+          label: "App downloads Storage"
+          description: "Path to (/downloads)."
           schema:
             additional_attrs: true
             type: dict

--- a/charts/stable/unpackerr/questions.yaml
+++ b/charts/stable/unpackerr/questions.yaml
@@ -15,9 +15,9 @@ questions:
 # Include{serviceExpert}
 # Include{serviceList}
 # Include{persistenceRoot}
-        - variable: downloads
-          label: "App downloads Storage"
-          description: "Path to (/downloads)."
+        - variable: config
+          label: "App Config Storage"
+          description: "Stores the Application Configuration"
           schema:
             additional_attrs: true
             type: dict

--- a/charts/stable/unpackerr/questions.yaml
+++ b/charts/stable/unpackerr/questions.yaml
@@ -22,6 +22,7 @@ questions:
             additional_attrs: true
             type: dict
             attrs:
+# Include{persistenceBasic}
         - variable: downloads
           label: "App downloads Storage"
           description: "Path to (/downloads)."
@@ -29,7 +30,6 @@ questions:
             additional_attrs: true
             type: dict
             attrs:
-# Include{persistenceBasic}
 # Include{persistenceList}
 # Include{securityContextRoot}
               - variable: runAsUser

--- a/charts/stable/unpackerr/questions.yaml
+++ b/charts/stable/unpackerr/questions.yaml
@@ -16,20 +16,21 @@ questions:
 # Include{serviceList}
 # Include{persistenceRoot}
         - variable: config
-          label: "App Config Storage"
-          description: "Stores the App Configuration (/config)"
+          label: App Config Storage
+          description: Stores the App Configuration (/config)
           schema:
             additional_attrs: true
             type: dict
             attrs:
 # Include{persistenceBasic}
         - variable: downloads
-          label: "App downloads Storage"
-          description: "Path to (/downloads)."
+          label: App downloads Storage
+          description: Stores downloads. (Defaults to /downloads)
           schema:
             additional_attrs: true
             type: dict
             attrs:
+# Include{persistenceBasic}
 # Include{persistenceList}
 # Include{securityContextRoot}
               - variable: runAsUser

--- a/charts/stable/unpackerr/values.yaml
+++ b/charts/stable/unpackerr/values.yaml
@@ -12,6 +12,9 @@ persistence:
   config:
     enabled: true
     mountPath: "/config"
+  downloads:
+    enabled: true
+    mountPath: "/downloads"
     ## Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning

--- a/charts/stable/unpackerr/values.yaml
+++ b/charts/stable/unpackerr/values.yaml
@@ -9,9 +9,9 @@ service:
       main:
         enabled: false
 persistence:
-  downloads:
+  config:
     enabled: true
-    mountPath: "/downloads"
+    mountPath: "/config"
     ## Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
**Description**
Fixes an issue where the Unpackerr chart would not automatically create (or load) unpackerr.conf unless the directory (/config) was created and mapped. The /downloads mapping was removed and replaced with /config instead. The chart will start without the directory present, however, it will only rely on environment variables. 

⚒️ Fixes:  
- Maps /config so that the app can create and read unpackerr.conf instead of relying on environment variables.
- Added whisparr to chart.yaml since it is supported by Unpackerr

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Make changes to affected files and start the chart.

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
