### PR TITLE
fix(bitmagnet): update env default

### DIFF
--- a/charts/stable/bitmagnet/Chart.yaml
+++ b/charts/stable/bitmagnet/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/bitmagnet
   - https://ghcr.io/bitmagnet-io/bitmagnet
 type: application
-version: 1.1.4
+version: 1.2.0

--- a/charts/stable/bitmagnet/Chart.yaml
+++ b/charts/stable/bitmagnet/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/bitmagnet
   - https://ghcr.io/bitmagnet-io/bitmagnet
 type: application
-version: 1.2.0
+version: 1.1.5

--- a/charts/stable/bitmagnet/questions.yaml
+++ b/charts/stable/bitmagnet/questions.yaml
@@ -28,7 +28,7 @@ questions:
                                         description: This parameter provides a compromise over disabling the saving of files altogether. Some torrents contain many thousands of files, which impacts performance and uses a lot of database disk space. This parameter will discard the files info when the number of files is greater than the threshold.
                                         schema:
                                           type: string
-                                          default: "50"
+                                          default: "100"
 # Include{containerBasic}
 # Include{containerAdvanced}
 # Include{containerConfig}

--- a/charts/stable/bitmagnet/values.yaml
+++ b/charts/stable/bitmagnet/values.yaml
@@ -46,7 +46,7 @@ workload:
                 name: cnpg-main-urls
                 key: host
             TMDB_API_KEY: ""
-            DHT_CRAWLER_SAVE_FILES_THRESHOLD: "50"
+            DHT_CRAWLER_SAVE_FILES_THRESHOLD: "100"
           args:
             - worker
             - run


### PR DESCRIPTION
**Description**
Update dht_crawler.save_files_threshold to match new upstream default of 100.

⚒️ Fixes  # 

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

**📃 Notes:**

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
