### PR TITLE
feat(TeslaMate): allow enable disable of dashboards, allow for custom annotations

### DIFF
--- a/charts/incubator/teslamate/Chart.yaml
+++ b/charts/incubator/teslamate/Chart.yaml
@@ -36,4 +36,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/incubator/teslamate
   - https://hub.docker.com/r/teslamate/teslamate
 type: application
-version: 2.1.2
+version: 2.1.3

--- a/charts/incubator/teslamate/Chart.yaml
+++ b/charts/incubator/teslamate/Chart.yaml
@@ -36,4 +36,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/incubator/teslamate
   - https://hub.docker.com/r/teslamate/teslamate
 type: application
-version: 2.1.3
+version: 2.2.0

--- a/charts/incubator/teslamate/templates/_configmap.tpl
+++ b/charts/incubator/teslamate/templates/_configmap.tpl
@@ -1,5 +1,6 @@
 {{/* Define the configmap */}}
 {{- define "teslamate.configmaps" -}}
+{{- if .Values.dashboards.enabled }}
 {{- $rootDir := "dashboards/" -}}
 {{- $dirs := dict -}}
 {{- range $path, $_ := .Files.Glob (printf "%s**/*.json" $rootDir) }}
@@ -18,12 +19,15 @@
 {{ $configMapKey | quote }}:
   enabled: true
   annotations:
-    k8s-sidecar-target-directory: "TeslaMate"
+    {{- range $key, $value := $.Values.dashboards.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
   labels:
-      grafana_dashboard: "1"
+    grafana_dashboard: "1"
   data:
     {{ $fileName | quote }}: |
 {{ $.Files.Get . | indent 6 }}
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{- end }}

--- a/charts/incubator/teslamate/values.yaml
+++ b/charts/incubator/teslamate/values.yaml
@@ -69,6 +69,11 @@ configmap:
             postgresVersion: 1500 # 903=9.3, 904=9.4, 905=9.5, 906=9.6, 1000=10
             timescaledb: false
 
+dashboards:
+  enabled: true
+  annotations:
+    k8s-sidecar-target-directory: "TeslaMate"
+
 portal:
   open:
     enabled: true


### PR DESCRIPTION
**Description**
This allows for enabled/disabled of the dashboards, and fixes the hard coded annotations on the TeslaMate dashboards that get created. 

I've created a new key of `dashboards` to allow for this to be utilized in any charts that include dashboards as there doesn't seem to be a singular way this is solved across all charts.   Especially when they have multiple directories full of dashboards to install.

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
`helm template my-teslamate . --values values.yaml`

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`
