### PR TITLE
fix(qbittorrent): allow webui access from all IP families

### DIFF
--- a/charts/stable/qbittorrent/Chart.yaml
+++ b/charts/stable/qbittorrent/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://hub.docker.com/r/mjmeli/qbittorrent-port-forward-gluetun-server
   - https://ghcr.io/onedr0p/qbittorrent
 type: application
-version: 20.0.4
+version: 20.0.5

--- a/charts/stable/qbittorrent/values.yaml
+++ b/charts/stable/qbittorrent/values.yaml
@@ -48,7 +48,7 @@ workload:
             # set the default port
             QBITTORRENT__PORT: "{{ .Values.service.main.ports.main.port }}"
             # stops users from bricking their chart from setting the ip to a random ip when its a container.
-            QBT_Preferences__WebUI__Address: "0.0.0.0"
+            QBT_Preferences__WebUI__Address: "*"
             # set port from gui.
             QBT_BitTorrent__Session__Port: "{{ .Values.service.torrent.ports.torrent.port }}"
             # legacy ini key


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Currently, the Qbittorrent's WebGUI Address is hardcoded to "0.0.0.0" which only allows access to the WebGUI via IPv4 addresses.
When the App is created with the Host Network option, IPv6 addresses might becorme available and users might want to be able to access the WebUI via those addresses.
Taking that scenario into account, change the hardcoded default created by commit 68b93f4 to qbittorrent's default "*", allowing all IP address families to access the WebGUI.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Tested the change in a running app to see if the WebUI was still available.

**📃 Notes:**
N/A

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`