### PR TITLE
ClusterIssuer: Fixing spaces in "-----BEGIN CERTIFICATE-----" or "-----BEGIN PRIVATE KEY-----" introducing extra newlines

### DIFF
--- a/charts/enterprise/clusterissuer/Chart.yaml
+++ b/charts/enterprise/clusterissuer/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/enterprise/clusterissuer
   - https://hub.docker.com/_/hello-world
 type: application
-version: 6.3.0
+version: 6.3.1

--- a/charts/enterprise/clusterissuer/templates/clusterissuer/_CA.tpl
+++ b/charts/enterprise/clusterissuer/templates/clusterissuer/_CA.tpl
@@ -39,8 +39,8 @@ metadata:
   name: {{ .name }}-ca
   namespace: {{ $namespace }}
 data:
-  tls.crt: {{ .crt | replace " " "\n" | b64enc }}
-  tls.key: {{ .key | replace " " "\n" | b64enc }}
+  tls.crt: {{ .crt | replace " CERTIFICATE" "_CERTIFICATE" | replace " " "\n" | replace "_CERTIFICATE" " CERTIFICATE" | b64enc }}
+  tls.key: {{ .key | replace " PRIVATE KEY" "_PRIVATE_KEY" | replace " " "\n" | replace "_PRIVATE_KEY" " PRIVATE KEY" | b64enc }}
 {{- end }}
 ---
 apiVersion: cert-manager.io/v1


### PR DESCRIPTION
**Description**
The template replaces all spaces with newlines. This causes the spaces in "-----BEGIN CERTIFICATE-----" or "-----BEGIN PRIVATE KEY-----" to introduce extra newlines and malforms the cert and key. The change first replaces the spaces in the BEGIN/END segments with _ before removing them again

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I forked the catalogue repository, made the change there and added it to TrueNAS. Was able to successfully set the CA Key/Cert for the clusterissuer.

Normal   KeyPairVerified  1s (x3 over 2d11h)     cert-manager-clusterissuers  Signing CA verified

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
