### PR TITLE
feat(satisfactory): Add healthcheck for Satisfactory

### DIFF
--- a/charts/stable/satisfactory/Chart.yaml
+++ b/charts/stable/satisfactory/Chart.yaml
@@ -32,4 +32,4 @@ sources:
   - https://github.com/wolveix/satisfactory-server
   - https://hub.docker.com/r/wolveix/satisfactory-server
 type: application
-version: 12.0.0
+version: 12.1.0

--- a/charts/stable/satisfactory/values.yaml
+++ b/charts/stable/satisfactory/values.yaml
@@ -36,6 +36,38 @@ workload:
     podSpec:
       containers:
         main:
+          ports:
+          - name: game
+            containerPort: {{ .Values.service.main.ports.main.port }}
+          probes:
+            liveness:
+              enabled: true
+              tcpSocket:
+                port: game
+              initialDelaySeconds: 5
+              timeoutSeconds: 1
+              periodSeconds: 5
+              failureThreshold: 3
+              successThreshold: 1
+            readiness:
+              enabled: true
+              exec:
+                command:
+                - bash
+                - /healthcheck.sh
+              initialDelaySeconds: 5
+              timeoutSeconds: 1
+              periodSeconds: 5
+              failureThreshold: 3
+              successThreshold: 1
+            startup:
+              enabled: true
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - test -f /config/gamefiles/FactoryGame/Saved/Logs/FactoryGame.log
+              initialDelaySeconds: 10
           env:
             AUTOSAVENUM: 5
             DEBUG: false


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Verified changes work locally in my cluster.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

Probes greatly improve k8s management of pods. Having them set up correctly means the cluster can self-heal when they become unhealthy.

Probes;

* Startup -- the Satisfactory image uses steamcmd to update the game files before starting the server. It also removes the previous log files before starts the update. So, the startup waits 10 seconds (for the update to start) and then looks for the log file, which means the server has started.
* Liveness -- game server port
* Readiness -- uses the [healthcheck script](https://github.com/wolveix/satisfactory-server/blob/main/healthcheck.sh) provided by the image

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
- [X] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
