### PR TITLE
fix(traefik): Add internals metrics

### DIFF
--- a/charts/premium/traefik/Chart.yaml
+++ b/charts/premium/traefik/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/truecharts/containers/tree/master/apps/traefik
   - https://traefik.io/
 type: application
-version: 29.3.2
+version: 29.3.3

--- a/charts/premium/traefik/templates/_args.tpl
+++ b/charts/premium/traefik/templates/_args.tpl
@@ -46,6 +46,9 @@ args:
   {{- if or .Values.metrics.main.enabled }}
   - "--metrics.prometheus=true"
   - "--metrics.prometheus.entrypoint=metrics"
+  {{- if .Values.metrics.main.addInternals }}
+  - "--metrics.addinternals"
+  {{- end }}
   {{- end }}
   {{- if .Values.providers.kubernetesCRD.enabled }}
   - "--providers.kubernetescrd"

--- a/charts/premium/traefik/values.yaml
+++ b/charts/premium/traefik/values.yaml
@@ -120,6 +120,7 @@ metrics:
   main:
     enabled: true
     type: servicemonitor
+    addInternals: true
     endpoints:
       - port: metrics
         path: /metrics


### PR DESCRIPTION
The grafana dashboard miss some data because traefik doesn't have the "--metrics.addinternals" args

- [ ] ⚙️ Feature/App addition
- [ x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

