### PR TITLE
feat(prometheus, prometheus-operator): add support for automatic grafana datasources/dashboards

### DIFF
--- a/charts/enterprise/prometheus/Chart.yaml
+++ b/charts/enterprise/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 kubeVersion: ">=1.24.0-0"
 apiVersion: v2
 name: prometheus
-version: 16.1.9
+version: 16.2.0
 appVersion: 2.48.1
 description: kube-prometheus-stack collects Kubernetes manifests, Grafana dashboards, and Prometheus rules combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
 home: https://truecharts.org/charts/enterprise/prometheus

--- a/charts/enterprise/prometheus/questions.yaml
+++ b/charts/enterprise/prometheus/questions.yaml
@@ -194,7 +194,7 @@ questions:
                             description: "This port exposes the container port on the service"
                             schema:
                               type: int
-                              default: 10086
+                              default: 9090
                               required: true
         - variable: alertmanager
           label: "alertmanager Service"
@@ -216,7 +216,7 @@ questions:
                             description: "This port exposes the container port on the service"
                             schema:
                               type: int
-                              default: 10087
+                              default: 9093
                               required: true
 # Include{serviceExpertRoot}
 # Include{serviceExpert}

--- a/charts/enterprise/prometheus/values.yaml
+++ b/charts/enterprise/prometheus/values.yaml
@@ -23,6 +23,36 @@ workload:
               enabled: false
             startup:
               enabled: false
+              
+
+configmap:
+  grafana-datasource:
+    enabled: "{{ if .Values.grafana.datasources.enabled }}true{{ else }}false{{ end }}"
+    data:
+      datasource.yaml: |-
+        apiVersion: 1
+        datasources:
+        - name: Prometheus
+          type: prometheus
+          uid: {{ .Values.grafana.datasource.uid | default "prometheus" }}
+          url: http://{{ include "tc.v1.common.lib.chart.names.fullname" $ }}.{{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $ "objectData" . "caller" "Configmap") }}:{{ .Values.service.main.ports.main.port }}
+          access: proxy
+          isDefault: {{ .Values.grafana.datasource.default | default true }}
+          jsonData:
+            httpMethod: {{ .Values.grafana.datasource.httpMethod | default "POST" }}
+            timeInterval: {{ .Values.grafana.datasource.scrapeInterval | default "30s" }}
+            {{- if .Values.grafana.datasource.timeout }}
+            timeout: {{ .Values.grafana.datasource.timeout }}
+            {{- end }}
+
+grafana:
+  datasource:
+    enabled: true
+    default: true
+    httpMethod: "POST"
+    scrapeInterval: "30s"
+    uid: "prometheus"
+
 service:
   main:
     selectorLabels:
@@ -30,7 +60,7 @@ service:
       prometheus: '{{ template "kube-prometheus.prometheus.fullname" . }}'
     ports:
       main:
-        port: 10086
+        port: 9090
         targetPort: 9090
         protocol: http
   alertmanager:
@@ -41,7 +71,7 @@ service:
     ports:
       alertmanager:
         enabled: true
-        port: 10087
+        port: 9093
         targetPort: 9093
         protocol: http
   thanos:

--- a/charts/enterprise/prometheus/values.yaml
+++ b/charts/enterprise/prometheus/values.yaml
@@ -27,7 +27,7 @@ workload:
 
 configmap:
   grafana-datasource:
-    enabled: "{{ if .Values.grafana.datasources.enabled }}true{{ else }}false{{ end }}"
+    enabled: "{{ if .Values.grafana.datasource.enabled }}true{{ else }}false{{ end }}"
     data:
       datasource.yaml: |-
         apiVersion: 1

--- a/charts/operators/prometheus-operator/Chart.yaml
+++ b/charts/operators/prometheus-operator/Chart.yaml
@@ -1,7 +1,7 @@
 kubeVersion: ">=1.24.0-0"
 apiVersion: v2
 name: prometheus-operator
-version: 4.1.0
+version: 4.2.0
 appVersion: latest
 description: Prometheus Operator is an operator for prometheus
 home: https://truecharts.org/charts/operators/prometheus-operator

--- a/charts/operators/prometheus-operator/values.yaml
+++ b/charts/operators/prometheus-operator/values.yaml
@@ -74,6 +74,7 @@ kps:
   ##
   grafana:
     enabled: false
+    forceDeployDashboards: true
 
   ## Flag to disable all the kubernetes component scrapers
   ##


### PR DESCRIPTION
**Description**
This PR aims to do two things:
1. It enabled automatic loading of grafana dashboards to the prometheus-operator. Dashboards fetched directly from upstream
2. It enables automatic loading of Prometheus as grafana datasource

Why have the dashboards on the operator?
We use upstream operator helm-chart dependency, which already allows us to use the latest dashboards from upstream. Without custom code, copying etc.

Which limits the chance of mistakes/bugs.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
