### PR TITLE
fix(spegel): spegel dashboard

### DIFF
--- a/charts/incubator/spegel/Chart.yaml
+++ b/charts/incubator/spegel/Chart.yaml
@@ -30,4 +30,4 @@ name: spegel
 sources:
   - https://github.com/truecharts/charts/tree/master/charts/system/spegel
 type: application
-version: 2.0.1
+version: 2.0.2

--- a/charts/incubator/spegel/dashboard.json
+++ b/charts/incubator/spegel/dashboard.json
@@ -1175,6 +1175,13 @@
     "templating": {
       "list": [
         {
+          "hide": 2,
+          "name": "DS_PROMETHEUS",
+          "query": "Prometheus",
+          "skipUrlSync": false,
+          "type": "constant"
+        },
+        {
           "current": {
             "selected": false,
             "text": "Prometheus",


### PR DESCRIPTION
The spegel dashboard uses DS_PROMETHEUS for its panels but it's not initialized

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I modified the json and created the new dashboard