### PR TITLE
fix(prowlarr): Change prowlarr exportarr pod into a sidecar container

### DIFF
--- a/charts/stable/bazarr/Chart.yaml
+++ b/charts/stable/bazarr/Chart.yaml
@@ -38,4 +38,4 @@ sources:
   - https://github.com/morpheus65535/bazarr
   - https://github.com/truecharts/charts/tree/master/charts/stable/bazarr
 type: application
-version: 21.1.3
+version: 21.1.4

--- a/charts/stable/bazarr/ci/default-values.yaml
+++ b/charts/stable/bazarr/ci/default-values.yaml
@@ -1,3 +1,3 @@
 metrics:
   main:
-    enabled: true
+    apiKey: newsn7zz12j67l4cwovjt6cyq6raqzmz

--- a/charts/stable/bazarr/ci/default-values.yaml
+++ b/charts/stable/bazarr/ci/default-values.yaml
@@ -1,3 +1,3 @@
 metrics:
   main:
-    apiKey: newsn7zz12j67l4cwovjt6cyq6raqzmz
+    enabled: true

--- a/charts/stable/bazarr/ci/disabledmetrics-values.yaml
+++ b/charts/stable/bazarr/ci/disabledmetrics-values.yaml
@@ -1,0 +1,9 @@
+metrics:
+  main:
+    enabled: false
+    type: "servicemonitor"
+    endpoints:
+      - port: metrics
+        path: /metrics
+    prometheusRule:
+      enabled: false

--- a/charts/stable/bazarr/values.yaml
+++ b/charts/stable/bazarr/values.yaml
@@ -14,7 +14,7 @@ service:
         protocol: http
         targetPort: 6767
   metrics:
-    enabled: true
+    enabled: "{{ .Values.metrics.main.enabled }}"
     type: ClusterIP
     ports:
       metrics:

--- a/charts/stable/bazarr/values.yaml
+++ b/charts/stable/bazarr/values.yaml
@@ -16,24 +16,17 @@ service:
   metrics:
     enabled: true
     type: ClusterIP
-    targetSelector: exportarr
     ports:
       metrics:
         enabled: true
         port: 7879
-        targetSelector: exportarr
 
 workload:
-  exportarr:
-    enabled: "{{ .Values.metrics.main.enabled }}"
-    type: Deployment
-    strategy: RollingUpdate
-    replicas: 1
+  main:
     podSpec:
       containers:
         exportarr:
-          primary: true
-          enabled: true
+          enabled: "{{ .Values.metrics.main.enabled }}"
           imageSelector: exportarrImage
           args:
             - bazarr
@@ -66,7 +59,6 @@ persistence:
       main:
         main:
           mountPath: /config
-      exportarr:
         exportarr:
           mountPath: /config
           readOnly: true

--- a/charts/stable/lidarr/Chart.yaml
+++ b/charts/stable/lidarr/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/Lidarr/Lidarr
   - https://github.com/truecharts/charts/tree/master/charts/stable/lidarr
 type: application
-version: 23.2.0
+version: 23.2.1

--- a/charts/stable/lidarr/ci/default-values.yaml
+++ b/charts/stable/lidarr/ci/default-values.yaml
@@ -1,0 +1,3 @@
+metrics:
+  main:
+    apiKey: newsn7zz12j67l4cwovjt6cyq6raqzmz

--- a/charts/stable/lidarr/ci/default-values.yaml
+++ b/charts/stable/lidarr/ci/default-values.yaml
@@ -1,3 +1,3 @@
 metrics:
   main:
-    apiKey: newsn7zz12j67l4cwovjt6cyq6raqzmz
+    enabled: true

--- a/charts/stable/lidarr/ci/disabledmetrics-values.yaml
+++ b/charts/stable/lidarr/ci/disabledmetrics-values.yaml
@@ -1,0 +1,9 @@
+metrics:
+  main:
+    enabled: false
+    type: "servicemonitor"
+    endpoints:
+      - port: metrics
+        path: /metrics
+    prometheusRule:
+      enabled: false

--- a/charts/stable/lidarr/templates/common.yaml
+++ b/charts/stable/lidarr/templates/common.yaml
@@ -1,11 +1,1 @@
-{{/* Make sure all variables are set properly */}}
-{{- include "tc.v1.common.loader.init" . -}}
-
-{{/* Disable [exportarr] if requested */}}
-{{- if not .Values.metrics.main.enabled -}}
-  {{- $_ := set .Values.workload.exportarr "enabled" false -}}
-  {{- $_ := set .Values.service.metrics "enabled" false -}}
-{{- end -}}
-
-{{/* Render the templates */}}
-{{- include "tc.v1.common.loader.apply" . -}}
+{{ include "tc.v1.common.loader.all" . }}

--- a/charts/stable/lidarr/values.yaml
+++ b/charts/stable/lidarr/values.yaml
@@ -17,12 +17,10 @@ service:
   metrics:
     enabled: true
     type: ClusterIP
-    targetSelector: exportarr
     ports:
       metrics:
         enabled: true
         port: 8687
-        targetSelector: exportarr
 workload:
   main:
     podSpec:
@@ -44,15 +42,7 @@ workload:
           env:
             LIDARR__PORT: "{{ .Values.service.main.ports.main.port }}"
             LIDARR__AUTHENTICATION_METHOD: ""
-  exportarr:
-    enabled: true
-    type: Deployment
-    strategy: RollingUpdate
-    replicas: 1
-    podSpec:
-      containers:
         exportarr:
-          primary: true
           enabled: true
           imageSelector: exportarrImage
           args:
@@ -89,7 +79,6 @@ persistence:
       main:
         main:
           mountPath: /config
-      exportarr:
         exportarr:
           mountPath: /config
           readOnly: true

--- a/charts/stable/lidarr/values.yaml
+++ b/charts/stable/lidarr/values.yaml
@@ -15,7 +15,7 @@ service:
       main:
         port: 8686
   metrics:
-    enabled: true
+    enabled: "{{ .Values.metrics.main.enabled }}"
     type: ClusterIP
     ports:
       metrics:
@@ -43,7 +43,7 @@ workload:
             LIDARR__PORT: "{{ .Values.service.main.ports.main.port }}"
             LIDARR__AUTHENTICATION_METHOD: ""
         exportarr:
-          enabled: true
+          enabled: "{{ .Values.metrics.main.enabled }}"
           imageSelector: exportarrImage
           args:
             - lidarr

--- a/charts/stable/prowlarr/Chart.yaml
+++ b/charts/stable/prowlarr/Chart.yaml
@@ -36,4 +36,4 @@ sources:
   - https://github.com/k8s-at-home/container-images
   - https://github.com/truecharts/charts/tree/master/charts/stable/prowlarr
 type: application
-version: 18.3.1
+version: 18.3.2

--- a/charts/stable/prowlarr/ci/default-values.yaml
+++ b/charts/stable/prowlarr/ci/default-values.yaml
@@ -1,0 +1,3 @@
+metrics:
+  main:
+    apiKey: newsn7zz12j67l4cwovjt6cyq6raqzmz

--- a/charts/stable/prowlarr/ci/default-values.yaml
+++ b/charts/stable/prowlarr/ci/default-values.yaml
@@ -1,3 +1,3 @@
 metrics:
   main:
-    apiKey: newsn7zz12j67l4cwovjt6cyq6raqzmz
+    enabled: true

--- a/charts/stable/prowlarr/ci/disabledmetrics-values.yaml
+++ b/charts/stable/prowlarr/ci/disabledmetrics-values.yaml
@@ -1,0 +1,9 @@
+metrics:
+  main:
+    enabled: false
+    type: "servicemonitor"
+    endpoints:
+      - port: metrics
+        path: /metrics
+    prometheusRule:
+      enabled: false

--- a/charts/stable/prowlarr/templates/common.yaml
+++ b/charts/stable/prowlarr/templates/common.yaml
@@ -1,11 +1,1 @@
-{{/* Make sure all variables are set properly */}}
-{{- include "tc.v1.common.loader.init" . -}}
-
-{{/* Disable [exportarr] if requested */}}
-{{- if not .Values.metrics.main.enabled -}}
-  {{- $_ := set .Values.workload.exportarr "enabled" false -}}
-  {{- $_ := set .Values.service.metrics "enabled" false -}}
-{{- end -}}
-
-{{/* Render the templates */}}
-{{- include "tc.v1.common.loader.apply" . -}}
+{{ include "tc.v1.common.loader.all" . }}

--- a/charts/stable/prowlarr/values.yaml
+++ b/charts/stable/prowlarr/values.yaml
@@ -17,12 +17,10 @@ service:
   metrics:
     enabled: true
     type: ClusterIP
-    targetSelector: exportarr
     ports:
       metrics:
         enabled: true
         port: 9697
-        targetSelector: exportarr
 workload:
   main:
     podSpec:
@@ -38,15 +36,7 @@ workload:
           env:
             PROWLARR__PORT: "{{ .Values.service.main.ports.main.port }}"
             PROWLARR__AUTHENTICATION_METHOD: ""
-  exportarr:
-    enabled: true
-    type: Deployment
-    strategy: RollingUpdate
-    replicas: 1
-    podSpec:
-      containers:
         exportarr:
-          primary: true
           enabled: true
           imageSelector: exportarrImage
           args:
@@ -87,7 +77,6 @@ persistence:
       main:
         main:
           mountPath: /config
-      exportarr:
         exportarr:
           mountPath: /config
           readOnly: true

--- a/charts/stable/prowlarr/values.yaml
+++ b/charts/stable/prowlarr/values.yaml
@@ -15,7 +15,7 @@ service:
       main:
         port: 9696
   metrics:
-    enabled: true
+    enabled: "{{ .Values.metrics.main.enabled }}"
     type: ClusterIP
     ports:
       metrics:
@@ -37,7 +37,7 @@ workload:
             PROWLARR__PORT: "{{ .Values.service.main.ports.main.port }}"
             PROWLARR__AUTHENTICATION_METHOD: ""
         exportarr:
-          enabled: true
+          enabled: "{{ .Values.metrics.main.enabled }}"
           imageSelector: exportarrImage
           args:
             - prowlarr

--- a/charts/stable/radarr/Chart.yaml
+++ b/charts/stable/radarr/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/Radarr/Radarr
   - https://github.com/truecharts/charts/tree/master/charts/stable/radarr
 type: application
-version: 23.3.0
+version: 23.3.1

--- a/charts/stable/radarr/ci/disabledmetrics-values.yaml
+++ b/charts/stable/radarr/ci/disabledmetrics-values.yaml
@@ -1,0 +1,9 @@
+metrics:
+  main:
+    enabled: false
+    type: "servicemonitor"
+    endpoints:
+      - port: metrics
+        path: /metrics
+    prometheusRule:
+      enabled: false

--- a/charts/stable/radarr/templates/common.yaml
+++ b/charts/stable/radarr/templates/common.yaml
@@ -1,11 +1,1 @@
-{{/* Make sure all variables are set properly */}}
-{{- include "tc.v1.common.loader.init" . -}}
-
-{{/* Disable [exportarr] if requested */}}
-{{- if not .Values.metrics.main.enabled -}}
-  {{- $_ := set .Values.workload.exportarr "enabled" false -}}
-  {{- $_ := set .Values.service.metrics "enabled" false -}}
-{{- end -}}
-
-{{/* Render the templates */}}
-{{- include "tc.v1.common.loader.apply" . -}}
+{{ include "tc.v1.common.loader.all" . }}

--- a/charts/stable/radarr/values.yaml
+++ b/charts/stable/radarr/values.yaml
@@ -15,7 +15,7 @@ service:
       main:
         port: 7878
   metrics:
-    enabled: true
+    enabled: "{{ .Values.metrics.main.enabled }}"
     type: ClusterIP
     ports:
       metrics:
@@ -42,7 +42,7 @@ workload:
           env:
             RADARR__PORT: "{{ .Values.service.main.ports.main.port }}"
         exportarr:
-          enabled: true
+          enabled: "{{ .Values.metrics.main.enabled }}"
           imageSelector: exportarrImage
           args:
             - radarr

--- a/charts/stable/radarr/values.yaml
+++ b/charts/stable/radarr/values.yaml
@@ -17,12 +17,10 @@ service:
   metrics:
     enabled: true
     type: ClusterIP
-    targetSelector: exportarr
     ports:
       metrics:
         enabled: true
         port: 7879
-        targetSelector: exportarr
 workload:
   main:
     podSpec:
@@ -43,15 +41,7 @@ workload:
               path: /ping
           env:
             RADARR__PORT: "{{ .Values.service.main.ports.main.port }}"
-  exportarr:
-    enabled: true
-    type: Deployment
-    strategy: RollingUpdate
-    replicas: 1
-    podSpec:
-      containers:
         exportarr:
-          primary: true
           enabled: true
           imageSelector: exportarrImage
           args:
@@ -88,7 +78,6 @@ persistence:
       main:
         main:
           mountPath: /config
-      exportarr:
         exportarr:
           mountPath: /config
           readOnly: true

--- a/charts/stable/readarr/Chart.yaml
+++ b/charts/stable/readarr/Chart.yaml
@@ -38,4 +38,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/readarr
   - https://readarr.com
 type: application
-version: 23.1.4
+version: 23.1.5

--- a/charts/stable/readarr/ci/default-values.yaml
+++ b/charts/stable/readarr/ci/default-values.yaml
@@ -1,0 +1,3 @@
+metrics:
+  main:
+    apiKey: newsn7zz12j67l4cwovjt6cyq6raqzmz

--- a/charts/stable/readarr/ci/default-values.yaml
+++ b/charts/stable/readarr/ci/default-values.yaml
@@ -1,3 +1,3 @@
 metrics:
   main:
-    apiKey: newsn7zz12j67l4cwovjt6cyq6raqzmz
+    enabled: true

--- a/charts/stable/readarr/ci/disabledmetrics-values.yaml
+++ b/charts/stable/readarr/ci/disabledmetrics-values.yaml
@@ -1,0 +1,9 @@
+metrics:
+  main:
+    enabled: false
+    type: "servicemonitor"
+    endpoints:
+      - port: metrics
+        path: /metrics
+    prometheusRule:
+      enabled: false

--- a/charts/stable/readarr/templates/common.yaml
+++ b/charts/stable/readarr/templates/common.yaml
@@ -1,11 +1,1 @@
-{{/* Make sure all variables are set properly */}}
-{{- include "tc.v1.common.loader.init" . -}}
-
-{{/* Disable [exportarr] if requested */}}
-{{- if not .Values.metrics.main.enabled -}}
-  {{- $_ := set .Values.workload.exportarr "enabled" false -}}
-  {{- $_ := set .Values.service.metrics "enabled" false -}}
-{{- end -}}
-
-{{/* Render the templates */}}
-{{- include "tc.v1.common.loader.apply" . -}}
+{{ include "tc.v1.common.loader.all" . }}

--- a/charts/stable/readarr/values.yaml
+++ b/charts/stable/readarr/values.yaml
@@ -15,7 +15,7 @@ service:
       main:
         port: 8787
   metrics:
-    enabled: true
+    enabled: "{{ .Values.metrics.main.enabled }}"
     type: ClusterIP
     ports:
       metrics:
@@ -43,7 +43,7 @@ workload:
             READARR__PORT: "{{ .Values.service.main.ports.main.port }}"
             READARR__AUTHENTICATION_METHOD: "None"
         exportarr:
-          enabled: true
+          enabled: "{{ .Values.metrics.main.enabled }}"
           imageSelector: exportarrImage
           args:
             - readarr

--- a/charts/stable/readarr/values.yaml
+++ b/charts/stable/readarr/values.yaml
@@ -17,12 +17,10 @@ service:
   metrics:
     enabled: true
     type: ClusterIP
-    targetSelector: exportarr
     ports:
       metrics:
         enabled: true
         port: 8788
-        targetSelector: exportarr
 workload:
   main:
     podSpec:
@@ -44,15 +42,7 @@ workload:
           env:
             READARR__PORT: "{{ .Values.service.main.ports.main.port }}"
             READARR__AUTHENTICATION_METHOD: "None"
-  exportarr:
-    enabled: true
-    type: Deployment
-    strategy: RollingUpdate
-    replicas: 1
-    podSpec:
-      containers:
         exportarr:
-          primary: true
           enabled: true
           imageSelector: exportarrImage
           args:
@@ -89,7 +79,6 @@ persistence:
       main:
         main:
           mountPath: /config
-      exportarr:
         exportarr:
           mountPath: /config
           readOnly: true

--- a/charts/stable/rtorrent-rutorrent/Chart.yaml
+++ b/charts/stable/rtorrent-rutorrent/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/rtorrent-rutorrent
   - https://truecharts.org/charts/stable/rtorrent-rutorrent
 type: application
-version: 6.1.4
+version: 6.1.5

--- a/charts/stable/rtorrent-rutorrent/ci/default-values.yaml
+++ b/charts/stable/rtorrent-rutorrent/ci/default-values.yaml
@@ -1,0 +1,3 @@
+metrics:
+  main:
+    apiKey: newsn7zz12j67l4cwovjt6cyq6raqzmz

--- a/charts/stable/rtorrent-rutorrent/ci/default-values.yaml
+++ b/charts/stable/rtorrent-rutorrent/ci/default-values.yaml
@@ -1,3 +1,3 @@
 metrics:
   main:
-    apiKey: newsn7zz12j67l4cwovjt6cyq6raqzmz
+    enabled: true

--- a/charts/stable/rtorrent-rutorrent/ci/disabledmetrics-values.yaml
+++ b/charts/stable/rtorrent-rutorrent/ci/disabledmetrics-values.yaml
@@ -1,0 +1,9 @@
+metrics:
+  main:
+    enabled: false
+    type: "servicemonitor"
+    endpoints:
+      - port: metrics
+        path: /metrics
+    prometheusRule:
+      enabled: false

--- a/charts/stable/rtorrent-rutorrent/templates/common.yaml
+++ b/charts/stable/rtorrent-rutorrent/templates/common.yaml
@@ -1,11 +1,1 @@
-{{/* Make sure all variables are set properly */}}
-{{- include "tc.v1.common.loader.init" . -}}
-
-{{/* Disable [exportarr] if requested */}}
-{{- if not .Values.metrics.main.enabled -}}
-  {{- $_ := set .Values.workload.exportarr "enabled" false -}}
-  {{- $_ := set .Values.service.metrics "enabled" false -}}
-{{- end -}}
-
-{{/* Render the templates */}}
-{{- include "tc.v1.common.loader.apply" . -}}
+{{ include "tc.v1.common.loader.all" . }}

--- a/charts/stable/rtorrent-rutorrent/values.yaml
+++ b/charts/stable/rtorrent-rutorrent/values.yaml
@@ -59,12 +59,10 @@ service:
   metrics:
     enabled: true
     type: ClusterIP
-    targetSelector: exportarr
     ports:
       metrics:
         enabled: true
         port: 9135
-        targetSelector: exportarr
 
 workload:
   main:
@@ -91,16 +89,7 @@ workload:
             XMLRPC_PORT: "{{ .Values.service.xmlrpc.ports.xmlrpc.port }}"
             WEBDAV_PORT: "{{ .Values.service.webdav.ports.webdav.port }}"
             RT_INC_PORT: "{{ .Values.service.rtinc.ports.rtinc.port }}"
-
-  exportarr:
-    enabled: true
-    type: Deployment
-    strategy: RollingUpdate
-    replicas: 1
-    podSpec:
-      containers:
         exportarr:
-          primary: true
           enabled: true
           imageSelector: exportarrImage
           args:

--- a/charts/stable/rtorrent-rutorrent/values.yaml
+++ b/charts/stable/rtorrent-rutorrent/values.yaml
@@ -57,7 +57,7 @@ service:
         enabled: true
         port: 50000
   metrics:
-    enabled: true
+    enabled: "{{ .Values.metrics.main.enabled }}"
     type: ClusterIP
     ports:
       metrics:
@@ -90,7 +90,7 @@ workload:
             WEBDAV_PORT: "{{ .Values.service.webdav.ports.webdav.port }}"
             RT_INC_PORT: "{{ .Values.service.rtinc.ports.rtinc.port }}"
         exportarr:
-          enabled: true
+          enabled: "{{ .Values.metrics.main.enabled }}"
           imageSelector: exportarrImage
           args:
             - --rtorrent.scrape-uri={{ printf "http://%s-xmlrpc.%s:%v/RPC2/" .Release.Name .Release.Namespace .Values.service.xmlrpc.ports.xmlrpc.port }}

--- a/charts/stable/sabnzbd/Chart.yaml
+++ b/charts/stable/sabnzbd/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/sabnzbd
   - https://sabnzbd.org/
 type: application
-version: 21.1.5
+version: 21.1.6

--- a/charts/stable/sabnzbd/Chart.yaml
+++ b/charts/stable/sabnzbd/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/sabnzbd
   - https://sabnzbd.org/
 type: application
-version: 21.1.4
+version: 21.1.5

--- a/charts/stable/sabnzbd/ci/default-values.yaml
+++ b/charts/stable/sabnzbd/ci/default-values.yaml
@@ -1,3 +1,3 @@
 metrics:
   main:
-    enabled: true
+    apiKey: newsn7zz12j67l4cwovjt6cyq6raqzmz

--- a/charts/stable/sabnzbd/ci/default-values.yaml
+++ b/charts/stable/sabnzbd/ci/default-values.yaml
@@ -1,3 +1,3 @@
 metrics:
   main:
-    apiKey: newsn7zz12j67l4cwovjt6cyq6raqzmz
+    enabled: true

--- a/charts/stable/sabnzbd/ci/disabledmetrics-values.yaml
+++ b/charts/stable/sabnzbd/ci/disabledmetrics-values.yaml
@@ -1,0 +1,9 @@
+metrics:
+  main:
+    enabled: false
+    type: "servicemonitor"
+    endpoints:
+      - port: metrics
+        path: /metrics
+    prometheusRule:
+      enabled: false

--- a/charts/stable/sabnzbd/values.yaml
+++ b/charts/stable/sabnzbd/values.yaml
@@ -14,12 +14,10 @@ service:
   metrics:
     enabled: true
     type: ClusterIP
-    targetSelector: exportarr
     ports:
       metrics:
         enabled: true
         port: 8990
-        targetSelector: exportarr
 workload:
   main:
     podSpec:
@@ -28,16 +26,8 @@ workload:
           env:
             SABNZBD__HOST_WHITELIST_ENTRIES: ""
             SABNZBD__PORT: "{{ .Values.service.main.ports.main.port }}"
-  exportarr:
-    enabled: "{{ .Values.metrics.main.enabled }}"
-    type: Deployment
-    strategy: RollingUpdate
-    replicas: 1
-    podSpec:
-      containers:
         exportarr:
-          primary: true
-          enabled: true
+          enabled: "{{ .Values.metrics.main.enabled }}"
           imageSelector: exportarrImage
           args:
             - sabnzbd
@@ -69,7 +59,6 @@ persistence:
       main:
         main:
           mountPath: /config
-      exportarr:
         exportarr:
           mountPath: /config
           readOnly: true

--- a/charts/stable/sabnzbd/values.yaml
+++ b/charts/stable/sabnzbd/values.yaml
@@ -12,7 +12,7 @@ service:
       main:
         port: 10097
   metrics:
-    enabled: true
+    enabled: "{{ .Values.metrics.main.enabled }}"
     type: ClusterIP
     ports:
       metrics:

--- a/charts/stable/sonarr/Chart.yaml
+++ b/charts/stable/sonarr/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/Sonarr/Sonarr
   - https://github.com/truecharts/charts/tree/master/charts/stable/sonarr
 type: application
-version: 23.1.5
+version: 23.1.6

--- a/charts/stable/sonarr/Chart.yaml
+++ b/charts/stable/sonarr/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/Sonarr/Sonarr
   - https://github.com/truecharts/charts/tree/master/charts/stable/sonarr
 type: application
-version: 23.1.4
+version: 23.1.5

--- a/charts/stable/sonarr/templates/common.yaml
+++ b/charts/stable/sonarr/templates/common.yaml
@@ -3,7 +3,7 @@
 
 {{/* Disable [exportarr] if requested */}}
 {{- if not .Values.metrics.main.enabled -}}
-  {{- $_ := set .Values.workload.exportarr "enabled" false -}}
+  {{- $_ := set .Values.workload.main.podSpec.containers.exportarr "enabled" false -}}
   {{- $_ := set .Values.service.metrics "enabled" false -}}
 {{- end -}}
 

--- a/charts/stable/sonarr/templates/common.yaml
+++ b/charts/stable/sonarr/templates/common.yaml
@@ -1,11 +1,1 @@
-{{/* Make sure all variables are set properly */}}
-{{- include "tc.v1.common.loader.init" . -}}
-
-{{/* Disable [exportarr] if requested */}}
-{{- if not .Values.metrics.main.enabled -}}
-  {{- $_ := set .Values.workload.main.podSpec.containers.exportarr "enabled" false -}}
-  {{- $_ := set .Values.service.metrics "enabled" false -}}
-{{- end -}}
-
-{{/* Render the templates */}}
-{{- include "tc.v1.common.loader.apply" . -}}
+{{ include "tc.v1.common.loader.all" . }}

--- a/charts/stable/sonarr/values.yaml
+++ b/charts/stable/sonarr/values.yaml
@@ -14,12 +14,10 @@ service:
   metrics:
     enabled: true
     type: ClusterIP
-    targetSelector: exportarr
     ports:
       metrics:
         enabled: true
         port: 8990
-        targetSelector: exportarr
 workload:
   main:
     podSpec:
@@ -41,15 +39,7 @@ workload:
           env:
             SONARR__PORT: "{{ .Values.service.main.ports.main.port }}"
             SONARR__AUTHENTICATION_METHOD: ""
-  exportarr:
-    enabled: true
-    type: Deployment
-    strategy: RollingUpdate
-    replicas: 1
-    podSpec:
-      containers:
         exportarr:
-          primary: true
           enabled: true
           imageSelector: exportarrImage
           args:
@@ -86,7 +76,6 @@ persistence:
       main:
         main:
           mountPath: /config
-      exportarr:
         exportarr:
           mountPath: /config
           readOnly: true

--- a/charts/stable/sonarr/values.yaml
+++ b/charts/stable/sonarr/values.yaml
@@ -12,7 +12,7 @@ service:
       main:
         port: 8989
   metrics:
-    enabled: true
+    enabled: "{{ .Values.metrics.main.enabled }}"
     type: ClusterIP
     ports:
       metrics:
@@ -40,7 +40,7 @@ workload:
             SONARR__PORT: "{{ .Values.service.main.ports.main.port }}"
             SONARR__AUTHENTICATION_METHOD: ""
         exportarr:
-          enabled: true
+          enabled: "{{ .Values.metrics.main.enabled }}"
           imageSelector: exportarrImage
           args:
             - sonarr


### PR DESCRIPTION
**Description**

Prowlarr helm chart and other Arrs implementing a exportarr pod can fail when deployed on a multi node cluster when the pods are provisioned on different nodes. This is because both mount the config PVC which is in ReadWriteOnce accessModes by default which only allows mounting on the same node.

Fixes #25130

The solution I chose is to convert the exportarr pod into a sidecar container. I choose this approach for simplicity.

If this is not acceptable I will gladly change the approach and create a new PR and create one for each other affected Arr chart.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

Deployed on my home lab.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
