### PR TITLE
fix(appsmith) - redis secret creation

### DIFF
--- a/charts/dev/appsmith/Chart.yaml
+++ b/charts/dev/appsmith/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     tags: []
     import-values: []
   - name: redis
-    version: 9.0.3
+    version: 11.1.6
     repository: https://deps.truecharts.org
     condition: redis.enabled
     alias: ""

--- a/charts/dev/appsmith/Chart.yaml
+++ b/charts/dev/appsmith/Chart.yaml
@@ -1,7 +1,7 @@
 kubeVersion: ">=1.24.0-0"
 apiVersion: v2
 name: appsmith
-version: 6.0.14
+version: 6.0.15
 appVersion: 1.9.57
 description: Turn any datasource into an internal app in minutes. Appsmith lets you drag-and-drop UI components to build pages, connect to any API, database or GraphQL source and write logic with JavaScript objects.
 home: https://truecharts.org/charts/incubator/appsmith

--- a/charts/dev/appsmith/values.yaml
+++ b/charts/dev/appsmith/values.yaml
@@ -42,7 +42,7 @@ persistence:
 
 redis:
   enabled: true
-  existingSecret: appsmith-rediscreds
+  existingSecret: rediscreds
   redisUsername: appsmith
 
 portal:

--- a/charts/dev/appsmith/values.yaml
+++ b/charts/dev/appsmith/values.yaml
@@ -33,7 +33,7 @@ workload:
             APPSMITH_REDIS_URL:
               secretKeyRef:
                 expandObjectName: false
-                name: '{{ printf "%s-%s" .Release.Name "appsmith-rediscreds" }}'
+                name: '{{ printf "%s-%s" .Release.Name "rediscreds" }}'
                 key: url
 persistence:
   appsmithstacks:

--- a/charts/dev/appsmith/values.yaml
+++ b/charts/dev/appsmith/values.yaml
@@ -33,7 +33,7 @@ workload:
             APPSMITH_REDIS_URL:
               secretKeyRef:
                 expandObjectName: false
-                name: '{{ printf "%s-%s" .Release.Name "rediscreds" }}'
+                name: '{{ printf "%s-%s" .Release.Name "appsmith-rediscreds" }}'
                 key: url
 persistence:
   appsmithstacks:
@@ -42,7 +42,7 @@ persistence:
 
 redis:
   enabled: true
-  existingSecret: rediscreds
+  existingSecret: appsmith-rediscreds
   redisUsername: appsmith
 
 portal:


### PR DESCRIPTION
**Description**

redis dependency does not start with error:

Error: secret "rediscreds" not found

checking on kctl its created with different name:
NAME                             TYPE                 DATA   AGE
appsmith-rediscreds              Opaque               6      18m
appsmith-redis-credentials       Opaque               1      18m
sh.helm.release.v1.appsmith.v1   helm.sh/release.v1   1      18m
appsmith-tls-0                   kubernetes.io/tls    2      16m


**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
