### PR TITLE
feat(openebs): BREAKING CHANGE (on scale) use zfs backend instead of localpath on scale

### DIFF
--- a/charts/system/openebs/Chart.yaml
+++ b/charts/system/openebs/Chart.yaml
@@ -42,4 +42,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/system/openebs
   - https://github.com/truecharts/containers/tree/master/apps/scratch
 type: application
-version: 3.7.1
+version: 3.7.2

--- a/charts/system/openebs/questions.yaml
+++ b/charts/system/openebs/questions.yaml
@@ -8,46 +8,115 @@ questions:
     schema:
       type: dict
       additional_attrs: true
+      hidden: true  
       attrs:
+        - variable: zfs-localpv
+          label: "ZFS Localpv Settings"
+          schema:
+            type: dict
+            additional_attrs: true
+            hidden: true  
+            attrs:
+              - variable: enabled
+                label: "enabled"
+                schema:
+                  type: boolean
+                  default: true
+                  hidden: true
         - variable: localprovisioner
           label: "Localprovisioner Settings"
           schema:
             type: dict
             additional_attrs: true
+            hidden: true  
             attrs:
-              - variable: enableDeviceClass
-                label: "enableDeviceClass"
+              - variable: enabled
+                label: "enabled"
                 schema:
                   type: boolean
                   default: false
-                  hidden: true
+                  hidden: true              
+              - variable: deviceClass
+                label: "deviceClass"
+                schema:
+                  additional_attrs: true
+                  type: dict
+                  attrs:
+                    - variable: enabled
+                      label: "enabled"
+                      schema:
+                        type: boolean
+                        default: false
+                        hidden: true
               - variable: hostpathClass
                 label: "hostpathClass"
                 schema:
                   additional_attrs: true
                   type: dict
                   attrs:
-                    - variable: reclaimPolicy
-                      label: "reclaimPolicy"
-                      schema:
-                        type: string
-                        required: true
-                        default: "Retain"
-                        enum:
-                          - value: Retain
-                            description: Retain (Keep Data on App Deletion)
-                          - value: Delete
-                            description: Delete (Delete data on App Deletion)
-                    - variable: isDefaultClass
-                      label: "Default Class"
+                    - variable: enabled
+                      label: "enabled"
                       schema:
                         type: boolean
-                        required: true
-                        default: true
-                    - variable: basePath
-                      label: "basePath"
-                      description: "Path to store your application data into"
+                        default: false
+                        hidden: true
+                        
+                        
+  - variable: storageClass
+    group: "Storage and Persistence"
+    label: "StorageClass Settings"
+    schema:
+      type: dict
+      additional_attrs: true
+      hidden: true  
+      attrs:
+        - variable: zfs-main
+          label: "ZFS Localpv Settings"
+          schema:
+            type: dict
+            additional_attrs: true
+            hidden: true  
+            attrs:
+              - variable: enabled
+                label: "enabled"
+                schema:
+                  type: boolean
+                  default: true
+                  hidden: true
+              - variable: provisioner
+                label: "provisioner"
+                schema:
+                  type: string
+                  default: "zfs.csi.openebs.io"
+                  hidden: true
+                  required: true
+              - variable: isDefaultClass
+                label: "Default Class"
+                schema:
+                  type: boolean
+                  default: true
+              - variable: reclaimPolicy
+                label: "reclaimPolicy"
+                schema:
+                  type: string
+                  required: true
+                  default: "Retain"
+                  enum:
+                    - value: Retain
+                      description: Retain (Keep Data on App Deletion)
+                    - value: Delete
+                      description: Delete (Delete data on App Deletion)
+              - variable: parameters
+                label: "parameters"
+                schema:
+                  type: dict
+                  additional_attrs: true
+                  hidden: true  
+                  attrs:
+                    - variable: poolname
+                      label: "Pool/Dataset"
                       schema:
                         type: string
-                        required: true
                         default: ""
+                        required: true
+                  


### PR DESCRIPTION
**Description**
Instead of a local path, we will use the ZFS backend on SCALE instead for OpenEBS.
Reason for that, is the support for snapshotting, which would allow us fancy things with both Velero and/or volsync

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
