### PR TITLE
fix(adguardhome-sync): deprecated env vars update

### DIFF
--- a/charts/stable/adguardhome-sync/Chart.yaml
+++ b/charts/stable/adguardhome-sync/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bakito/adguardhome-sync/
   - https://github.com/truecharts/charts/tree/master/charts/stable/adguardhome-sync
 type: application
-version: 7.0.11
+version: 7.0.12

--- a/charts/stable/adguardhome-sync/questions.yaml
+++ b/charts/stable/adguardhome-sync/questions.yaml
@@ -69,12 +69,12 @@ questions:
                                                 required: true
                                                 private: true
                                                 default: ""
-                                            - variable: REPLICA_AUTOSETUP
+                                            - variable: REPLICA_AUTO_SETUP
                                               label: Replica Auto Setup
                                               schema:
                                                 type: boolean
                                                 default: false
-                                            - variable: REPLICA_INTERFACENAME
+                                            - variable: REPLICA_INTERFACE_NAME
                                               label: Replica Interface Name
                                               schema:
                                                 type: string
@@ -85,7 +85,7 @@ questions:
                                         schema:
                                           type: string
                                           default: "*/10 * * * *"
-                                      - variable: RUNONSTART
+                                      - variable: RUN_ON_START
                                         label: Run On Start
                                         schema:
                                           type: boolean
@@ -97,22 +97,22 @@ questions:
                                           default: false
                                           show_subquestions_if: true
                                           subquestions:
-                                            - variable: FEATURES_GENERALSETTINGS
+                                            - variable: FEATURES_GENERAL_SETTINGS
                                               label: Features General Settings
                                               schema:
                                                 type: boolean
                                                 default: true
-                                            - variable: FEATURES_QUERYLOGCONFIG
+                                            - variable: FEATURES_QUERY_LOG_CONFIG
                                               label: Features Query Log Config
                                               schema:
                                                 type: boolean
                                                 default: true
-                                            - variable: FEATURES_STATSCONFIG
+                                            - variable: FEATURES_STATS_CONFIG
                                               label: Features Stats Config
                                               schema:
                                                 type: boolean
                                                 default: true
-                                            - variable: FEATURES_CLIENTSETTINGS
+                                            - variable: FEATURES_CLIENT_SETTINGS
                                               label: Features Clients Settings
                                               schema:
                                                 type: boolean
@@ -127,22 +127,22 @@ questions:
                                               schema:
                                                 type: boolean
                                                 default: true
-                                            - variable: FEATURES_DHCP_SERVERCONFIG
+                                            - variable: FEATURES_DHCP_SERVER_CONFIG
                                               label: Features DHCP Server Config
                                               schema:
                                                 type: boolean
                                                 default: true
-                                            - variable: FEATURES_DHCP_STATICLEASES
+                                            - variable: FEATURES_DHCP_STATIC_LEASES
                                               label: Features DHCP Static Leases
                                               schema:
                                                 type: boolean
                                                 default: true
-                                            - variable: FEATURES_DNS_SERVERCONFIG
+                                            - variable: FEATURES_DNS_SERVER_CONFIG
                                               label: Features DNS Server Config
                                               schema:
                                                 type: boolean
                                                 default: true
-                                            - variable: FEATURES_DNS_ACCESSLISTS
+                                            - variable: FEATURES_DNS_ACCESS_LISTS
                                               label: Features DNS Access Lists
                                               schema:
                                                 type: boolean


### PR DESCRIPTION
**Description**
Update deprecated variables as listed here: [https://github.com/bakito/adguardhome-sync/wiki/Deprecations](https://github.com/bakito/adguardhome-sync/wiki/Deprecations)

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
It has not, just a manual verification of new env variable names. If there's a good way for me to deploy and test this, let me know and I will.

**📃 Notes:**
This will hopefully fix a bug where `heavyscript update` fails on the adguardhome-sync chart.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
