### PR TITLE
Fix reconciling for cattle.io plans

### DIFF
--- a/clustertool/embed/generic/kubernetes/core/system-upgrade-controller-plans/app/kubernetes.yaml
+++ b/clustertool/embed/generic/kubernetes/core/system-upgrade-controller-plans/app/kubernetes.yaml
@@ -4,6 +4,7 @@ apiVersion: upgrade.cattle.io/v1
 kind: Plan
 metadata:
   name: kubernetes
+  namespace: system-upgrade
 spec:
   version: ${KUBERNETES_VERSION}
   serviceAccountName: system-upgrade

--- a/clustertool/embed/generic/kubernetes/core/system-upgrade-controller-plans/app/talos.yaml
+++ b/clustertool/embed/generic/kubernetes/core/system-upgrade-controller-plans/app/talos.yaml
@@ -3,6 +3,7 @@ apiVersion: upgrade.cattle.io/v1
 kind: Plan
 metadata:
   name: talos
+  namespace: system-upgrade
 spec:
   version: ${TALOS_VERSION}
   serviceAccountName: system-upgrade


### PR DESCRIPTION
**Description**
Kustomization for system-upgrade-controller-plans never finishes with message:

Plan/talos namespace not specified: the server could not find the requested resource (patch plans.upgrade.cattle.io talos)

Also reported on discord: https://discord.com/channels/830763548678291466/1253691401644933200/1299641386563403899

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Tested on a fresh installation with ClusterTool RC20

**📃 Notes:**
If the namespace is not set, the Plans for talos and kubernates is never created via fluxCD

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
