### PR TITLE
feat(Grafana): Enable grafana folders

### DIFF
--- a/charts/premium/grafana/Chart.yaml
+++ b/charts/premium/grafana/Chart.yaml
@@ -38,4 +38,4 @@ sources:
   - https://quay.io/kiwigrid/k8s-sidecar
   - https://hub.docker.com/r/grafana/grafana
 type: application
-version: 14.9.0
+version: 14.10.0

--- a/charts/premium/grafana/values.yaml
+++ b/charts/premium/grafana/values.yaml
@@ -216,7 +216,7 @@ configmap:
             allowUiUpdates: false
             updateIntervalSeconds: 30
             options:
-              foldersFromFilesStructure: false
+              foldersFromFilesStructure: true
               path: /tmp/dashboards
   config:
     enabled: true


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
you would need to use k8s-sidecar-target-directory on the other charts for it to use subfolders otherwise everything just gets dumped into the root folder since the other charts end up in root.

We could update any other charts with more than a couple dashboards with k8s-sidecar-target-directory to put them in folders to keep them clean but i'll leave that up to whomever else feels it should happen. so far in the apps i use i havent found any that would need a folder.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
