### PR TITLE
fix: LDAP and OIDC are independently conditional

### DIFF
--- a/charts/stable/mealie/templates/_secrets.tpl
+++ b/charts/stable/mealie/templates/_secrets.tpl
@@ -94,6 +94,9 @@ api:
     LDAP_MAIL_ATTRIBUTE: {{ . | quote }}
     {{- end -}}
     {{- with $api.oidc.auth_enabled }}
+  {{- end }}
+    {{/* OIDC */}}
+  {{- if $api.oidc.auth_enabled }}
     OIDC_AUTH_ENABLED: {{ . | quote }}
     {{- end -}}
     {{- with $api.oidc.signup_enabled }}


### PR DESCRIPTION
**Description**

Enabling LDAP should not add OIDC configuration, and OIDC configuration should not require LDAP.

⚒️ Fixes  # <!--(issue)-->

Adds a condition for `oidc.auth_enabled` so that OIDC environment is populated without also enabling LDAP auth.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
