### PR TITLE
Allow fileflows to escalate priviledge so that it can install dockermods

### DIFF
--- a/charts/stable/fileflows/Chart.yaml
+++ b/charts/stable/fileflows/Chart.yaml
@@ -33,4 +33,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/fileflows
   - https://hub.docker.com/r/revenz/fileflows
 type: application
-version: 11.1.0
+version: 11.1.1

--- a/charts/stable/fileflows/values.yaml
+++ b/charts/stable/fileflows/values.yaml
@@ -8,6 +8,8 @@ securityContext:
     runAsNonRoot: false
     runAsUser: 0
     runAsGroup: 0
+    allowPrivilegeEscalation: true
+    privileged: true
 workload:
   main:
     podSpec:


### PR DESCRIPTION
**Description**

The latest update to FileFlows includes an incredible new feature called DockerMods, this allows you to install the packages you need rather than keeping the base image huge. However because of this some privileged's need to be increased.

https://fileflows.com/docs/webconsole/extensions/dockermods

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

I do not run truenas myself, however I do run kuberentes and can confirm that these changes are required as your defaults noted here https://truecharts.org/common/securitycontext/ are not compatible 

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`
