### PR TITLE
feat(livebook) AWS credentials and data folder

### DIFF
--- a/charts/dev/livebook/Chart.yaml
+++ b/charts/dev/livebook/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/dev/livebook
   - https://ghcr.io/livebook-dev/livebook
 type: application
-version: 3.1.1
+version: 3.2.0

--- a/charts/dev/livebook/ci/test-values.yaml
+++ b/charts/dev/livebook/ci/test-values.yaml
@@ -1,1 +1,2 @@
-password: thisisunsafefortests
+livebook:
+  password: thisisunsafefortests

--- a/charts/dev/livebook/ci/test-values.yaml
+++ b/charts/dev/livebook/ci/test-values.yaml
@@ -1,0 +1,1 @@
+password: thisisunsafefortests

--- a/charts/dev/livebook/questions.yaml
+++ b/charts/dev/livebook/questions.yaml
@@ -13,62 +13,63 @@ questions:
 # Include{containerAdvanced}
 # Include{containerConfig}
 # Include{podOptions}
-  - variable: password
+  - variable: livebook
     group: App Configuration
-    label: "Password (LIVEBOOK_PASSWORD)"
-    description: Password needed to access livebook (must be at least 12 characters)
-    schema:
-      type: string
-      min_length: 12
-      required: true
-      private: true
-  - variable: debug
-    group: App Configuration
-    label: "Debug Logging (LIVEBOOK_DEBUG)"
-    description: >
-      Enables verbose logging, when set to "true". Disabled by default.
-    schema:
-      type: boolean
-      default: false
-  - variable: updateInstructionsUrl
-    group: App Configuration
-    label: "Update instruction URL (LIVEBOOK_UPDATE_INSTRUCTIONS_URL)"
-    description: >
-      Sets the URL to direct the user to for updating Livebook when a new version becomes available.
-    schema:
-      type: string
-  - variable: awsCredentials
-    group: App Configuration
-    label: AWS Credentials
+    label: Livebook
     schema:
       additional_attrs: true
       type: dict
       attrs:
-        - variable: enabled
-          label: "Set AWS Credentials"
+        - variable: password
+          label: "Password (LIVEBOOK_PASSWORD)"
+          description: Password needed to access livebook (must be at least 12 characters)
+          schema:
+            type: string
+            min_length: 12
+            required: true
+            private: true
+        - variable: debug
+          label: "Debug Logging (LIVEBOOK_DEBUG)"
           description: >
-            Enable Livebook to read AWS Credentials from environment variables,
-            AWS Credentials, EC2/ECS metadata when configuring S3 buckets.
+            Enables verbose logging, when set to "true". Disabled by default.
           schema:
             type: boolean
             default: false
-            show_subquestions_if: true
-            subquestions:
-              - variable: accessKeyId
-                group: App Configuration
-                label: "AWS Access Key ID"
+        - variable: updateInstructionsUrl
+          label: "Update instruction URL (LIVEBOOK_UPDATE_INSTRUCTIONS_URL)"
+          description: >
+            Sets the URL to direct the user to for updating Livebook when a new version becomes available.
+          schema:
+            type: string
+        - variable: awsCredentials
+          label: AWS Credentials
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+              - variable: enabled
+                label: "Set AWS Credentials"
                 description: >
-                  AWS Access Key ID in case you want to configure AWS S3 Storage inside Livebook
+                  Enable Livebook to read AWS Credentials from environment variables,
+                  AWS Credentials, EC2/ECS metadata when configuring S3 buckets.
                 schema:
-                  type: string
-              - variable: secretAccessKey
-                group: App Configuration
-                label: "AWS Secret Access Key"
-                description: >
-                  AWS Secret Access Key in case you want to configure AWS S3 Storage inside Livebook
-                schema:
-                  type: string
-                  private: true
+                  type: boolean
+                  default: false
+                  show_subquestions_if: true
+                  subquestions:
+                    - variable: accessKeyId
+                      label: "AWS Access Key ID"
+                      description: >
+                        AWS Access Key ID in case you want to configure AWS S3 Storage inside Livebook
+                      schema:
+                        type: string
+                    - variable: secretAccessKey
+                      label: "AWS Secret Access Key"
+                      description: >
+                        AWS Secret Access Key in case you want to configure AWS S3 Storage inside Livebook
+                      schema:
+                        type: string
+                        private: true
 # Include{serviceRoot}
         - variable: main
           label: "Main Service"

--- a/charts/dev/livebook/questions.yaml
+++ b/charts/dev/livebook/questions.yaml
@@ -13,8 +13,8 @@ questions:
 # Include{containerAdvanced}
 # Include{containerConfig}
 # Include{podOptions}
-  - variable: livebookPassword
-    group: "App Configuration"
+  - variable: password
+    group: App Configuration
     label: "Password (LIVEBOOK_PASSWORD)"
     description: Password needed to access livebook (must be at least 12 characters)
     schema:
@@ -22,43 +22,53 @@ questions:
       min_length: 12
       required: true
       private: true
-  - variable: livebookDebug
-    group: "App Configuration"
+  - variable: debug
+    group: App Configuration
     label: "Debug Logging (LIVEBOOK_DEBUG)"
     description: >
       Enables verbose logging, when set to "true". Disabled by default.
     schema:
       type: boolean
-  - variable: livebookUpdateInstructionsUrl
-    group: "App Configuration"
+      default: false
+  - variable: updateInstructionsUrl
+    group: App Configuration
     label: "Update instruction URL (LIVEBOOK_UPDATE_INSTRUCTIONS_URL)"
     description: >
       Sets the URL to direct the user to for updating Livebook when a new version becomes available.
     schema:
       type: string
-  - variable: livebookAwsCredentials
-    group: "App Configuration"
-    label: "Read AWS Credentials From Env (LIVEBOOK_AWS_CREDENTIALS)"
-    description: >
-      Enable Livebook to read AWS Credentials from environment variables,
-      AWS Credentials, EC2/ECS metadata when configuring S3 buckets.
+  - variable: awsCredentials
+    group: App Configuration
+    label: AWS Credentials
     schema:
-      type: boolean
-  - variable: awsAccessKeyId
-    group: "App Configuration"
-    label: "AWS Access Key ID"
-    description: >
-      AWS Access Key ID in case you want to configure AWS S3 Storage inside Livebook
-    schema:
-      type: string
-  - variable: awsSecretAccessKey
-    group: "App Configuration"
-    label: "AWS Secret Access Key"
-    description: >
-      AWS Secret Access Key in case you want to configure AWS S3 Storage inside Livebook
-    schema:
-      type: string
-      private: true
+      additional_attrs: true
+      type: dict
+      attrs:
+        - variable: enabled
+          label: "Set AWS Credentials"
+          description: >
+            Enable Livebook to read AWS Credentials from environment variables,
+            AWS Credentials, EC2/ECS metadata when configuring S3 buckets.
+          schema:
+            type: boolean
+            default: false
+            show_subquestions_if: true
+            subquestions:
+              - variable: accessKeyId
+                group: App Configuration
+                label: "AWS Access Key ID"
+                description: >
+                  AWS Access Key ID in case you want to configure AWS S3 Storage inside Livebook
+                schema:
+                  type: string
+              - variable: secretAccessKey
+                group: App Configuration
+                label: "AWS Secret Access Key"
+                description: >
+                  AWS Secret Access Key in case you want to configure AWS S3 Storage inside Livebook
+                schema:
+                  type: string
+                  private: true
 # Include{serviceRoot}
         - variable: main
           label: "Main Service"

--- a/charts/dev/livebook/questions.yaml
+++ b/charts/dev/livebook/questions.yaml
@@ -34,6 +34,9 @@ questions:
                                           sets the URL to direct the user to for updating Livebook when a new version becomes available.
                                         schema:
                                           type: string
+# Include{containerBasic}
+# Include{containerAdvanced}
+# Include{containerConfig}
 # Include{serviceRoot}
         - variable: main
           label: "Main Service"
@@ -86,13 +89,13 @@ questions:
                 description: "The UserID of the user running the application"
                 schema:
                   type: int
-                  default: 0
+                  default: 568
               - variable: runAsGroup
                 label: "runAsGroup"
                 description: "The groupID of the user running the application"
                 schema:
                   type: int
-                  default: 0
+                  default: 568
 # Include{securityContextContainer}
 # Include{securityContextAdvanced}
 # Include{securityContextPod}

--- a/charts/dev/livebook/questions.yaml
+++ b/charts/dev/livebook/questions.yaml
@@ -17,23 +17,31 @@ questions:
                                     attrs:
                                       - variable: LIVEBOOK_PASSWORD
                                         label: "Password (LIVEBOOK_PASSWORD)"
-                                        description: "Password needed to access livebook (must be at least 12 characters)"
+                                        description: Password needed to access livebook (must be at least 12 characters)
                                         schema:
                                           type: string
+                                          min_length: 12
                                           required: true
                                           private: true
                                       - variable: LIVEBOOK_DEBUG
                                         label: "Debug Logging (LIVEBOOK_DEBUG)"
                                         description: >
-                                          enables verbose logging, when set to "true". Disabled by default.
+                                          Enables verbose logging, when set to "true". Disabled by default.
                                         schema:
                                           type: boolean
                                       - variable: LIVEBOOK_UPDATE_INSTRUCTIONS_URL
                                         label: "Update instruction URL (LIVEBOOK_UPDATE_INSTRUCTIONS_URL)"
                                         description: >
-                                          sets the URL to direct the user to for updating Livebook when a new version becomes available.
+                                          Sets the URL to direct the user to for updating Livebook when a new version becomes available.
                                         schema:
                                           type: string
+                                      - variable: LIVEBOOK_AWS_CREDENTIALS
+                                        label: "Read AWS Credentials From Env (LIVEBOOK_AWS_CREDENTIALS)"
+                                        description: >
+                                          Enable Livebook to read AWS Credentials from environment variables,
+                                          AWS Credentials, EC2/ECS metadata when configuring S3 buckets.
+                                        schema:
+                                          type: boolean
 # Include{containerBasic}
 # Include{containerAdvanced}
 # Include{containerConfig}

--- a/charts/dev/livebook/questions.yaml
+++ b/charts/dev/livebook/questions.yaml
@@ -9,42 +9,56 @@ questions:
 # Include{replicas1}
 # Include{podSpec}
 # Include{containerMain}
-                                - variable: env
-                                  label: Image Environment
-                                  schema:
-                                    additional_attrs: true
-                                    type: dict
-                                    attrs:
-                                      - variable: LIVEBOOK_PASSWORD
-                                        label: "Password (LIVEBOOK_PASSWORD)"
-                                        description: Password needed to access livebook (must be at least 12 characters)
-                                        schema:
-                                          type: string
-                                          min_length: 12
-                                          required: true
-                                          private: true
-                                      - variable: LIVEBOOK_DEBUG
-                                        label: "Debug Logging (LIVEBOOK_DEBUG)"
-                                        description: >
-                                          Enables verbose logging, when set to "true". Disabled by default.
-                                        schema:
-                                          type: boolean
-                                      - variable: LIVEBOOK_UPDATE_INSTRUCTIONS_URL
-                                        label: "Update instruction URL (LIVEBOOK_UPDATE_INSTRUCTIONS_URL)"
-                                        description: >
-                                          Sets the URL to direct the user to for updating Livebook when a new version becomes available.
-                                        schema:
-                                          type: string
-                                      - variable: LIVEBOOK_AWS_CREDENTIALS
-                                        label: "Read AWS Credentials From Env (LIVEBOOK_AWS_CREDENTIALS)"
-                                        description: >
-                                          Enable Livebook to read AWS Credentials from environment variables,
-                                          AWS Credentials, EC2/ECS metadata when configuring S3 buckets.
-                                        schema:
-                                          type: boolean
 # Include{containerBasic}
 # Include{containerAdvanced}
 # Include{containerConfig}
+# Include{podOptions}
+  - variable: livebookPassword
+    group: "App Configuration"
+    label: "Password (LIVEBOOK_PASSWORD)"
+    description: Password needed to access livebook (must be at least 12 characters)
+    schema:
+      type: string
+      min_length: 12
+      required: true
+      private: true
+  - variable: livebookDebug
+    group: "App Configuration"
+    label: "Debug Logging (LIVEBOOK_DEBUG)"
+    description: >
+      Enables verbose logging, when set to "true". Disabled by default.
+    schema:
+      type: boolean
+  - variable: livebookUpdateInstructionsUrl
+    group: "App Configuration"
+    label: "Update instruction URL (LIVEBOOK_UPDATE_INSTRUCTIONS_URL)"
+    description: >
+      Sets the URL to direct the user to for updating Livebook when a new version becomes available.
+    schema:
+      type: string
+  - variable: livebookAwsCredentials
+    group: "App Configuration"
+    label: "Read AWS Credentials From Env (LIVEBOOK_AWS_CREDENTIALS)"
+    description: >
+      Enable Livebook to read AWS Credentials from environment variables,
+      AWS Credentials, EC2/ECS metadata when configuring S3 buckets.
+    schema:
+      type: boolean
+  - variable: awsAccessKeyId
+    group: "App Configuration"
+    label: "AWS Access Key ID"
+    description: >
+      AWS Access Key ID in case you want to configure AWS S3 Storage inside Livebook
+    schema:
+      type: string
+  - variable: awsSecretAccessKey
+    group: "App Configuration"
+    label: "AWS Secret Access Key"
+    description: >
+      AWS Secret Access Key in case you want to configure AWS S3 Storage inside Livebook
+    schema:
+      type: string
+      private: true
 # Include{serviceRoot}
         - variable: main
           label: "Main Service"

--- a/charts/dev/livebook/templates/_secrets.tpl
+++ b/charts/dev/livebook/templates/_secrets.tpl
@@ -12,6 +12,6 @@ enabled: true
 data:
   LIVEBOOK_SECRET_KEY_BASE: {{ $secretKeyBase | quote }}
   LIVEBOOK_COOKIE: {{ $cookie | quote }}
-  LIVEBOOK_PASSWORD: {{ .Values.password | quote }}
-  AWS_SECRET_ACCESS_KEY: {{ .Values.awsCredentials.secretAccessKey | default "" | quote }}
+  LIVEBOOK_PASSWORD: {{ .Values.livebook.password | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.livebook.awsCredentials.secretAccessKey | default "" | quote }}
 {{- end -}}

--- a/charts/dev/livebook/templates/_secrets.tpl
+++ b/charts/dev/livebook/templates/_secrets.tpl
@@ -13,5 +13,5 @@ data:
   LIVEBOOK_SECRET_KEY_BASE: {{ $secretKeyBase | quote }}
   LIVEBOOK_COOKIE: {{ $cookie | quote }}
   LIVEBOOK_PASSWORD: {{ .Values.livebookPassword | quote }}
-  AWS_SECRET_ACCESS_KEY: {{ .Values.awsSecretAccessKey | default "false" | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.awsSecretAccessKey | default "" | quote }}
 {{- end -}}

--- a/charts/dev/livebook/templates/_secrets.tpl
+++ b/charts/dev/livebook/templates/_secrets.tpl
@@ -10,6 +10,8 @@
 {{- end }}
 enabled: true
 data:
-  LIVEBOOK_SECRET_KEY_BASE: {{ $secretKeyBase }}
-  LIVEBOOK_COOKIE: {{ $cookie }}
+  LIVEBOOK_SECRET_KEY_BASE: {{ $secretKeyBase | quote }}
+  LIVEBOOK_COOKIE: {{ $cookie | quote }}
+  LIVEBOOK_PASSWORD: {{ .Values.livebookPassword | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.awsSecretAccessKey | default "false" | quote }}
 {{- end -}}

--- a/charts/dev/livebook/templates/_secrets.tpl
+++ b/charts/dev/livebook/templates/_secrets.tpl
@@ -12,6 +12,6 @@ enabled: true
 data:
   LIVEBOOK_SECRET_KEY_BASE: {{ $secretKeyBase | quote }}
   LIVEBOOK_COOKIE: {{ $cookie | quote }}
-  LIVEBOOK_PASSWORD: {{ .Values.livebookPassword | quote }}
-  AWS_SECRET_ACCESS_KEY: {{ .Values.awsSecretAccessKey | default "" | quote }}
+  LIVEBOOK_PASSWORD: {{ .Values.password | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.awsCredentials.secretAccessKey | default "" | quote }}
 {{- end -}}

--- a/charts/dev/livebook/values.yaml
+++ b/charts/dev/livebook/values.yaml
@@ -55,15 +55,16 @@ workload:
               secretKeyRef:
                 name: secrets
                 key: LIVEBOOK_PASSWORD
-            LIVEBOOK_DEBUG: '{{ ternary "true" "false" .Values.debug }}'
-            LIVEBOOK_UPDATE_INSTRUCTIONS_URL: "{{ .Values.updateInstructionsUrl }}"
-            LIVEBOOK_AWS_CREDENTIALS: '{{ ternary "true" "false" .Values.awsCredentials.enabled }}'
-            AWS_ACCESS_KEY_ID: "{{ .Values.awsCredentials.accessKeyId }}"
+            LIVEBOOK_DEBUG: '{{ ternary "true" "false" .Values.livebook.debug }}'
+            LIVEBOOK_UPDATE_INSTRUCTIONS_URL: "{{ .Values.livebook.updateInstructionsUrl }}"
+            LIVEBOOK_AWS_CREDENTIALS: '{{ ternary "true" "false" .Values.livebook.awsCredentials.enabled }}'
+            AWS_ACCESS_KEY_ID: "{{ .Values.livebook.awsCredentials.accessKeyId }}"
             AWS_SECRET_ACCESS_KEY:
               secretKeyRef:
                 name: secrets
                 key: AWS_SECRET_ACCESS_KEY
 # default values
-debug: false
-awsCredentials:
-  enabled: false
+livebook:
+  debug: false
+  awsCredentials:
+    enabled: false

--- a/charts/dev/livebook/values.yaml
+++ b/charts/dev/livebook/values.yaml
@@ -56,9 +56,9 @@ workload:
                 name: secrets
                 key: LIVEBOOK_PASSWORD
             LIVEBOOK_DEBUG: '{{ ternary "true" "false" .Values.livebookDebug }}'
-            LIVEBOOK_UPDATE_INSTRUCTIONS_URL: '{{ .Values.livebookUpdateInstructionsUrl }}'
+            LIVEBOOK_UPDATE_INSTRUCTIONS_URL: {{ .Values.livebookUpdateInstructionsUrl }}
             LIVEBOOK_AWS_CREDENTIALS: '{{ ternary "true" "false" .Values.livebookAwsCredentials }}'
-            AWS_ACCESS_KEY_ID: '{{ .Values.awsAccessKeyId }}'
+            AWS_ACCESS_KEY_ID: {{ .Values.awsAccessKeyId }}
             AWS_SECRET_ACCESS_KEY:
               secretKeyRef:
                 name: secrets

--- a/charts/dev/livebook/values.yaml
+++ b/charts/dev/livebook/values.yaml
@@ -51,3 +51,15 @@ workload:
               secretKeyRef:
                 name: secrets
                 key: LIVEBOOK_COOKIE
+            LIVEBOOK_PASSWORD:
+              secretKeyRef:
+                name: secrets
+                key: LIVEBOOK_PASSWORD
+            LIVEBOOK_DEBUG: '{{ ternary "true" "false" .Values.livebookDebug }}'
+            LIVEBOOK_UPDATE_INSTRUCTIONS_URL: '{{ .Values.livebookUpdateInstructionsUrl }}'
+            LIVEBOOK_AWS_CREDENTIALS: '{{ ternary "true" "false" .Values.livebookAwsCredentials }}'
+            AWS_ACCESS_KEY_ID: '{{ .Values.awsAccessKeyId }}'
+            AWS_SECRET_ACCESS_KEY:
+              secretKeyRef:
+                name: secrets
+                key: AWS_SECRET_ACCESS_KEY

--- a/charts/dev/livebook/values.yaml
+++ b/charts/dev/livebook/values.yaml
@@ -12,8 +12,8 @@ portal:
 securityContext:
   container:
     readOnlyRootFilesystem: false
-    runAsGroup: 0
-    runAsUser: 0
+    runAsGroup: 568
+    runAsUser: 568
 service:
   main:
     ports:

--- a/charts/dev/livebook/values.yaml
+++ b/charts/dev/livebook/values.yaml
@@ -42,6 +42,7 @@ workload:
             LIVEBOOK_NODE: livebook@$(A_POD_IP)
             LIVEBOOK_PORT: "{{ .Values.service.main.ports.main.port }}"
             LIVEBOOK_HOME: "{{ .Values.persistence.data.mountPath }}"
+            LIVEBOOK_DATA_PATH: "{{ .Values.persistence.data.mountPath }}"
             LIVEBOOK_SECRET_KEY_BASE:
               secretKeyRef:
                 name: secrets

--- a/charts/dev/livebook/values.yaml
+++ b/charts/dev/livebook/values.yaml
@@ -65,6 +65,10 @@ workload:
                 key: AWS_SECRET_ACCESS_KEY
 # default values
 livebook:
+  password: ""
+  updateInstructionsUrl: ""
   debug: false
   awsCredentials:
     enabled: false
+    accessKeyId: ""
+    secretAccessKey: ""

--- a/charts/dev/livebook/values.yaml
+++ b/charts/dev/livebook/values.yaml
@@ -55,11 +55,15 @@ workload:
               secretKeyRef:
                 name: secrets
                 key: LIVEBOOK_PASSWORD
-            LIVEBOOK_DEBUG: '{{ ternary "true" "false" .Values.livebookDebug }}'
-            LIVEBOOK_UPDATE_INSTRUCTIONS_URL: {{ .Values.livebookUpdateInstructionsUrl }}
-            LIVEBOOK_AWS_CREDENTIALS: '{{ ternary "true" "false" .Values.livebookAwsCredentials }}'
-            AWS_ACCESS_KEY_ID: {{ .Values.awsAccessKeyId }}
+            LIVEBOOK_DEBUG: '{{ ternary "true" "false" .Values.debug }}'
+            LIVEBOOK_UPDATE_INSTRUCTIONS_URL: "{{ .Values.updateInstructionsUrl }}"
+            LIVEBOOK_AWS_CREDENTIALS: '{{ ternary "true" "false" .Values.awsCredentials.enabled }}'
+            AWS_ACCESS_KEY_ID: "{{ .Values.awsCredentials.accessKeyId }}"
             AWS_SECRET_ACCESS_KEY:
               secretKeyRef:
                 name: secrets
                 key: AWS_SECRET_ACCESS_KEY
+# default values
+debug: false
+awsCredentials:
+  enabled: false


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Followup after #16880. I'm still waiting for the next release of Livebook before moving this to the stable train as it comes with a fix for clustering (https://github.com/phoenixframework/dns_cluster/issues/10).

* Adding variables for AWS credentials
* moved the variables in `questions.yaml` to the `podOptions` section. This ways I can put secret values inside secrets.
* Run as non-root by default
* Point the `LIVEBOOK_DATA_PATH` to the PVC in order to persist the config (e.g. aws storage config)

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Using `helm template` to verify the resulting manifest.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
