### PR TITLE
fix(ispy-agent-dvr): Add persistence for ffmpeg6 and fix scale q's

### DIFF
--- a/charts/stable/ispy-agent-dvr/Chart.yaml
+++ b/charts/stable/ispy-agent-dvr/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/ispy-agent-dvr
   - https://hub.docker.com/r/doitandbedone/ispyagentdvr
 type: application
-version: 9.5.2
+version: 9.6.0

--- a/charts/stable/ispy-agent-dvr/questions.yaml
+++ b/charts/stable/ispy-agent-dvr/questions.yaml
@@ -227,6 +227,30 @@ questions:
             type: dict
             attrs:
 # Include{persistenceBasic}
+        - variable: media
+          label: "App Media Storage"
+          description: "Stores the Application Media."
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{persistenceBasic}
+        - variable: commands
+          label: "App Command Storage"
+          description: "Stores the Commands directory."
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{persistenceBasic}
+        - variable: ffmpeg
+          label: "ffmpeg6 Storage"
+          description: "Stores the ffmpeg folder."
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{persistenceBasic}
 # Include{persistenceList}
 # Include{ingressRoot}
         - variable: main

--- a/charts/stable/ispy-agent-dvr/values.yaml
+++ b/charts/stable/ispy-agent-dvr/values.yaml
@@ -84,6 +84,9 @@ persistence:
   commands:
     enabled: true
     mountPath: "/agent/Commands"
+  ffmpeg:
+    enabled: true
+    mountPath: "/agent/ffmpeg6"
 portal:
   open:
     enabled: true


### PR DESCRIPTION
**Description**

Added the `ffmpeg6` folder to be persisted and other minor fixes

For those who didn't persist ffmpeg6 previously

Go into shell and do

```bash
cd agent
./setup-ffmpeg-linux.sh ffmpeg6/
```

⚒️ Fixes  #17970 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
