### PR TITLE
fix(actualserver): fix actualserver mountPaths  **BREAKING CHANGE**

### DIFF
--- a/charts/stable/actualserver/Chart.yaml
+++ b/charts/stable/actualserver/Chart.yaml
@@ -33,4 +33,4 @@ sources:
   - https://github.com/Kippenhof/docker-templates
   - https://github.com/truecharts/charts/tree/master/charts/stable/actualserver
 type: application
-version: 12.11.0
+version: 13.0.0

--- a/charts/stable/actualserver/values.yaml
+++ b/charts/stable/actualserver/values.yaml
@@ -32,12 +32,9 @@ service:
         protocol: http
         targetPort: 5006
 persistence:
-  server-files:
+  data:
     enabled: true
-    mountPath: /data/server-files
-  user-files:
-    enabled: true
-    mountPath: /data/user-files
+    mountPath: /data
 portal:
   open:
     enabled: true


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Actualserver creates a .migrate file in /data which also needs to be persisted. 
Only mounting the /data folder is also the current example setup for actualserver https://github.com/actualbudget/actual-server/blob/master/docker-compose.yml#L21
This would be a breaking change and require exporting and importing all data on upgrade.
⚒️ Fixes  #30662

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
