### PR TITLE
feat(common): handle separately backup compression & encryption

### DIFF
--- a/charts/library/common-test/Chart.yaml
+++ b/charts/library/common-test/Chart.yaml
@@ -7,7 +7,7 @@ apiVersion: v2
 appVersion: unknown
 dependencies:
   - name: common
-    version: ~25.1.0
+    version: ~25.2.0
     repository: file://../common/
     condition: ""
     alias: ""

--- a/charts/library/common-test/tests/cnpg/cluster_backup_spec_test.yaml
+++ b/charts/library/common-test/tests/cnpg/cluster_backup_spec_test.yaml
@@ -61,6 +61,7 @@ tests:
             backup:
               barmanObjectStore:
                 data:
+                  compression: gzip
                   jobs: 2
                 destinationPath: some-path
                 endpointURL: some-url
@@ -72,6 +73,8 @@ tests:
                     key: ACCESS_SECRET_KEY
                     name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
                 serverName: test-release-name-common-test-cnpg-my-pg
+                wal:
+                  compression: gzip
               retentionPolicy: 10d
               target: primary
 
@@ -126,6 +129,7 @@ tests:
             backup:
               barmanObjectStore:
                 data:
+                  compression: gzip
                   jobs: 2
                 destinationPath: some-path
                 endpointURL: some-url
@@ -137,6 +141,8 @@ tests:
                     key: ACCESS_SECRET_KEY
                     name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
                 serverName: test-release-name-common-test-cnpg-my-pg-rsome-revision
+                wal:
+                  compression: gzip
               retentionPolicy: 10d
               target: primary
 
@@ -191,6 +197,7 @@ tests:
             backup:
               barmanObjectStore:
                 data:
+                  compression: gzip
                   jobs: 2
                 destinationPath: some-path
                 endpointURL: some-url
@@ -202,6 +209,8 @@ tests:
                     key: ACCESS_SECRET_KEY
                     name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
                 serverName: some-server-name
+                wal:
+                  compression: gzip
               retentionPolicy: 10d
               target: primary
 
@@ -257,6 +266,7 @@ tests:
             backup:
               barmanObjectStore:
                 data:
+                  compression: gzip
                   jobs: 2
                 destinationPath: some-path
                 endpointURL: some-url
@@ -268,6 +278,8 @@ tests:
                     key: ACCESS_SECRET_KEY
                     name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
                 serverName: some-server-name-r1
+                wal:
+                  compression: gzip
               retentionPolicy: 10d
               target: primary
 
@@ -339,5 +351,71 @@ tests:
                 wal:
                   compression: gzip
                   encryption: AES256
+              retentionPolicy: 10d
+              target: primary
+
+  - it: should disable compression when set to false
+    set:
+      credentials:
+        test: *test
+      cnpg:
+        my-pg:
+          enabled: true
+          user: test-user
+          database: test-db
+          password: test-password
+          backups:
+            enabled: true
+            target: primary
+            retentionPolicy: 10d
+            credentials: test
+            destinationPath: some-path
+            compression:
+              enabled: false
+    asserts:
+      - documentIndex: *secretDoc
+        isKind:
+          of: Secret
+      - documentIndex: *secretDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
+      - documentIndex: *secretDoc
+        equal:
+          path: stringData
+          value:
+            ACCESS_KEY_ID: some-access-key
+            ACCESS_SECRET_KEY: some-secret-key
+      - documentIndex: &clusterDoc 0
+        isKind:
+          of: Cluster
+      - documentIndex: *clusterDoc
+        isAPIVersion:
+          of: postgresql.cnpg.io/v1
+      - documentIndex: *clusterDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg
+      - documentIndex: *clusterDoc
+        isSubset:
+          path: spec
+          content:
+            backup:
+              barmanObjectStore:
+                data:
+                  jobs: 2
+                destinationPath: some-path
+                endpointURL: some-url
+                s3Credentials:
+                  accessKeyId:
+                    key: ACCESS_KEY_ID
+                    name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
+                  secretAccessKey:
+                    key: ACCESS_SECRET_KEY
+                    name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
+                serverName: test-release-name-common-test-cnpg-my-pg
               retentionPolicy: 10d
               target: primary

--- a/charts/library/common-test/tests/cnpg/cluster_backup_spec_test.yaml
+++ b/charts/library/common-test/tests/cnpg/cluster_backup_spec_test.yaml
@@ -61,7 +61,7 @@ tests:
             backup:
               barmanObjectStore:
                 data:
-                  compression: gzip
+                  compression: bzip2
                   jobs: 2
                 destinationPath: some-path
                 endpointURL: some-url
@@ -74,7 +74,7 @@ tests:
                     name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
                 serverName: test-release-name-common-test-cnpg-my-pg
                 wal:
-                  compression: gzip
+                  compression: bzip2
               retentionPolicy: 10d
               target: primary
 
@@ -129,7 +129,7 @@ tests:
             backup:
               barmanObjectStore:
                 data:
-                  compression: gzip
+                  compression: bzip2
                   jobs: 2
                 destinationPath: some-path
                 endpointURL: some-url
@@ -142,7 +142,7 @@ tests:
                     name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
                 serverName: test-release-name-common-test-cnpg-my-pg-rsome-revision
                 wal:
-                  compression: gzip
+                  compression: bzip2
               retentionPolicy: 10d
               target: primary
 
@@ -197,7 +197,7 @@ tests:
             backup:
               barmanObjectStore:
                 data:
-                  compression: gzip
+                  compression: bzip2
                   jobs: 2
                 destinationPath: some-path
                 endpointURL: some-url
@@ -210,7 +210,7 @@ tests:
                     name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
                 serverName: some-server-name
                 wal:
-                  compression: gzip
+                  compression: bzip2
               retentionPolicy: 10d
               target: primary
 
@@ -266,7 +266,7 @@ tests:
             backup:
               barmanObjectStore:
                 data:
-                  compression: gzip
+                  compression: bzip2
                   jobs: 2
                 destinationPath: some-path
                 endpointURL: some-url
@@ -279,7 +279,7 @@ tests:
                     name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
                 serverName: some-server-name-r1
                 wal:
-                  compression: gzip
+                  compression: bzip2
               retentionPolicy: 10d
               target: primary
 
@@ -335,7 +335,7 @@ tests:
             backup:
               barmanObjectStore:
                 data:
-                  compression: gzip
+                  compression: bzip2
                   encryption: AES256
                   jobs: 2
                 destinationPath: some-path
@@ -349,7 +349,7 @@ tests:
                     name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
                 serverName: test-release-name-common-test-cnpg-my-pg
                 wal:
-                  compression: gzip
+                  compression: bzip2
                   encryption: AES256
               retentionPolicy: 10d
               target: primary

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -48,4 +48,4 @@ sources:
   - https://hub.docker.com/r/mikefarah/yq
   - https://hub.docker.com/r/traefik/whoami
 type: library
-version: 25.1.7
+version: 25.2.0

--- a/charts/library/common/templates/lib/cnpg/cluster/_backup.tpl
+++ b/charts/library/common/templates/lib/cnpg/cluster/_backup.tpl
@@ -21,19 +21,19 @@ backup:
       jobs: {{ $objectData.backups.jobs | default 2 }}
       {{- with $compression }}
       compression: {{ . }}
-      {{- end }}
+      {{- end -}}
       {{- with $encryption }}
       encryption: {{ . }}
-      {{- end }}
+      {{- end -}}
     {{- if or $compression $encryption }}
     wal:
       {{- with $compression }}
       compression: {{ . }}
-      {{- end }}
+      {{- end -}}
       {{- with $encryption }}
       encryption: {{ . }}
-      {{- end }}
-    {{- end }}
+      {{- end -}}
+    {{- end -}}
   {{/* Fetch provider data */}}
   {{/* Get the creds defined in backup.$provider */}}
   {{- $creds := (get $rootCtx.Values.credentials $objectData.backups.credentials) -}}

--- a/charts/library/common/templates/lib/cnpg/cluster/_backup.tpl
+++ b/charts/library/common/templates/lib/cnpg/cluster/_backup.tpl
@@ -19,11 +19,11 @@ backup:
   barmanObjectStore:
     data:
       jobs: {{ $objectData.backups.jobs | default 2 }}
-      {{- if $compression }}
-      compression: {{ $compression }}
+      {{- with $compression }}
+      compression: {{ . }}
       {{- end }}
-      {{- if $encryption }}
-      encryption: {{ $encryption }}
+      {{- with $encryption }}
+      encryption: {{ . }}
       {{- end }}
     {{- if or $compression $encryption }}
     wal:

--- a/charts/library/common/templates/lib/cnpg/cluster/_backup.tpl
+++ b/charts/library/common/templates/lib/cnpg/cluster/_backup.tpl
@@ -27,11 +27,11 @@ backup:
       {{- end }}
     {{- if or $compression $encryption }}
     wal:
-      {{- if $compression }}
-      compression: {{ $compression }}
+      {{- with $compression }}
+      compression: {{ . }}
       {{- end }}
-      {{- if $encryption }}
-      encryption: {{ $encryption }}
+      {{- with $encryption }}
+      encryption: {{ . }}
       {{- end }}
     {{- end }}
   {{/* Fetch provider data */}}

--- a/charts/library/common/templates/lib/cnpg/cluster/_backup.tpl
+++ b/charts/library/common/templates/lib/cnpg/cluster/_backup.tpl
@@ -1,6 +1,16 @@
 {{- define "tc.v1.common.lib.cnpg.cluster.backup" -}}
   {{- $rootCtx := .rootCtx -}}
   {{- $objectData := .objectData -}}
+
+  {{- $compression := "gzip" -}}
+  {{- if and $objectData.backups.compression (not $objectData.backups.compression.enabled) -}}
+    {{- $compression = "" -}}
+  {{- end -}}
+
+  {{- $encryption := "" -}}
+  {{- if and $objectData.backups.encryption $objectData.backups.encryption.enabled -}}
+    {{- $encryption = "AES256" -}}
+  {{- end }}
 backup:
   {{- with $objectData.backups.target }}
   target: {{ . }}
@@ -9,13 +19,21 @@ backup:
   barmanObjectStore:
     data:
       jobs: {{ $objectData.backups.jobs | default 2 }}
-  {{- if and $objectData.backups.encryption $objectData.backups.encryption.enabled }}
-      compression: "gzip"
-      encryption: "AES256"
+      {{- if $compression }}
+      compression: {{ $compression }}
+      {{- end }}
+      {{- if $encryption }}
+      encryption: {{ $encryption }}
+      {{- end }}
+    {{- if or $compression $encryption }}
     wal:
-      compression: "gzip"
-      encryption: "AES256"
-  {{- end -}}
+      {{- if $compression }}
+      compression: {{ $compression }}
+      {{- end }}
+      {{- if $encryption }}
+      encryption: {{ $encryption }}
+      {{- end }}
+    {{- end }}
   {{/* Fetch provider data */}}
   {{/* Get the creds defined in backup.$provider */}}
   {{- $creds := (get $rootCtx.Values.credentials $objectData.backups.credentials) -}}

--- a/charts/library/common/templates/lib/cnpg/cluster/_backup.tpl
+++ b/charts/library/common/templates/lib/cnpg/cluster/_backup.tpl
@@ -2,7 +2,7 @@
   {{- $rootCtx := .rootCtx -}}
   {{- $objectData := .objectData -}}
 
-  {{- $compression := "gzip" -}}
+  {{- $compression := "bzip2" -}}
   {{- if and $objectData.backups.compression (not $objectData.backups.compression.enabled) -}}
     {{- $compression = "" -}}
   {{- end -}}


### PR DESCRIPTION
**Description**

Currently compression is only enabled for backups and wal if the encryption is enabled

This PR allows to set encryption and compression parameters separately

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
- Ran the updated tests
- Checked on a live cluster with the different combinations

**📃 Notes:**
I checked if it would impact charts using cnpg with encrypted backups enabled but didn't find any

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`


---

