### PR TITLE
feat(wordpress) Add external mariadb support, and existing salt overide

### DIFF
--- a/charts/stable/wordpress/Chart.yaml
+++ b/charts/stable/wordpress/Chart.yaml
@@ -41,4 +41,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/wordpress
   - https://hub.docker.com/r/bitnami/wordpress
 type: application
-version: 8.0.5
+version: 8.1.0

--- a/charts/stable/wordpress/Chart.yaml
+++ b/charts/stable/wordpress/Chart.yaml
@@ -41,4 +41,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/wordpress
   - https://hub.docker.com/r/bitnami/wordpress
 type: application
-version: 8.0.4
+version: 8.0.5

--- a/charts/stable/wordpress/questions.yaml
+++ b/charts/stable/wordpress/questions.yaml
@@ -70,6 +70,72 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: skip_wordpress_setup
+          label: Wordpress - Skip Setup?
+          description: Skip the wordpress setup, must be set if you're using an existing database. Must be unchecked if you're creating a new site.
+          schema:
+            type: boolean
+            default: false
+        - variable: specified_salts
+          label: Specify Wordpress Salts
+          schema:
+            type: dict
+            attrs:
+              - variable: enabled
+                label: Specify your own Salts to use?
+                schema:
+                  type: boolean
+                  default: false
+                  show_subquestions_if: true
+                  subquestions:
+                    - variable: wordpressAuthKey
+                      label: Wordpress Auth Key
+                      schema:
+                        type: string
+                        default: ""
+                        required: true
+                    - variable: wordpressSecureAuthKey
+                      label: Wordpress Secure Auth Key
+                      schema:
+                        type: string
+                        default: ""
+                        required: true
+                    - variable: wordpressLoggedInKey
+                      label: Wordpress Logged In Key
+                      schema:
+                        type: string
+                        default: ""
+                        required: true
+                    - variable: wordpressNonceKey
+                      label: Wordpress Nonce Key
+                      schema:
+                        type: string
+                        default: ""
+                        required: true
+                    - variable: wordpressAuthSalt
+                      label: Wordpress Auth Salt
+                      schema:
+                        type: string
+                        default: ""
+                        required: true
+                    - variable: wordpressSecureAuthSalt
+                      label: Wordpress Secure Auth Salt
+                      schema:
+                        type: string
+                        default: ""
+                        required: true
+                    - variable: wordpressLoggedInSalt
+                      label: Wordpress Logged In Salt
+                      schema:
+                        type: string
+                        default: ""
+                        required: true
+                    - variable: wordpressNonceSalt
+                      label: Wordpress Nonce Salt
+                      schema:
+                        type: string
+                        default: ""
+                        required: true
   - variable: smtp
     group: App Configuration
     label: SMTP Configuration
@@ -107,6 +173,55 @@ questions:
                   type: string
                   private: true
                   default: ""
+  - variable: mariadb
+    group: App Configuration
+    label: MariaDB Configuration
+    schema:
+      additional_attrs: true
+      type: dict
+      attrs:
+        - variable: enabled
+          label: Use Internal MariaDB Container
+          schema:
+            type: boolean
+            default: true
+            show_subquestions_if: false
+            subquestions:
+              - variable: mariadbHost
+                label: MariaDB Host
+                schema:
+                  type: string
+                  default: "mariadb.ix-mariadb.svc.cluster.local"
+                  required: true
+              - variable: mariadbPort
+                label: MariaDB Port
+                schema:
+                  type: string
+                  default: "3306"
+                  required: true
+              - variable: mariadbDatabase
+                label: MariaDB Database
+                schema:
+                  type: string
+                  default: "wordpress"
+                  required: true
+              - variable: mariadbUsername
+                label: MariaDB Username
+                schema:
+                  type: string
+                  default: "wordpress"
+                  required: true
+              - variable: mariadbPassword
+                label: MariaDB Password
+                schema:
+                  type: string
+                  default: "wordpress"
+                  required: true
+              - variable: wordpressTablePrefix
+                label: MariaDB Table Prefix
+                schema:
+                  type: string
+                  default: "wp_"
   - variable: php-config
     group: App Configuration
     label: PHP Configuration

--- a/charts/stable/wordpress/values.yaml
+++ b/charts/stable/wordpress/values.yaml
@@ -38,6 +38,16 @@ wordpress:
   blog_name: Truecharts Blog
   enable_reverse_proxy_headers: true
   skip_wordpress_setup: false
+  specified_salts:
+      enabled: false
+      wordpressAuthKey: ""
+      wordpressSecureAuthKey: ""
+      wordpressLoggedInKey: ""
+      wordpressNonceKey: ""
+      wordpressAuthSalt: ""
+      wordpressSecureAuthSalt: ""
+      wordpressLoggedInSalt: ""
+      wordpressNonceSalt: ""
 smtp:
   enabled: false
   host: ""
@@ -68,6 +78,9 @@ mariadb:
   includeCommon: true
   mariadbUsername: wordpress
   mariadbDatabase: wordpress
+  mariadbHost: "mariadb.ix-mariadb.svc.cluster.local"
+  mariadbPort: "3306"
+  wordpressTablePrefix: "wp_"
 portal:
   open:
     enabled: true

--- a/charts/stable/wordpress/values.yaml
+++ b/charts/stable/wordpress/values.yaml
@@ -37,6 +37,7 @@ wordpress:
   last_name: TrueCharts
   blog_name: Truecharts Blog
   enable_reverse_proxy_headers: true
+  skip_wordpress_setup: false
 smtp:
   enabled: false
   host: ""


### PR DESCRIPTION
**Description**

Added support for multiple wordpress app installations to use a centralized (or external) mariadb installation. This allows for fewer resources to be used, and for easier backup/import/migration of wordpress websites. Additionally includes config options for table prefixes, existing wordpress salts, and database name to support importing existing wordpress sites more easily.

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I created a fork of the repo with only this wordpress chart, and added my forked catalog to my truenas server. I created a single mariadb app on my truenas scale install, and pointed three instances of this wordpress app to that single mariadb hostname. I confirmed that all of the individual wordpress tables showed up on that installation using PhpMyAdmin. I also imported my old wordpress sites' databases from my old server box into truenas using phpMyAdmin import and using the new configurations to configure the container properly I setup the apps pointing to my existing databases and they worked as expected. [jrobe.me](jrobe.me) is currently being hosted out of a container created with these helm changes.

**📃 Notes:**
The only thing I haven't tested (unfortunately) is going from an old wordpress installation using the previous chart version to the new one. However, all of my changes introduced to the questions are defaulted to match the existing behavior, therefore it _should_ be safe as a minor version bump.

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
- [X] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
