### PR TITLE
fix(ispy-agent-dvr): set to loadbalancer

### DIFF
--- a/charts/stable/ispy-agent-dvr/Chart.yaml
+++ b/charts/stable/ispy-agent-dvr/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/ispy-agent-dvr
   - https://hub.docker.com/r/doitandbedone/ispyagentdvr
 type: application
-version: 11.5.1
+version: 11.5.2

--- a/charts/stable/ispy-agent-dvr/values.yaml
+++ b/charts/stable/ispy-agent-dvr/values.yaml
@@ -4,12 +4,14 @@ image:
   pullPolicy: IfNotPresent
 service:
   main:
+    type: LoadBalancer
     ports:
       main:
         port: 10184
         targetPort: 8090
   turn:
     enabled: true
+    type: LoadBalancer
     ports:
       turn:
         enabled: true


### PR DESCRIPTION
**Description**
Sets ispy-agent-dvr to LoadBalancer by default as reverse proxy support requires a license.

⚒️ Fixes  #28811 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

**📃 Notes:**

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
- [X] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
