### PR TITLE
fix(unpoller): Prometheus dashboards

### DIFF
--- a/charts/stable/unpoller/Chart.yaml
+++ b/charts/stable/unpoller/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/unpoller
   - https://github.com/unifi-poller/unifi-poller
 type: application
-version: 12.2.0
+version: 12.2.1

--- a/charts/stable/unpoller/dashboards/UAP.json
+++ b/charts/stable/unpoller/dashboards/UAP.json
@@ -3513,6 +3513,13 @@
     "templating": {
         "list": [
             {
+                "hide": 2,
+                "name": "DS_PROMETHEUS",
+                "query": "Prometheus",
+                "skipUrlSync": false,
+                "type": "constant"
+            },
+            {
                 "allValue": ".*",
                 "current": {},
                 "datasource": "${DS_PROMETHEUS}",

--- a/charts/stable/unpoller/dashboards/USG.json
+++ b/charts/stable/unpoller/dashboards/USG.json
@@ -2363,6 +2363,13 @@
     "templating": {
         "list": [
             {
+                "hide": 2,
+                "name": "DS_PROMETHEUS",
+                "query": "Prometheus",
+                "skipUrlSync": false,
+                "type": "constant"
+            },
+            {
                 "allValue": ".*",
                 "current": {},
                 "datasource": "${DS_PROMETHEUS}",

--- a/charts/stable/unpoller/dashboards/USW.json
+++ b/charts/stable/unpoller/dashboards/USW.json
@@ -2650,6 +2650,13 @@
     "templating": {
         "list": [
             {
+                "hide": 2,
+                "name": "DS_PROMETHEUS",
+                "query": "Prometheus",
+                "skipUrlSync": false,
+                "type": "constant"
+            },
+            {
                 "allValue": ".*",
                 "current": {},
                 "datasource": "${DS_PROMETHEUS}",

--- a/charts/stable/unpoller/dashboards/clients.json
+++ b/charts/stable/unpoller/dashboards/clients.json
@@ -2959,6 +2959,13 @@
     "templating": {
         "list": [
             {
+                "hide": 2,
+                "name": "DS_PROMETHEUS",
+                "query": "Prometheus",
+                "skipUrlSync": false,
+                "type": "constant"
+            },
+            {
                 "allValue": null,
                 "current": {},
                 "datasource": "${DS_PROMETHEUS}",

--- a/charts/stable/unpoller/dashboards/network.json
+++ b/charts/stable/unpoller/dashboards/network.json
@@ -1353,6 +1353,13 @@
     "templating": {
         "list": [
             {
+                "hide": 2,
+                "name": "DS_PROMETHEUS",
+                "query": "Prometheus",
+                "skipUrlSync": false,
+                "type": "constant"
+            },
+            {
                 "allValue": null,
                 "current": {},
                 "datasource": "${DS_PROMETHEUS}",


### PR DESCRIPTION
The unpoller dashboards can't be loaded in Prometheus with the error "Failed to upgrade legacy queries"

The panels uses the ${DS_PROMETHEUS} variable which is not defined in the dashboards

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I installed the chart with the new dashboards and they work
