### PR TITLE
fix(rdesktop): Mark port and probes as TCP

### DIFF
--- a/.github/ct-install.yaml
+++ b/.github/ct-install.yaml
@@ -148,7 +148,6 @@ excluded-charts:
   - charts/stable/plex-meta-manager
   - charts/stable/pod-gateway
   - charts/stable/promcord
-  - charts/stable/rdesktop
   - charts/stable/reg
   - charts/stable/romm
   - charts/stable/ser2sock
@@ -173,7 +172,6 @@ excluded-charts:
   - charts/stable/plex-meta-manager
   - charts/stable/pod-gateway
   - charts/stable/promcord
-  - charts/stable/rdesktop
   - charts/stable/reg
   - charts/stable/romm
   - charts/stable/ser2sock

--- a/charts/stable/rdesktop/Chart.yaml
+++ b/charts/stable/rdesktop/Chart.yaml
@@ -1,7 +1,7 @@
 kubeVersion: ">=1.24.0-0"
 apiVersion: v2
 name: rdesktop
-version: 7.1.22
+version: 7.1.23
 appVersion: latest
 description: Full desktop environments in many popular flavors for Alpine, Ubuntu, Arch, and Fedora accessible via RDP.
 home: https://truecharts.org/charts/stable/rdesktop

--- a/charts/stable/rdesktop/values.yaml
+++ b/charts/stable/rdesktop/values.yaml
@@ -105,7 +105,7 @@ service:
     ports:
       main:
         port: 3389
-        protocol: http
+        protocol: tcp
         targetPort: 3389
 persistence:
   config:


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Fixes liveness probe of rdesktop. Port 3389 is RDP protocol, not HTTP.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

I don't have a way to test it.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
