### PR TITLE
 fix(common, metallb-config) change deprecated annotation prefix to metallb.io

### DIFF
--- a/charts/library/common-test/tests/service/load_balancer_test.yaml
+++ b/charts/library/common-test/tests/service/load_balancer_test.yaml
@@ -57,7 +57,7 @@ tests:
         isSubset:
           path: metadata.annotations
           content:
-            metallb.universe.tf/loadBalancerIPs: "1.2.3.4,5.6.7.8"
+            metallb.io/loadBalancerIPs: "1.2.3.4,5.6.7.8"
 
   - it: should pass with type LoadBalancer and available options set
     set:
@@ -153,4 +153,4 @@ tests:
         isSubset:
           path: metadata.annotations
           content:
-            metallb.universe.tf/loadBalancerIPs: "10.100.200.45"
+            metallb.io/loadBalancerIPs: "10.100.200.45"

--- a/charts/library/common-test/tests/service/metadata_test.yaml
+++ b/charts/library/common-test/tests/service/metadata_test.yaml
@@ -154,7 +154,7 @@ tests:
         isSubset:
           path: metadata.annotations
           content:
-            metallb.universe.tf/allow-shared-ip: test-release-name-common-test
+            metallb.io/allow-shared-ip: test-release-name-common-test
             traefik.ingress.kubernetes.io/service.serversscheme: https
 
   - it: should add metallb shared ip annotation without externalTrafficPolicy
@@ -186,7 +186,7 @@ tests:
         isSubset:
           path: metadata.annotations
           content:
-            metallb.universe.tf/allow-shared-ip: test-release-name-common-test
+            metallb.io/allow-shared-ip: test-release-name-common-test
 
   - it: should add metallb shared ip annotation with externalTrafficPolicy set to Cluster
     set:
@@ -218,7 +218,7 @@ tests:
         isSubset:
           path: metadata.annotations
           content:
-            metallb.universe.tf/allow-shared-ip: test-release-name-common-test
+            metallb.io/allow-shared-ip: test-release-name-common-test
 
   - it: should NOT add metallb shared ip annotation with externalTrafficPolicy set to Local
     set:

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -48,4 +48,4 @@ sources:
   - https://hub.docker.com/_/
   - https://hub.docker.com/r/mikefarah/yq
 type: library
-version: 25.2.5
+version: 25.2.6

--- a/charts/library/common/templates/lib/service/_additionalAnnotations.tpl
+++ b/charts/library/common/templates/lib/service/_additionalAnnotations.tpl
@@ -22,7 +22,7 @@ annotations: The annotations variable reference, to append the MetalLB annotatio
     {{- if $rootCtx.Values.global.metallb.addServiceAnnotations -}}
       {{/* If externalTrafficPolicy is not set or is not Local, add the shared key as annotation */}}
       {{- if ne $objectData.externalTrafficPolicy "Local" -}}
-        {{- $_ := set $annotations "metallb.universe.tf/allow-shared-ip" $sharedKey -}}
+        {{- $_ := set $annotations "metallb.io/allow-shared-ip" $sharedKey -}}
       {{- end -}}
 
       {{- if and $objectData.loadBalancerIP $objectData.loadBalancerIPs -}}
@@ -52,7 +52,7 @@ annotations: The annotations variable reference, to append the MetalLB annotatio
       {{- end -}}
 
       {{- if $ips -}}
-        {{- $_ := set $annotations "metallb.universe.tf/loadBalancerIPs" (join "," $ips) -}}
+        {{- $_ := set $annotations "metallb.io/loadBalancerIPs" (join "," $ips) -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}

--- a/charts/premium/metallb-config/Chart.yaml
+++ b/charts/premium/metallb-config/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v2
 appVersion: latest
 dependencies:
   - name: common
-    version: 25.2.4
+    version: 25.2.6
     repository: oci://tccr.io/truecharts
     condition: ""
     alias: ""
@@ -32,6 +32,6 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/truecharts/charts/tree/master/charts/premium/metallb-config
   - https://hub.docker.com/_/hello-world
-  - https://metallb.universe.tf
+  - https://metallb.io
 type: application
-version: 8.3.1
+version: 8.3.2

--- a/charts/premium/metallb-config/Chart.yaml
+++ b/charts/premium/metallb-config/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v2
 appVersion: latest
 dependencies:
   - name: common
-    version: 25.2.6
+    version: 25.2.4
     repository: oci://tccr.io/truecharts
     condition: ""
     alias: ""

--- a/charts/premium/metallb-config/docs/setup-guide.md
+++ b/charts/premium/metallb-config/docs/setup-guide.md
@@ -43,4 +43,4 @@ Run the command `kubectl get svc -A` to verify the IP addresses assigned for eac
 
 If you have an IP conflict with a previously assigned address it will show as `<pending>`.
 
-For details on other configuration options, please reference the [MetaLB documentation](https://metallb.universe.tf/configuration/).
+For details on other configuration options, please reference the [MetaLB documentation](https://metallb.io/configuration/).

--- a/website/src/content/docs/common/service/LoadBalancer.md
+++ b/website/src/content/docs/common/service/LoadBalancer.md
@@ -25,7 +25,7 @@ title: LoadBalancer
 
 ## `sharedKey`
 
-Sets the shared key in `metallb.universe.tf/allow-shared-ip` **MetalLB** Annotation
+Sets the shared key in `metallb.io/allow-shared-ip` **MetalLB** Annotation
 
 |            |                           |
 | ---------- | ------------------------- |
@@ -45,7 +45,7 @@ service:
 
 ## `loadBalancerIP`
 
-Define the load balancer IP, sets the `metallb.universe.tf/loadBalancerIPs` **MetalLB** annotation. Mutually exclusive with `loadBalancerIPs`
+Define the load balancer IP, sets the `metallb.io/loadBalancerIPs` **MetalLB** annotation. Mutually exclusive with `loadBalancerIPs`
 
 |            |                                |
 | ---------- | ------------------------------ |
@@ -65,7 +65,7 @@ service:
 
 ## `loadBalancerIPs`
 
-Define the load balancer IPs, sets the `metallb.universe.tf/loadBalancerIPs` **MetalLB** annotation. Mutually exclusive with `loadBalancerIP`
+Define the load balancer IPs, sets the `metallb.io/loadBalancerIPs` **MetalLB** annotation. Mutually exclusive with `loadBalancerIP`
 
 |            |                                 |
 | ---------- | ------------------------------- |


### PR DESCRIPTION
**Description**

metallb deprecated the old annotation prefix metallb.universe.tf in favor of metallb.io. See [release-notes](https://metallb.universe.tf/release-notes/) and [pr-2495](https://github.com/metallb/metallb/pull/2495)

This currently leads to warnings in logs for pods using loadbalancer ips.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
