### PR TITLE
fix(tachidesk): Remove backup Time env var

### DIFF
--- a/charts/stable/tachidesk-docker/Chart.yaml
+++ b/charts/stable/tachidesk-docker/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/tachidesk-docker
   - https://ghcr.io/suwayomi/tachidesk
 type: application
-version: 6.2.0
+version: 6.2.1

--- a/charts/stable/tachidesk-docker/questions.yaml
+++ b/charts/stable/tachidesk-docker/questions.yaml
@@ -136,10 +136,10 @@ questions:
                                           default: false
                                       - variable: BACKUP_TIME
                                         label: "Backup Time in 00:00 format"
-                                        description: "    Range: hour: 0-23, minute: 0-59 - Time of day at which the automated backup should be triggered"
+                                        description: "Range in hours:minutes 0-23:0-59 - Time of day at which the automated backup should be triggered"
                                         schema:
                                           type: string
-                                          default: "00:00"
+                                          default: 00:00
                                       - variable: BACKUP_INTERVAL
                                         label: "Backup Update Interval"
                                         description: "Time in days (0 to disable it) for the interval in which the server will automatically create a backup"

--- a/charts/stable/tachidesk-docker/questions.yaml
+++ b/charts/stable/tachidesk-docker/questions.yaml
@@ -134,12 +134,6 @@ questions:
                                         schema:
                                           type: boolean
                                           default: false
-                                      - variable: BACKUP_TIME
-                                        label: "Backup Time in 00:00 format"
-                                        description: "Range in hours:minutes 0-23:0-59 - Time of day at which the automated backup should be triggered"
-                                        schema:
-                                          type: string
-                                          default: 00:00
                                       - variable: BACKUP_INTERVAL
                                         label: "Backup Update Interval"
                                         description: "Time in days (0 to disable it) for the interval in which the server will automatically create a backup"

--- a/charts/stable/tachidesk-docker/values.yaml
+++ b/charts/stable/tachidesk-docker/values.yaml
@@ -38,7 +38,7 @@ workload:
             UPDATE_EXCLUDE_COMPLETED: true
             UPDATE_INTERVAL: 12
             UPDATE_MANGA_INFO: false
-            BACKUP_TIME: "00:00"
+            BACKUP_TIME: 00:00
             BACKUP_INTERVAL: 1
             BACKUP_TTL: 14
             FLARESOLVERR_ENABLED: false

--- a/charts/stable/tachidesk-docker/values.yaml
+++ b/charts/stable/tachidesk-docker/values.yaml
@@ -38,7 +38,7 @@ workload:
             UPDATE_EXCLUDE_COMPLETED: true
             UPDATE_INTERVAL: 12
             UPDATE_MANGA_INFO: false
-            BACKUP_TIME: ""
+            BACKUP_TIME: "00:00"
             BACKUP_INTERVAL: 1
             BACKUP_TTL: 14
             FLARESOLVERR_ENABLED: false

--- a/charts/stable/tachidesk-docker/values.yaml
+++ b/charts/stable/tachidesk-docker/values.yaml
@@ -38,7 +38,6 @@ workload:
             UPDATE_EXCLUDE_COMPLETED: true
             UPDATE_INTERVAL: 12
             UPDATE_MANGA_INFO: false
-            BACKUP_TIME: 00:00
             BACKUP_INTERVAL: 1
             BACKUP_TTL: 14
             FLARESOLVERR_ENABLED: false


### PR DESCRIPTION
**Description**

Setting the time would break the install, this removes it, the backup will run at 00:00, if people REALLY want to customize it then they can wait for upstream and/or do another fix lol

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
