### PR TITLE
fix(heimdall): Undo old chart update from poor upstream versioning

### DIFF
--- a/charts/stable/heimdall/Chart.yaml
+++ b/charts/stable/heimdall/Chart.yaml
@@ -7,7 +7,7 @@ annotations:
   truecharts.org/min_helm_version: "3.12"
   truecharts.org/train: stable
 apiVersion: v2
-appVersion: 2021.11.28
+appVersion: 2.5.8
 dependencies:
   - name: common
     version: 17.2.29
@@ -33,4 +33,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/heimdall
   - https://hub.docker.com/r/linuxserver/heimdall
 type: application
-version: 19.0.0
+version: 19.0.1

--- a/charts/stable/heimdall/values.yaml
+++ b/charts/stable/heimdall/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: linuxserver/heimdall
-  tag: 2021.11.28@sha256:08863e36675217d6f73ce4e6d55dd52775e3c73b1762b35a406eced85729d2a3
+  tag: 2.5.8@sha256:d8195f797baebeb231ad01586e70d5ace32f58029e07b46ec1295939f41bcff2
   pullPolicy: IfNotPresent
 service:
   main:


### PR DESCRIPTION
**Description**

Fixed the chart here since @stavros-k fixed renovate

⚒️ Fixes  #17774 
**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
