### PR TITLE
Minor corrections for mcbackup container in the minecraft-java chart

### DIFF
--- a/charts/stable/minecraft-java/Chart.yaml
+++ b/charts/stable/minecraft-java/Chart.yaml
@@ -20,7 +20,7 @@ keywords:
   - minecraft
 dependencies:
   - name: common
-    version: 17.2.22
+    version: 17.2.23
     repository: oci://tccr.io/truecharts
     condition: ""
     alias: ""

--- a/charts/stable/minecraft-java/values.yaml
+++ b/charts/stable/minecraft-java/values.yaml
@@ -85,7 +85,7 @@ service:
 mcbackup:
   enabled: true
   initial_delay: 2m
-  backup_interval: 24hr
+  backup_interval: 24h
   player_online_check_interval: 5m
   prune_backups_days: 7
   pause_if_no_players: false
@@ -233,7 +233,7 @@ workload:
             DEST_DIR: "{{.Values.persistence.backups.mountPath }}"
             SRC_DIR: "{{.Values.persistence.data.mountPath }}"
             SERVER_PORT: "{{ .Values.service.main.ports.main.port }}"
-            RCON_HOST: '{{ include "tc.v1.common.lib.chart.names.fullname" $ }}'
+            RCON_HOST: '{{ include "tc.v1.common.lib.chart.names.fullname" $ }}-rcon'
             RCON_PORT: "{{ .Values.service.rcon.ports.rcon.port }}"
             RCON_PASSWORD: "{{ .Values.workload.main.podSpec.containers.main.env.RCON_PASSWORD }}"
             INITIAL_DELAY: "{{ .Values.mcbackup.initial_delay }}"
@@ -260,6 +260,10 @@ persistence:
   backups:
     enabled: true
     mountPath: /backups
+    targetSelector:
+      mcbackup:
+        mcbackup:
+          mountPath: /backups
 
 portal:
   open:


### PR DESCRIPTION
**Description**
The "mcbackup" container in the minecraft-java chart was not working properly due to the RCON port and backup mounts, as well as a minor typo in the default backup interval.

I run a Minecraft server via this chart and was unable to backup using the built in option, but this chart update corrects the issues I was having.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Tested using TrueNAS SCALE installation via Helm. Logs of the mcbackup container were audited and tested repeatedly as well as tested the backup archive themselves.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
