### PR TITLE
fix(frigate): add /config/model_cache for frigate 0.13.x

### DIFF
--- a/charts/stable/frigate/templates/common.yaml
+++ b/charts/stable/frigate/templates/common.yaml
@@ -7,7 +7,9 @@
   {{- $_ := set .Values.configmap "frigate-config" $config -}}
 {{- end -}}
 
-{{- if not .Values.frigateConfig -}}
+{{- if .Values.frigateConfig -}}
+  {{- $_ := set .Values.persistence.modelcache "enabled" true -}}
+{{- else }}
   {{- $_ := set .Values.persistence.config "enabled" true -}}
 {{- end -}}
 

--- a/charts/stable/frigate/values.yaml
+++ b/charts/stable/frigate/values.yaml
@@ -33,7 +33,7 @@ workload:
             - /bin/sh
             - -c
             - |
-              mkdir -p /config
+              mkdir -p /config/model_cache
               if [ ! -f /config/config.yml ]; then
                 echo "Config file not found, copying dummy..."
                 cp /dummy-config/config.yml.dummy /config/config.yml
@@ -90,6 +90,10 @@ persistence:
       main:
         main: {}
         init-config: {}
+  modelcache:
+    # Only enable when using frigateConfig
+    enabled: false
+    mountPath: /config/model_cache
 portal:
   open:
     enabled: true

--- a/charts/stable/frigate/values.yaml
+++ b/charts/stable/frigate/values.yaml
@@ -33,7 +33,6 @@ workload:
             - /bin/sh
             - -c
             - |
-              mkdir -p /config/model_cache
               if [ ! -f /config/config.yml ]; then
                 echo "Config file not found, copying dummy..."
                 cp /dummy-config/config.yml.dummy /config/config.yml


### PR DESCRIPTION
During launch, /config/model_cache needs to exist frigate to launch. When TrueNAS, Frigate can create the directory. When helm, /config is readonly so [startup fails](https://github.com/truecharts/charts/actions/runs/8034174241/job/21945516123?pr=17936#step:10:657).

⚒️ Fixes install for upgrade to 0.13.x in #17936

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
