### PR TITLE
fix(customVersioning): correct formating for customVersioning.json5

### DIFF
--- a/.github/renovate/special/customVersioning.json5
+++ b/.github/renovate/special/customVersioning.json5
@@ -29,206 +29,206 @@
       "matchPackagePatterns": ["postgresql"],
       "allowedVersions": "<17"
     },
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>14)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["tccr.io/tccr/postgresql"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^v(?<major>\\d{2})(?<minor>\\d{2})(?<patch>\\d{2})$",
-  matchPackageNames: ["photoprism"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^v(?<major>\\d{4})-(?<minor>\\d{2})$",
-  matchPackageNames: ["rssbridge/rss-bridge"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d{2})\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["linuxserver/heimdall"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^v(?<major>\\d+)-(?<minor>\\d+)$",
-  matchPackagePrefixes: ["jupyter"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>14)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackagePatterns: ["^bitnami/postgresql$"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})$",
-  matchPackagePatterns: ["^.*oznu\\/homebridge$"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)$",
-  matchPackagePatterns: ["^jupyter\\/.+$"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ubuntu$",
-  matchPackagePatterns: ["^zabbix\\/zabbix-.*$"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^stable-(?<major>\\d{1})(?<minor>\\d{1})(?<patch>\\d{2}).*$",
-  matchPackagePatterns: ["^jitsi\\/.*$"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^latest-(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})$",
-  matchPackagePatterns: ["^wangqiru/ttrss$"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackagePatterns: ["^penpot\\/.*$"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^\\d+-jammy-(?<compatibility>(full|lite))-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackagePatterns: ["^.+\\/koush\\/scrypted$"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^version-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-.*$",
-  matchPackagePatterns: ["^.*linuxserver\\/deluge$"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-postgres-tomcat$",
-  matchPackageNames: ["xwiki"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^version-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["fireflyiii/core"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-\\d+\\.\\d+\\.\\d+$",
-  matchPackageNames: ["netboxcommunity/netbox"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d{2})(?<minor>\\d{2})(?<patch>\\d{2})$",
-  matchPackageNames: ["photoprism/photoprism"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["cloudflare/cloudflared"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^version-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["linuxserver/calibre-web"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^postgresql-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["ghcr.io/umami-software/umami"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^version-v(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>\\d*)$",
-  matchPackageNames: ["linuxserver/mylar3"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^[a-z0-9]{9}-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-go\\d+\\.\\d+\\.\\d+$",
-  matchPackageNames: ["storjlabs/storagenode"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-php8\\.0-apache$",
-  matchPackageNames: ["joyqi/typecho"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^v\\.(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["difegue/lanraragi"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^RELEASE\\.(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)T\\d+-\\d+-\\d+Z$",
-  matchPackageNames: ["minio/minio"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^RELEASE\\.(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)T\\d+-\\d+-\\d+Z$",
-  matchPackageNames: ["minio/mc"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^apache-(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>\\d*)-prod$",
-  matchPackageNames: ["kimai/kimai2"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)$",
-  matchPackageNames: ["rssbridge/rss-bridge"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)$",
-  matchPackageNames: ["alexta69/metube"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^focal-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["codeproject/senseai-server"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^latest-(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)$",
-  matchPackageNames: ["codeproject/senseai-client"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackagePatterns: ["^snyk/snyk$"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["ghcr.io/cirruslabs/ubuntu"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["bcavin/hexo"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["linode/lke"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["mcr.microsoft.com/mssql/server"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^\\d+\\.(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["mcr.microsoft.com/dotnet/runtime"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["coder/coder"],
-},
-{
-  matchDatasources: ["docker"],
-  versioning: "regex:^latest-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-  matchPackageNames: ["registry.gitlab.com/gitlab-org/gitlab-runner"],
-},
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>14)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["tccr.io/tccr/postgresql"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^v(?<major>\\d{2})(?<minor>\\d{2})(?<patch>\\d{2})$",
+      "matchPackageNames": ["photoprism"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^v(?<major>\\d{4})-(?<minor>\\d{2})$",
+      "matchPackageNames": ["rssbridge/rss-bridge"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d{2})\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["linuxserver/heimdall"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^v(?<major>\\d+)-(?<minor>\\d+)$",
+      "matchPackagePrefixes": ["jupyter"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>14)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackagePatterns": ["^bitnami/postgresql$"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})$",
+      "matchPackagePatterns": ["^.*oznu\\/homebridge$"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)$",
+      "matchPackagePatterns": ["^jupyter\\/.+$"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ubuntu$",
+      "matchPackagePatterns": ["^zabbix\\/zabbix-.*$"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^stable-(?<major>\\d{1})(?<minor>\\d{1})(?<patch>\\d{2}).*$",
+      "matchPackagePatterns": ["^jitsi\\/.*$"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^latest-(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})$",
+      "matchPackagePatterns": ["^wangqiru/ttrss$"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackagePatterns": ["^penpot\\/.*$"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^\\d+-jammy-(?<compatibility>(full|lite))-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackagePatterns": ["^.+\\/koush\\/scrypted$"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^version-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-.*$",
+      "matchPackagePatterns": ["^.*linuxserver\\/deluge$"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-postgres-tomcat$",
+      "matchPackageNames": ["xwiki"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^version-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["fireflyiii/core"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-\\d+\\.\\d+\\.\\d+$",
+      "matchPackageNames": ["netboxcommunity/netbox"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d{2})(?<minor>\\d{2})(?<patch>\\d{2})$",
+      "matchPackageNames": ["photoprism/photoprism"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["cloudflare/cloudflared"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^version-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["linuxserver/calibre-web"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^postgresql-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["ghcr.io/umami-software/umami"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^version-v(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>\\d*)$",
+      "matchPackageNames": ["linuxserver/mylar3"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^[a-z0-9]{9}-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-go\\d+\\.\\d+\\.\\d+$",
+      "matchPackageNames": ["storjlabs/storagenode"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-php8\\.0-apache$",
+      "matchPackageNames": ["joyqi/typecho"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^v\\.(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["difegue/lanraragi"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^RELEASE\\.(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)T\\d+-\\d+-\\d+Z$",
+      "matchPackageNames": ["minio/minio"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^RELEASE\\.(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)T\\d+-\\d+-\\d+Z$",
+      "matchPackageNames": ["minio/mc"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^apache-(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>\\d*)-prod$",
+      "matchPackageNames": ["kimai/kimai2"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)$",
+      "matchPackageNames": ["rssbridge/rss-bridge"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)$",
+      "matchPackageNames": ["alexta69/metube"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^focal-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["codeproject/senseai-server"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^latest-(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)$",
+      "matchPackageNames": ["codeproject/senseai-client"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackagePatterns": ["^snyk/snyk$"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["ghcr.io/cirruslabs/ubuntu"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["bcavin/hexo"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["linode/lke"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["mcr.microsoft.com/mssql/server"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^\\d+\\.(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["mcr.microsoft.com/dotnet/runtime"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["coder/coder"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^latest-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "matchPackageNames": ["registry.gitlab.com/gitlab-org/gitlab-runner"]
+    },
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)(?<minor>\\d{2})(?<patch>\\d{2})-ls(?<build>\\d+)$",


### PR DESCRIPTION
**Description**
formating of customVersioning.json5 is not correct, and it seems like renovate is not using the implemented rules. I have checked a view packages (mylar3, calibre-web, oscam, scrypted) and all of them are outdated. 

hoping to fix this by fixing formating


⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
