### PR TITLE
fix(handbrake): implement handbrake.DARK_MODE

### DIFF
--- a/charts/stable/handbrake/Chart.yaml
+++ b/charts/stable/handbrake/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://handbrake.fr/
   - https://hub.docker.com/r/jlesage/handbrake
 type: application
-version: 23.8.1
+version: 23.8.2

--- a/charts/stable/handbrake/values.yaml
+++ b/charts/stable/handbrake/values.yaml
@@ -25,6 +25,7 @@ handbrake:
   AUTOMATED_CONVERSION_FORMAT: "mp4"
   AUTOMATED_CONVERSION_KEEP_SOURCE: true
   AUTOMATED_CONVERSION_NON_VIDEO_FILE_ACTION: "ignore"
+  DARK_MODE: false
 configmap:
   handbrake:
     enabled: true
@@ -38,6 +39,7 @@ configmap:
       AUTOMATED_CONVERSION_PRESET: "{{ .Values.handbrake.AUTOMATED_CONVERSION_PRESET }}"
       AUTOMATED_CONVERSION_FORMAT: "{{ .Values.handbrake.AUTOMATED_CONVERSION_FORMAT }}"
       AUTOMATED_CONVERSION_NON_VIDEO_FILE_ACTION: "{{ .Values.handbrake.AUTOMATED_CONVERSION_NON_VIDEO_FILE_ACTION }}"
+      DARK_MODE: '{{ ternary "1" "0" .Values.handbrake.DARK_MODE }}'
 persistence:
   config:
     enabled: true


### PR DESCRIPTION
**Description**

Adds DARK_MODE to the list of values set under `values.handbrake` so that this is included in the configmap, in preference to the user adding under `workload.main.podSpec.[..].env`.

It is added with value `false` by default.

This is implemented in the same way as in the makemkv chart, whose upstream maintainer is the same as for handbrake, and follows the model already used for existing values set under this section of the chart. For this reason I have updated as semVer patch only.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Confirmed locally that this value can be set under `workload.main.podSpec.containers.main.env` and is implemented as DARK_MODE setting.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
