### PR TITLE
chore(autoscan): switch to new upstream repo

### DIFF
--- a/charts/stable/autoscan/Chart.yaml
+++ b/charts/stable/autoscan/Chart.yaml
@@ -33,4 +33,4 @@ sources:
   - https://hotio.dev/containers/autoscan
   - https://github.com/truecharts/charts/tree/master/charts/stable/autoscan
 type: application
-version: 7.1.7
+version: 7.1.8

--- a/charts/stable/autoscan/values.yaml
+++ b/charts/stable/autoscan/values.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: IfNotPresent
-  repository: cr.hotio.dev/hotio/autoscan
+  repository: ghcr.io/hotio/autoscan
   tag: latest@sha256:a15a6db9b2a3888d2d8bb8d65f51df67f3999225348c4118faa6a317feea0a53
 securityContext:
   container:


### PR DESCRIPTION


**Description**
<!--
Autoscan currently fails when pulling the image. This is due to cr.hotio.dev being disabled and instead the image is accessible at ghcr.io/hotio/autoscan
-->
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
This [link ](https://hotio.dev/containers/autoscan/) shows the "Important Announcement" at the top about cr.hotio.dev being disabled.


**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
