### PR TITLE
fix(minecraft-gate) update chart with new config | lite mode | fix persistence

### DIFF
--- a/charts/incubator/minecraft-gate/Chart.yaml
+++ b/charts/incubator/minecraft-gate/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/minekube/gate
   - https://github.com/truecharts/charts/tree/master/charts/incubator/minecraft-gate
 type: application
-version: 0.0.1
+version: 0.0.2

--- a/charts/incubator/minecraft-gate/values.yaml
+++ b/charts/incubator/minecraft-gate/values.yaml
@@ -14,23 +14,6 @@ service:
         enabled: true
         protocol: udp
         port: 25565
-
-configmap:
-  config:
-    enabled: true
-    data:
-      config.yml: |-
-        config:
-          bind: 0.0.0.0:{{ .Values.service.main.ports.main.port }}
-          servers:
-            server1: localhost:25566
-          try:
-            - server1
-          query:
-            enabled: true
-            port: "{{ .Values.service.main.ports.query.port }}"
-            showPlugins: false
-
 workload:
   main:
     podSpec:
@@ -45,14 +28,31 @@ workload:
               type: tcp
             startup:
               type: tcp
-
+# https://gate.minekube.com/guide/lite.html
+# https://gate.minekube.com/guide/config/
+configmap:
+  config:
+    enabled: true
+    data:
+      config.yml: |
+        config:
+          bind: 0.0.0.0:{{ .Values.service.main.ports.main.port }}
+          query:
+            enabled: true
+            port: {{ .Values.service.main.ports.query.port }}
+            showPlugins: false
+          lite:
+            enabled: true
+            routes:
+              - host: minecraft.local
+                backend: localhost:25565
 persistence:
   config-file:
     enabled: true
     type: configmap
     objectName: config
-    mountPath: "/config.yml"
-
+    mountPath: /config.yml
+    subPath: config.yml
 portal:
   open:
     enabled: false


### PR DESCRIPTION
**Description**
Updating the initial config which is basically the lite proxy to match a hostname like minecraft.local to a backend like minecraft-java.minecraft.svc.cluster.local:25565

added comments for the full config for both.

also fixed the configmap mount.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
- [X] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
