### PR TITLE
feat(common): Add destinationPVC when volsync direct copy method is used

### DIFF
--- a/.github/workflows/common-tests.yaml
+++ b/.github/workflows/common-tests.yaml
@@ -159,6 +159,8 @@ jobs:
           ## TODO: reenable when we've some credentials ready to rock for testing
           # - volsync-dest-values.yaml
           # - volsync-src-values.yaml
+          # - volsync-dest-direct-values.yaml
+          # - volsync-src-direct-values.yaml
 
     steps:
       - name: Checkout

--- a/charts/library/common-test/ci/volsync-dest-direct-values.yaml
+++ b/charts/library/common-test/ci/volsync-dest-direct-values.yaml
@@ -36,19 +36,21 @@ workload:
               port: "{{ .Values.service.main.ports.main.port }}"
 
 persistence:
-  srcbackup:
+  destbackup:
     enabled: true
     type: pvc
     mountPath: /backedup
+    copyMethod: Direct
     targetSelectAll: true
     volsync:
       - name: mybackup
         type: restic
+        copyMethod: Direct
         credentials: mys3
         dest:
-          enabled: false
-        src:
           enabled: true
+        src:
+          enabled: false
 
 credentials:
   mys3:

--- a/charts/library/common-test/ci/volsync-dest-values.yaml
+++ b/charts/library/common-test/ci/volsync-dest-values.yaml
@@ -53,7 +53,7 @@ persistence:
 credentials:
   mys3:
     type: s3
-    url: "test"
+    url: "http://test"
     bucket: "test"
     accessKey: "test"
     secretKey: "test"

--- a/charts/library/common-test/ci/volsync-src-direct-values.yaml
+++ b/charts/library/common-test/ci/volsync-src-direct-values.yaml
@@ -40,11 +40,13 @@ persistence:
     enabled: true
     type: pvc
     mountPath: /backedup
+    copyMethod: Direct
     targetSelectAll: true
     volsync:
       - name: mybackup
         type: restic
         credentials: mys3
+        copyMethod: Direct
         dest:
           enabled: false
         src:

--- a/charts/library/common-test/tests/volsync/replication_dest_spec_test.yaml
+++ b/charts/library/common-test/tests/volsync/replication_dest_spec_test.yaml
@@ -304,3 +304,49 @@ tests:
                 fsGroup: 568
                 runAsUser: 568
                 runAsGroup: 568
+
+  - it: should generate correct spec with destinationPVC
+    set:
+      persistence:
+        destbackup:
+          enabled: true
+          type: pvc
+          mountPath: /backedup
+          volsync:
+            - name: mybackup1
+              type: restic
+              credentials: mys3
+              copyMethod: Direct
+              dest:
+                enabled: true
+                capacity: 200Gi
+              src:
+                enabled: false
+      credentials: *credentials
+    asserts:
+      - documentIndex: *replicationDestDoc
+        isKind:
+          of: ReplicationDestination
+      - documentIndex: *replicationDestDoc
+        isAPIVersion:
+          of: volsync.backube/v1alpha1
+      - documentIndex: *replicationDestDoc
+        equal:
+          path: spec
+          value:
+            trigger:
+              manual: restore-once
+            restic:
+              repository: test-release-name-common-test-destbackup-volsync-mybackup1
+              copyMethod: Direct
+              cleanupTempPVC: false
+              cleanupCachePVC: false
+              destinationPVC: test-release-name-common-test-destbackup
+              cacheCapacity: 10Gi
+              capacity: 200Gi
+              accessModes:
+                - ReadWriteOnce
+              moverSecurityContext:
+                fsGroup: 568
+                runAsUser: 568
+                runAsGroup: 568

--- a/charts/library/common/templates/class/volsync/_replicationDestination.tpl
+++ b/charts/library/common/templates/class/volsync/_replicationDestination.tpl
@@ -56,6 +56,9 @@ spec:
     repository: {{ $volsyncData.repository }}
     copyMethod: {{ $volsyncData.copyMethod | default "Snapshot"}}
     capacity: {{ $capacity }}
+{{- if and (hasKey $volsyncData "copyMethod") (eq $volsyncData.copyMethod "Direct") }}
+    destinationPVC: {{ $objectData.name }}
+{{- end }}
     cleanupTempPVC: {{ $cleanupTempPVC }}
     cleanupCachePVC: {{ $cleanupCachePVC }}
   {{- include "tc.v1.common.lib.volsync.storage" (dict "rootCtx" $rootCtx "objectData" $objectData "volsyncData" $volsyncData "target" "dest") | trim | nindent 4 }}

--- a/charts/library/common/templates/class/volsync/_replicationDestination.tpl
+++ b/charts/library/common/templates/class/volsync/_replicationDestination.tpl
@@ -26,6 +26,7 @@ objectData:
     {{- $cleanupCachePVC = $volsyncData.cleanupCachePVC -}}
   {{- end -}}
 
+  {{- $copyMethod := $volsyncData.copyMethod | default "Snapshot" -}}
   {{- $capacity := $rootCtx.Values.global.fallbackDefaults.pvcSize -}}
   {{- if $objectData.size -}}
     {{- $capacity = $objectData.size -}}
@@ -54,11 +55,11 @@ spec:
     manual: restore-once
   {{ $volsyncData.type }}:
     repository: {{ $volsyncData.repository }}
-    copyMethod: {{ $volsyncData.copyMethod | default "Snapshot"}}
+    copyMethod: {{ $copyMethod }}
     capacity: {{ $capacity }}
-{{- if and (hasKey $volsyncData "copyMethod") (eq $volsyncData.copyMethod "Direct") }}
+    {{- if eq $copyMethod "Direct" }}
     destinationPVC: {{ $objectData.name }}
-{{- end }}
+    {{- end }}
     cleanupTempPVC: {{ $cleanupTempPVC }}
     cleanupCachePVC: {{ $cleanupCachePVC }}
   {{- include "tc.v1.common.lib.volsync.storage" (dict "rootCtx" $rootCtx "objectData" $objectData "volsyncData" $volsyncData "target" "dest") | trim | nindent 4 }}


### PR DESCRIPTION
**Description**
When using direct copy method of volsync, the destinationPVC shall be set in order to restore the file in the corresponding volume.
This modification adds the correct attribute when this copy method is active  
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
I was not able to test it as I did not found the instruction to load my branch in FluxCD.
**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
