### PR TITLE
chore(clustertool) change included patch format and add nvidia patch

### DIFF
--- a/clustertool/embed/generic/patches/all.yaml
+++ b/clustertool/embed/generic/patches/all.yaml
@@ -1,49 +1,39 @@
-- op: replace
-  path: /machine/time
-  value:
-    "disabled": false
-    "servers":
-      - "time.cloudflare.com"
-- op: replace
-  path: /cluster/proxy
-  value:
-    "disabled": true
-- op: add
-  path: /machine/kubelet/extraArgs
-  value:
-    "rotate-server-certificates": true
-- op: add
-  path: /machine/kubelet/extraConfig
-  value:
-    "maxPods": 250
-    "shutdownGracePeriod": "15s"
-    "shutdownGracePeriodCriticalPods": "10s"
-- op: add
-  path: /machine/kubelet/extraMounts
-  value:
-    - "destination": "/var/openebs/local"
-      "type": "bind"
-      "source": "/var/openebs/local"
-      "options":
-        - "bind"
-        - "rshared"
-        - "rw"
-    - destination: /var/lib/longhorn
-      type: bind
-      source: /var/lib/longhorn
-      options:
-        - bind
-        - rshared
-        - rw
-- op: replace
-  path: /machine/features/hostDNS
-  value:
-    enabled: true
-    resolveMemberNames: true
-    forwardKubeDNSToHost: true
-- op: add
-  path: /machine/sysctls
-  value:
+cluster:
+  proxy:
+    disabled: true
+machine:
+  time:
+    disabled: false
+    servers:
+      - time.cloudflare.com
+  kubelet:
+    extraArgs:
+      rotate-server-certificates: "true"
+    extraConfig:
+      maxPods: 250
+      shutdownGracePeriod: 15s
+      shutdownGracePeriodCriticalPods: 10s
+    extraMounts:
+      - destination: /var/openebs/local
+        type: bind
+        source: /var/openebs/local
+        options:
+          - bind
+          - rshared
+          - rw
+      - destination: /var/lib/longhorn
+        type: bind
+        source: /var/lib/longhorn
+        options:
+          - bind
+          - rshared
+          - rw
+  features:
+    hostDNS:
+      enabled: true
+      forwardKubeDNSToHost: true
+      resolveMemberNames: true
+  sysctls:
     fs.inotify.max_queued_events: "65536"
     fs.inotify.max_user_instances: "8192"
     fs.inotify.max_user_watches: "524288"
@@ -58,47 +48,45 @@
     net.ipv4.tcp_wmem: 4096 65536 33554432 # 10Gb/s
     net.ipv4.tcp_window_scaling: 1         # 10Gb/s
     vm.nr_hugepages: 1024                  # PostgreSQL
-
-- op: add
-  path: /machine/registries/mirrors
-  value:
-    cgr.dev:
-      endpoints:
-        - https://cgr.dev
-    docker.io:
-      endpoints:
-        - https://mirror.gcr.io
-        - https://registry-1.docker.io
-        - https://docker.io
-    registry-1.docker.io:
-      endpoints:
-        - https://mirror.gcr.io
-        - https://registry-1.docker.io
-    ghcr.io:
-      endpoints:
-        - https://ghcr.io
-    quay.io:
-      endpoints:
-        - https://quay.io
-    mcr.microsoft.com:
-      endpoints:
-        - https://mcr.microsoft.com
-    public.ecr.aws:
-      endpoints:
-        - https://public.ecr.aws
-    gcr.io:
-      endpoints:
-        - https://gcr.io
-    registry.k8s.io:
-      endpoints:
-        - https://registry.k8s.io
-    k8s.gcr.io:
-      endpoints:
-        - https://k8s.gcr.io
-    tccr.io:
-      endpoints:
-        - https://quay.io
-        - https://tccr.io
-    factory.talos.dev:
-      endpoints:
-        - https://factory.talos.dev
+  registries:
+    mirrors:
+      cgr.dev:
+        endpoints:
+          - https://cgr.dev
+      docker.io:
+        endpoints:
+          - https://mirror.gcr.io
+          - https://registry-1.docker.io
+          - https://docker.io
+      factory.talos.dev:
+        endpoints:
+          - https://factory.talos.dev
+      gcr.io:
+        endpoints:
+          - https://gcr.io
+      ghcr.io:
+        endpoints:
+          - https://ghcr.io
+      k8s.gcr.io:
+        endpoints:
+          - https://k8s.gcr.io
+      mcr.microsoft.com:
+        endpoints:
+          - https://mcr.microsoft.com
+      public.ecr.aws:
+        endpoints:
+          - https://public.ecr.aws
+      quay.io:
+        endpoints:
+          - https://quay.io
+      registry-1.docker.io:
+        endpoints:
+          - https://mirror.gcr.io
+          - https://registry-1.docker.io
+      registry.k8s.io:
+        endpoints:
+          - https://registry.k8s.io
+      tccr.io:
+        endpoints:
+          - https://quay.io
+          - https://tccr.io

--- a/clustertool/embed/generic/patches/controlplane.yaml
+++ b/clustertool/embed/generic/patches/controlplane.yaml
@@ -18,17 +18,8 @@ cluster:
     admissionControl:
       - name: PodSecurity
         configuration:
-          apiVersion: pod-security.admission.config.k8s.io/v1alpha1
-          defaults:
-            audit: restricted
-            audit-version: latest
-            enforce: baseline
-            enforce-version: latest
-            warn: restricted
-            warn-version: latest
           exemptions:
             namespaces:
-              - kube-system
               - metallb
               - metallb-config
               - topolvm-system
@@ -39,9 +30,6 @@ cluster:
               - snapshot-controller
               - volsync
               - flux-system
-            runtimeClasses: []
-            usernames: []
-          kind: PodSecurityConfiguration
   scheduler:
     config:
       apiVersion: kubescheduler.config.k8s.io/v1

--- a/clustertool/embed/generic/patches/controlplane.yaml
+++ b/clustertool/embed/generic/patches/controlplane.yaml
@@ -1,27 +1,21 @@
-- op: add
-  path: /cluster/proxy/extraArgs
-  value:
-    "metrics-bind-address": "0.0.0.0:10249"
-- op: add
-  path: /cluster/controllerManager/extraArgs
-  value:
-    "bind-address": "0.0.0.0"
-
-- op: add
-  path: /cluster/scheduler/extraArgs
-  value:
-    "bind-address": "0.0.0.0"
-
-- op: add
-  path: /cluster/apiServer/extraArgs
-  value:
-    enable-aggregator-routing: true
-    runtime-config: admissionregistration.k8s.io/v1alpha1=true
-    feature-gates: MutatingAdmissionPolicy=true
-
-- op: replace
-  path: /cluster/apiServer/admissionControl
-  value:
+machine:
+  features:
+    kubernetesTalosAPIAccess:
+      enabled: true
+      allowedRoles:
+        - os:admin
+      allowedKubernetesNamespaces:
+        - system-upgrade
+cluster:
+  controllerManager:
+    extraArgs:
+      bind-address: 0.0.0.0
+  apiServer:
+    extraArgs:
+      enable-aggregator-routing: "true"
+      feature-gates: MutatingAdmissionPolicy=true
+      runtime-config: admissionregistration.k8s.io/v1alpha1=true
+    admissionControl:
       - name: PodSecurity
         configuration:
           apiVersion: pod-security.admission.config.k8s.io/v1alpha1
@@ -48,31 +42,21 @@
             runtimeClasses: []
             usernames: []
           kind: PodSecurityConfiguration
-- op: add
-  path: /machine/features/kubernetesTalosAPIAccess
-  value:
-    enabled: true
-    allowedRoles:
-      - os:admin
-    allowedKubernetesNamespaces:
-      - system-upgrade
-- op: add
-  path: /cluster/scheduler
-  value:
+  scheduler:
     config:
       apiVersion: kubescheduler.config.k8s.io/v1
       kind: KubeSchedulerConfiguration
       profiles:
-        - schedulerName: default-scheduler
-          plugins:
-            score:
-              disabled:
-                - name: ImageLocality
-          pluginConfig:
-            - name: PodTopologySpread
-              args:
-                defaultingType: List
+        - pluginConfig:
+            - args:
                 defaultConstraints:
                   - maxSkew: 1
                     topologyKey: kubernetes.io/hostname
                     whenUnsatisfiable: ScheduleAnyway
+                defaultingType: List
+              name: PodTopologySpread
+          plugins:
+            score:
+              disabled:
+                - name: ImageLocality
+          schedulerName: default-scheduler

--- a/clustertool/embed/generic/patches/controlplane.yaml
+++ b/clustertool/embed/generic/patches/controlplane.yaml
@@ -10,6 +10,9 @@ cluster:
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
+  proxy:
+    extraArgs:
+      metrics-bind-address: 0.0.0.0:10249
   apiServer:
     extraArgs:
       enable-aggregator-routing: "true"
@@ -31,6 +34,8 @@ cluster:
               - volsync
               - flux-system
   scheduler:
+    extraArgs:
+      bind-address: 0.0.0.0
     config:
       apiVersion: kubescheduler.config.k8s.io/v1
       kind: KubeSchedulerConfiguration

--- a/clustertool/embed/generic/patches/nvidia.yaml
+++ b/clustertool/embed/generic/patches/nvidia.yaml
@@ -1,0 +1,9 @@
+machine:
+  kernel:
+    modules:
+      - name: nvidia
+      - name: nvidia_uvm
+      - name: nvidia_drm
+      - name: nvidia_modeset
+  sysctls:
+    net.core.bpf_jit_harden: 1

--- a/clustertool/embed/generic/patches/worker.yaml
+++ b/clustertool/embed/generic/patches/worker.yaml
@@ -1,6 +1,5 @@
-- op: replace
-  path: /machine/time
-  value:
-    "disabled": false
-    "servers":
-      - "time.cloudflare.com"
+machine:
+  time:
+    disabled: false
+    servers:
+      - time.cloudflare.com


### PR DESCRIPTION
**Description**
Change clustertool included patches from RFC6902 (json patches) to strategic merge patches, see [talos-guides](https://www.talos.dev/v1.9/talos-guides/configuration/patching/).
This allows for the used to easily add to some of the "list" values like sysctls and kernel modules.

For example, this list operation overwrites any previous adds to sysctls.
```yaml
- op: add
  path: /machine/sysctls
  value:
    fs.inotify.max_queued_events: "65536"
    fs.inotify.max_user_instances: "8192"
```

this is not the case when using strategic merge patches
```yaml
machine:
  sysctls:
    fs.inotify.max_queued_events: "65536"
    fs.inotify.max_user_instances: "8192"
```

for example nvidia.yaml can add to this
```yaml
machine:
  sysctls:
    net.core.bpf_jit_harden: 1
```
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I ran clustertool genconfig with the default configs before and after the change. The resulting main-k8s-control-1.yaml was identical (except, see below). 

**📃 Notes:**

The bind addresses for proxy and scheduler did never end up in the generated config because they got overwritten by subsequent patch operations. Now these entries will be in the generated config, not sure if that could be an issue?

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
