### PR TITLE
chore(scrypted): update container image to 20-jammy-lite-v0.97.0

### DIFF
--- a/charts/stable/scrypted/Chart.yaml
+++ b/charts/stable/scrypted/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/scrypted
   - https://hub.docker.com/r/koush/scrypted
 type: application
-version: 4.7.5
+version: 4.8.0

--- a/charts/stable/scrypted/values.yaml
+++ b/charts/stable/scrypted/values.yaml
@@ -1,10 +1,10 @@
 image:
   repository: koush/scrypted
-  tag: 18-jammy-lite-v0.85.0@sha256:9ab4fdc05b6e9ef64916c92080976d23fcd07064dd387de4566b43aa8cf5f827
+  tag: 20-jammy-lite-v0.97.0@sha256:299c500feed500f65d31b1e4f4cdcecedfeaefff8b3a0a7c8fcb3895ca323432
   pullPolicy: Always
 liteImage:
   repository: koush/scrypted
-  tag: 18-jammy-lite-v0.85.0@sha256:73970927cd349a387e8da81960d919daf3006b6309b2859586bd874e92f80a9c
+  tag: 20-jammy-lite-v0.97.0@sha256:d8f331b4532c446ef287ffd44d66f7e7a81feed96d6c37b8307d9b5bbca3ea6e
   pullPolicy: Always
 
 securityContext:

--- a/charts/stable/scrypted/values.yaml
+++ b/charts/stable/scrypted/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: koush/scrypted
-  tag: 20-jammy-lite-v0.97.0@sha256:299c500feed500f65d31b1e4f4cdcecedfeaefff8b3a0a7c8fcb3895ca323432
+  tag: 20-jammy-full-v0.97.0@sha256:c72e4f4877afc8dbe1da51d4ef5578e0172886cf6c6d34a4c497ad693c0a2364
   pullPolicy: Always
 liteImage:
   repository: koush/scrypted


### PR DESCRIPTION
**Description**
<!--
Updated image version values to the latest Scrypted lite version. Appears after version 0.85.0 that Scrypted now uses 20-jammy instead of 18-jammy for the lite container images. 
-->
⚒️ Fixes  #19856 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
-->

**📃 Notes:**
I believe this should solve the issue with the version number change that newer versions of scrypted use. I would imagine this being the best option instead of using the lite tag as that can be updated at anytime. Not sure if the bot can track this type of change.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
