### PR TITLE
fix(renovate): explicit package names in customVersioning.json5

### DIFF
--- a/.github/renovate/special/customVersioning.json5
+++ b/.github/renovate/special/customVersioning.json5
@@ -99,7 +99,7 @@
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-postgres-tomcat$",
-      "matchPackageNames": ["xwiki"]
+      "matchPackageNames": ["docker.io/library/xwiki"]
     },
     {
       "matchDatasources": ["docker"],
@@ -203,13 +203,13 @@
       // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "matchPackageNames": ["bcavin/hexo"]
+      "matchPackageNames": ["docker.io/bcavin/hexo"]
     },
     {
       // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "matchPackageNames": ["linode/lke"]
+      "matchPackageNames": ["docker.io/linode/lke"]
     },
     {
       // Not found in repository 2025-02-01
@@ -227,7 +227,7 @@
       // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "matchPackageNames": ["coder/coder"]
+      "matchPackageNames": ["docker.io/coder/coder"]
     },
     {
       // Not found in repository 2025-02-01

--- a/.github/renovate/special/customVersioning.json5
+++ b/.github/renovate/special/customVersioning.json5
@@ -25,9 +25,8 @@
       "allowedVersions": "<999"
     },
     {
-      // !Confirm match against recent PRs
       "matchDatasources": ["docker"],
-      "matchPackagePatterns": ["postgresql"],
+      "matchPackagePatterns": ["ghcr.io/cloudnative-pg/postgresql"],
       "allowedVersions": "<17"
     },
     {

--- a/.github/renovate/special/customVersioning.json5
+++ b/.github/renovate/special/customVersioning.json5
@@ -16,20 +16,22 @@
     {
       "description": ["Custom versioning for minio"],
       "matchDatasources": ["docker"],
-      "matchPackagePatterns": ["minio"],
+      "matchPackagePatterns": ["docker.io/minio/minio"],
       "versioning": "regex:^RELEASE\\.(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)T.*Z$"
     },
     {
       "matchDatasources": ["docker"],
-      "matchPackagePatterns": ["kopia"],
+      "matchPackagePatterns": ["docker.io/kopia/kopia"],
       "allowedVersions": "<999"
     },
     {
+      // !Confirm match against recent PRs
       "matchDatasources": ["docker"],
       "matchPackagePatterns": ["postgresql"],
       "allowedVersions": "<17"
     },
     {
+      // Not found in repository
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>14)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "matchPackageNames": ["tccr.io/tccr/postgresql"]
@@ -37,12 +39,7 @@
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^v(?<major>\\d{2})(?<minor>\\d{2})(?<patch>\\d{2})$",
-      "matchPackageNames": ["photoprism"]
-    },
-    {
-      "matchDatasources": ["docker"],
-      "versioning": "regex:^v(?<major>\\d{4})-(?<minor>\\d{2})$",
-      "matchPackageNames": ["rssbridge/rss-bridge"]
+      "matchPackageNames": ["docker.io/photoprism/photoprism"]
     },
     {
       "matchDatasources": ["docker"],
@@ -50,11 +47,13 @@
       "matchPackageNames": ["linuxserver/heimdall"]
     },
     {
+      // Duplicated below
       "matchDatasources": ["docker"],
       "versioning": "regex:^v(?<major>\\d+)-(?<minor>\\d+)$",
       "matchPackagePrefixes": ["jupyter"]
     },
     {
+      // Not found in respository - alternative package used - 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>14)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "matchPackagePatterns": ["^bitnami/postgresql$"]
@@ -62,7 +61,7 @@
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})$",
-      "matchPackagePatterns": ["^.*oznu\\/homebridge$"]
+      "matchPackagePatterns": ["docker.io/homebridge/homebridge"]
     },
     {
       "matchDatasources": ["docker"],
@@ -70,21 +69,25 @@
       "matchPackagePatterns": ["^jupyter\\/.+$"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ubuntu$",
       "matchPackagePatterns": ["^zabbix\\/zabbix-.*$"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^stable-(?<major>\\d{1})(?<minor>\\d{1})(?<patch>\\d{2}).*$",
       "matchPackagePatterns": ["^jitsi\\/.*$"]
     },
     {
+      // Not found in repository - alternative package used 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^latest-(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})$",
       "matchPackagePatterns": ["^wangqiru/ttrss$"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "matchPackagePatterns": ["^penpot\\/.*$"]
@@ -92,12 +95,12 @@
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^\\d+-jammy-(?<compatibility>(full|lite))-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "matchPackagePatterns": ["^.+\\/koush\\/scrypted$"]
+      "matchPackagePatterns": ["docker.io/koush/scrypted"]
     },
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^version-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-.*$",
-      "matchPackagePatterns": ["^.*linuxserver\\/deluge$"]
+      "matchPackagePatterns": ["ghcr.io/linuxserver/deluge"]
     },
     {
       "matchDatasources": ["docker"],
@@ -107,9 +110,10 @@
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^version-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "matchPackageNames": ["fireflyiii/core"]
+      "matchPackageNames": ["docker.io/fireflyiii/core"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-\\d+\\.\\d+\\.\\d+$",
       "matchPackageNames": ["netboxcommunity/netbox"]
@@ -117,17 +121,17 @@
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d{2})(?<minor>\\d{2})(?<patch>\\d{2})$",
-      "matchPackageNames": ["photoprism/photoprism"]
+      "matchPackageNames": ["docker.io/photoprism/photoprism"]
     },
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "matchPackageNames": ["cloudflare/cloudflared"]
+      "matchPackageNames": ["docker.io/cloudflare/cloudflared"]
     },
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^version-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "matchPackageNames": ["linuxserver/calibre-web"]
+      "matchPackageNames": ["lscr.io/linuxserver/calibre-web"]
     },
     {
       "matchDatasources": ["docker"],
@@ -137,14 +141,15 @@
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^version-v(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>\\d*)$",
-      "matchPackageNames": ["linuxserver/mylar3"]
+      "matchPackageNames": ["lscr.io/linuxserver/mylar3"]
     },
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^[a-z0-9]{9}-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-go\\d+\\.\\d+\\.\\d+$",
-      "matchPackageNames": ["storjlabs/storagenode"]
+      "matchPackageNames": ["docker.io/storjlabs/storagenode"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-php8\\.0-apache$",
       "matchPackageNames": ["joyqi/typecho"]
@@ -152,19 +157,16 @@
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^v\\.(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "matchPackageNames": ["difegue/lanraragi"]
+      "matchPackageNames": ["docker.io/difegue/lanraragi"]
     },
     {
-      "matchDatasources": ["docker"],
-      "versioning": "regex:^RELEASE\\.(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)T\\d+-\\d+-\\d+Z$",
-      "matchPackageNames": ["minio/minio"]
-    },
-    {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^RELEASE\\.(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)T\\d+-\\d+-\\d+Z$",
       "matchPackageNames": ["minio/mc"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^apache-(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>\\d*)-prod$",
       "matchPackageNames": ["kimai/kimai2"]
@@ -172,7 +174,7 @@
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)$",
-      "matchPackageNames": ["rssbridge/rss-bridge"]
+      "matchPackageNames": ["docker.io/rssbridge/rss-bridge"]
     },
     {
       "matchDatasources": ["docker"],
@@ -180,51 +182,61 @@
       "matchPackageNames": ["docker.io/alexta69/metube"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^focal-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "matchPackageNames": ["codeproject/senseai-server"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^latest-(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)$",
       "matchPackageNames": ["codeproject/senseai-client"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "matchPackagePatterns": ["^snyk/snyk$"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "matchPackageNames": ["ghcr.io/cirruslabs/ubuntu"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "matchPackageNames": ["bcavin/hexo"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "matchPackageNames": ["linode/lke"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "matchPackageNames": ["mcr.microsoft.com/mssql/server"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^\\d+\\.(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "matchPackageNames": ["mcr.microsoft.com/dotnet/runtime"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "matchPackageNames": ["coder/coder"]
     },
     {
+      // Not found in repository 2025-02-01
       "matchDatasources": ["docker"],
       "versioning": "regex:^latest-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "matchPackageNames": ["registry.gitlab.com/gitlab-org/gitlab-runner"]
@@ -232,12 +244,12 @@
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d+)(?<minor>\\d{2})(?<patch>\\d{2})-ls(?<build>\\d+)$",
-      "matchPackageNames": ["linuxserver/oscam"]
+      "matchPackageNames": ["ghcr.io/linuxserver/oscam"]
     },
     {
       "matchDatasources": ["docker"],
-      "matchPackageNames": ["alicevision/meshroom"],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+      "matchPackageNames": ["docker.io/alicevision/meshroom"],
+      "versioning": "regex:^version-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
     }
   ]
 }

--- a/.github/renovate/special/customVersioning.json5
+++ b/.github/renovate/special/customVersioning.json5
@@ -25,11 +25,6 @@
       "allowedVersions": "<999"
     },
     {
-      "matchDatasources": ["docker"],
-      "matchPackagePatterns": ["ghcr.io/cloudnative-pg/postgresql"],
-      "allowedVersions": "<17"
-    },
-    {
       // Not found in repository
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>14)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",

--- a/.github/renovate/special/customVersioning.json5
+++ b/.github/renovate/special/customVersioning.json5
@@ -38,7 +38,7 @@
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d{2})\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "matchPackageNames": ["linuxserver/heimdall"]
+      "matchPackageNames": ["lscr.io/linuxserver/heimdall"]
     },
     {
       // Duplicated below


### PR DESCRIPTION
**Description**

Confirms all matchPackagePatterns explicitly include full repository names as referenced in the relevant values.yaml - it was found that Renovate had not been picking up these matches.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Confirmed by PrivatePuffin that it was necessary add full match in commit https://github.com/truecharts/public/commit/5047c596eefda4e98e4a5a5cb0aaed258f561583

**📃 Notes:**
In the process of looking up the full repository names used in the values.yaml, it has been found that some packages referenced in this file no longer appear to be used in the repository. I have not removed these at the point of submitting this PR but am happy to do this if desirable.

Some packages were duplicated within this document - the duplicates have been removed.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
