### PR TITLE
ollama: add trusted email option

### DIFF
--- a/charts/stable/homepage/Chart.yaml
+++ b/charts/stable/homepage/Chart.yaml
@@ -33,4 +33,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/homepage
   - https://ghcr.io/gethomepage/homepage
 type: application
-version: 7.8.15
+version: 7.8.16

--- a/charts/stable/homepage/values.yaml
+++ b/charts/stable/homepage/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: ghcr.io/gethomepage/homepage
-  tag: v0.8.12@sha256:ad5a8edea1c25b50c6d180d35f72c1623986335113457c4ba38e1ddf16816a4b
+  repository: ghcr.io/discretizer/homepage
+  tag: v0.8.12@sha256:c61e81191b264dc3ae97ceabacf964a0e872adbd5b2454ce3e15c1e248b41767
   pullPolicy: IfNotPresent
 
 workload:

--- a/charts/stable/ollama/Chart.yaml
+++ b/charts/stable/ollama/Chart.yaml
@@ -36,4 +36,4 @@ sources:
   - https://hub.docker.com/r/ollama/ollama
   - https://ghcr.io/open-webui/open-webui
 type: application
-version: 5.4.23
+version: 5.4.24

--- a/charts/stable/ollama/questions.yaml
+++ b/charts/stable/ollama/questions.yaml
@@ -55,6 +55,11 @@ questions:
                       description: User
                     - value: admin
                       description: Admin
+              - variable: trusted_email_header
+                label: Trusted E-mail Header
+                schema: 
+                  type: string 
+                  default: ""
         - variable: stable_diffusion
           label: Stable Diffusion Configuration
           schema:

--- a/charts/stable/ollama/values.yaml
+++ b/charts/stable/ollama/values.yaml
@@ -115,9 +115,11 @@ workload:
             AUTOMATIC1111_BASE_URL: "{{ .Values.ollama.stable_diffusion.base_url }}"
             ENABLE_SIGNUP: "{{ .Values.ollama.registration.enabled }}"
             DEFAULT_USER_ROLE: "{{ .Values.ollama.registration.def_user_role }}"
+            WEBUI_AUTH_TRUSTED_EMAIL_HEADER: "{{ .Values.ollama.registration.trusted_email_header }}"
             WHISPER_MODEL: "{{ .Values.ollama.whisper.model }}"
             RAG_EMBEDDING_MODEL: "{{ .Values.ollama.rag.model }}"
             RAG_EMBEDDING_MODEL_DEVICE_TYPE: "{{ .Values.ollama.rag.model_device_type }}"
+
             # OPENAI_API_BASE_URL
             # OPENAI_API_KEY
             # DEFAULT_MODELS


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This change enables a configuration option to allow open webui (or the Ollama UI container) to use a web auth header (like one passed by the Authentik app HTTP proxy app) as a login source.  This allows unified login with centralized authentication (like authentik).  Note that this potentially also can be done by changing the container that applies the standardized environment variables to chart. 

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Tested change on my local deployment. 

**📃 Notes:**
Feel free to update or comment 

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
