### PR TITLE
fix(vaultwarden): Replace old variable name "smtp.ssl" with "smtp.security"

### DIFF
--- a/charts/enterprise/vaultwarden/Chart.yaml
+++ b/charts/enterprise/vaultwarden/Chart.yaml
@@ -38,4 +38,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/enterprise/vaultwarden
   - https://hub.docker.com/r/vaultwarden/server
 type: application
-version: 25.1.9
+version: 25.1.10

--- a/charts/enterprise/vaultwarden/templates/_configmap.tpl
+++ b/charts/enterprise/vaultwarden/templates/_configmap.tpl
@@ -46,7 +46,7 @@ data:
   {{- if .Values.vaultwarden.smtp.fromName }}
   SMTP_FROM_NAME: {{ .Values.vaultwarden.smtp.fromName | quote }}
   {{- end }}
-  {{- if .Values.vaultwarden.smtp.ssl }}
+  {{- if .Values.vaultwarden.smtp.security }}
   SMTP_SECURITY: {{ .Values.vaultwarden.smtp.security | quote }}
   {{- end }}
   {{- if .Values.vaultwarden.smtp.port }}


### PR DESCRIPTION
**Description**
This is a fix for the SMTP configuration in vaultwarden.

With commit https://github.com/truecharts/charts/commit/088f8933cf1440ae79bcd54971f0523254be4fa0 the variable was renamed from "smtp.ssl" to "smtp.security". During that process one place was forgotten, which breaks SMTP configuration for SMTP servers that require TLS instead of STARTTLS.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Not tested but assuming this fixes the issue.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning