### PR TITLE
feat(clusterissuer): support desec via webhook

### DIFF
--- a/charts/enterprise/clusterissuer/Chart.yaml
+++ b/charts/enterprise/clusterissuer/Chart.yaml
@@ -16,6 +16,13 @@ dependencies:
     alias: ""
     tags: []
     import-values: []
+  - name: cert-manager-webhook-desec-http
+    version: 1.0.1
+    repository: ghcr.io/irreleph4nt/cert-manager-webhook-desec-http
+    condition: {{ eq .Values.questions.clusterIssuer.ACME.type "desec" }}
+    alias: webhookDesec
+    tags: []
+    import-values: []
 deprecated: false
 description: Certificate management for Kubernetes
 home: https://truecharts.org/charts/enterprise/clusterissuer

--- a/charts/enterprise/clusterissuer/questions.yaml
+++ b/charts/enterprise/clusterissuer/questions.yaml
@@ -49,6 +49,8 @@ questions:
                             description: HTTP01 (Experimental)
                           - value: acmedns
                             description: ACME DNS (Advanced)
+                          - value: desec
+                            description: deSEC (Advanced)
                     - variable: server
                       label: Server
                       description: "Server for ACME, for example: letsencrypt"
@@ -261,6 +263,14 @@ questions:
                                           type: ipaddr
                                           cidr: true
                                           required: true
+                    - variable: desec-token
+                      label: deSEC Token
+                      description: "deSEC Access Token"
+                      schema:
+                        show_if: [["type", "=", "desec"]]
+                        type: string
+                        required: true
+                        default: ""
         - variable: CA
           label: Certificate Authority Issuer
           schema:

--- a/charts/enterprise/clusterissuer/templates/clusterissuer/_ACME.tpl
+++ b/charts/enterprise/clusterissuer/templates/clusterissuer/_ACME.tpl
@@ -14,7 +14,7 @@
   {{- if or (not .name) (not (mustRegexMatch "^[a-z]+(-?[a-z]){0,63}-?[a-z]+$" .name)) -}}
     {{- fail "ACME - Expected name to be all lowercase with hyphens, but not start or end with a hyphen" -}}
   {{- end -}}
-  {{- $validTypes := list "HTTP01" "cloudflare" "route53" "digitalocean" "akamai" "rfc2136" "acmedns" -}}
+  {{- $validTypes := list "HTTP01" "cloudflare" "route53" "digitalocean" "akamai" "rfc2136" "acmedns" "desec" -}}
   {{- if not (mustHas .type $validTypes) -}}
     {{- fail (printf "Expected ACME type to be one of [%s], but got [%s]" (join ", " $validTypes) .type) -}}
   {{- end -}}
@@ -101,6 +101,11 @@ spec:
           accountSecretRef:
             name: {{ $issuerSecretName }}
             key: acmednsJson
+      {{- else if eq .type "desec" }}
+        desec:
+          apiUrl: https://desec.io/api/v1
+          name: {{ $issuerSecretName }}
+          key: desec-token
       {{- end -}}
     {{- end }}
 ---
@@ -124,5 +129,6 @@ stringData:
 {{- else if $acmednsDict }}
   acmednsJson: {{ toJson $acmednsDict | quote }}
 {{- end -}}
+  desec-token: {{ .desec-token | default "" }}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**Description**
The Clusterissuer chart supports few issuers,
only the ones integrated in Cert-manager.
Cert-manager has since v0.8 (see [link](https://cert-manager.io/docs/releases/release-notes/release-notes-0.8/#webhook-based-acme-dns01-solver)
) limited the number of ACME providers
they support within their codebase,
and opened up for external webhooks.
[This webhook](https://github.com/irreleph4nt/cert-manager-webhook-desec-http) implements support for the
non-profit, open source DNS provider deSEC
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->
partially #17055 
**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
My Trunas Scale install is semi-borked, and I don't have a cluster on my laptop.
Ergo, this hasn't been tested.

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
