### PR TITLE
fix(clustertool): localtime should be fetched after NTP time

### DIFF
--- a/clustertool/pkg/helper/time.go
+++ b/clustertool/pkg/helper/time.go
@@ -13,8 +13,6 @@ import (
 func CheckSystemTime() bool {
     log.Info().Msg("Checking if System Time is correct...")
     threshold := 5 * time.Second
-    // Get the current system time
-    systemTime := time.Now()
 
     // Get the time from an NTP server
     ntpTime, err := ntp.Time("pool.ntp.org")
@@ -22,6 +20,9 @@ func CheckSystemTime() bool {
         log.Info().Msgf("Failed to get NTP time: %v", err)
         return true
     }
+
+    // Get the current system time
+    systemTime := time.Now()
 
     // Calculate the difference between system time and NTP time
     timeDifference := systemTime.Sub(ntpTime)

--- a/clustertool/pkg/helper/time.go
+++ b/clustertool/pkg/helper/time.go
@@ -12,7 +12,7 @@ import (
 // checkSystemTime compares the system time with an NTP server time and returns whether it's correct within the given threshold
 func CheckSystemTime() bool {
     log.Info().Msg("Checking if System Time is correct...")
-    threshold := 5 * time.Second
+    threshold := 10 * time.Second
 
     // Get the time from an NTP server
     ntpTime, err := ntp.Time("pool.ntp.org")


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #30580
By swapping the localtime and the NTP time in the code, we ensure the time it takes to receive an answer from the NTP server is not actually counted as a time discrepancy.

I also increase the threshold from 5 to 10 seconds since problem always seems to be at just above 5 seconds.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

I compiled clustertool from source with the proposed modification. It solved the issue.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
