### PR TITLE
chore: add our own GPU GUI for SCALE

### DIFF
--- a/templates/questions/general/resources.yaml
+++ b/templates/questions/general/resources.yaml
@@ -25,6 +25,21 @@
                   type: string
                   default: 8Gi
                   valid_chars: '^(?!^0(e[0-9]|[EPTGMK]i?|)$)([0-9]+)(|[EPTGMK]i?|e[0-9]+)$'
+              - variable: 'intel.com/i915'
+                label: Add Intel i915 GPUs
+                schema:
+                  type: int
+                  default: 0
+              - variable: 'nvidia.com/gpu'
+                label: Add NVIDIA GPUs
+                schema:
+                  type: int
+                  default: 0
+              - variable: 'amd.com/gpu'
+                label: Add AMD GPUs
+                schema:
+                  type: int
+                  default: 0
         - variable: requests
           label: "Minimum Resources Required (request)"
           schema:
@@ -89,31 +104,3 @@
                 schema:
                   type: string
                   default: "/dev/ttyACM0"
-  - variable: scaleGPU
-    label: GPU Configuration
-    group: Resources and Devices
-    schema:
-      type: list
-      default: []
-      items:
-        - variable: scaleGPUEntry
-          label: GPU
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-              # Specify GPU configuration
-              - variable: gpu
-                label: Select GPU
-                schema:
-                  additional_attrs: true
-                  type: dict
-                  $ref:
-                    - "definitions/gpuConfiguration"
-                  attrs: []
-              - variable: workaround
-                label: "Workaround"
-                schema:
-                  type: string
-                  default: workaround
-                  hidden: true

--- a/templates/questions/general/resources.yaml
+++ b/templates/questions/general/resources.yaml
@@ -31,7 +31,7 @@
                   type: int
                   default: 0
               - variable: 'nvidia.com/gpu'
-                label: Add NVIDIA GPUs
+                label: Add NVIDIA GPUs (Experimental)
                 schema:
                   type: int
                   default: 0

--- a/templates/questions/general/resources.yaml
+++ b/templates/questions/general/resources.yaml
@@ -104,3 +104,31 @@
                 schema:
                   type: string
                   default: "/dev/ttyACM0"
+  - variable: scaleGPU
+    label: GPU Configuration
+    group: Resources and Devices
+    schema:
+      type: list
+      default: []
+      items:
+        - variable: scaleGPUEntry
+          label: GPU
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+              # Specify GPU configuration
+              - variable: gpu
+                label: Select GPU
+                schema:
+                  additional_attrs: true
+                  type: dict
+                  $ref:
+                    - "definitions/gpuConfiguration"
+                  attrs: []
+              - variable: workaround
+                label: "Workaround"
+                schema:
+                  type: string
+                  default: workaround
+                  hidden: true


### PR DESCRIPTION
**Description**
We want to migrate away from using TrueNAS-Only GPU elements where we can.
On top of this, the "allocate x" language in the way iX-Systems has designed the GPU selection GUI is *terrible*.

This replaces said GUI with our own.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
For the NVIDIA GPU's to work, we likely need a runtime selection trick added to common.

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
