### PR TITLE
feat(rimgo): deprecate

### DIFF
--- a/charts/stable/rimgo/Chart.yaml
+++ b/charts/stable/rimgo/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     alias: ""
     tags: []
     import-values: []
-deprecated: false
+deprecated: true
 description: Alternative Imgur front-end
 home: https://truecharts.org/charts/stable/rimgo
 icon: https://truecharts.org/img/hotlink-ok/chart-icons/rimgo.webp
@@ -32,4 +32,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/rimgo
   - https://quay.io/pussthecatorg/rimgo
 type: application
-version: 8.2.19
+version: 9.0.0

--- a/charts/stable/rimgo/values.yaml
+++ b/charts/stable/rimgo/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/pussthecatorg/rimgo
-  tag: latest@sha256:c1cf74fc110c1541e77bd99e059fe000de775323b765f3815157785bb239c25f
+  tag: latest@sha256:83c673fb7b73ad8e6b7b9a28efdefb53299077f2f70d2eaca9e4fa2917c76a79
   pullPolicy: IfNotPresent
 persistence: {}
 


### PR DESCRIPTION
**Description**
Deprecate rimgo due to no action from upstream dev on https://github.com/PussTheCat-org/docker-rimgo-quay/issues/2

⚒️ Fixes  # 

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

**📃 Notes:**

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
- [X] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
