### PR TITLE
feat(common): Allow configuring default topologyKey

### DIFF
--- a/charts/library/common-test/Chart.yaml
+++ b/charts/library/common-test/Chart.yaml
@@ -7,7 +7,7 @@ apiVersion: v2
 appVersion: unknown
 dependencies:
   - name: common
-    version: ~26.3.0
+    version: ~26.4.0
     repository: file://../common/
     condition: ""
     alias: ""

--- a/charts/library/common-test/tests/pod/topologySpreadConstraints.yaml
+++ b/charts/library/common-test/tests/pod/topologySpreadConstraints.yaml
@@ -120,6 +120,40 @@ tests:
               topologyKey: truecharts.org/test
               whenUnsatisfiable: ScheduleAnyway
 
+  - it: should pass with topologyKey from "global"
+    set:
+      global:
+        fallbackDefaults:
+          topologyKey: "truecharts.org/test"
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec: {}
+    asserts:
+      - documentIndex: *deploymentDoc
+        equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/instance: test-release-name
+            app.kubernetes.io/name: common-test
+            pod.name: workload-name1
+      - documentIndex: *deploymentDoc
+        equal:
+          path: spec.template.spec.topologySpreadConstraints
+          value:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: test-release-name
+                  app.kubernetes.io/name: common-test
+                  pod.name: workload-name1
+              maxSkew: 1
+              nodeAffinityPolicy: Honor
+              nodeTaintsPolicy: Honor
+              topologyKey: truecharts.org/test
+              whenUnsatisfiable: ScheduleAnyway
+
   - it: should pass with multiple topologySpreadConstraints from "pod"
     set:
       podOptions:

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -48,4 +48,4 @@ sources:
   - https://hub.docker.com/_/
   - https://hub.docker.com/r/mikefarah/yq
 type: library
-version: 26.3.0
+version: 26.4.0

--- a/charts/library/common/templates/lib/pod/_topologySpreadConstraints .tpl
+++ b/charts/library/common/templates/lib/pod/_topologySpreadConstraints .tpl
@@ -24,7 +24,7 @@ objectData: The object data to be used to render the Pod.
   {{- if and (mustHas $objectData.type $validTypes) $rootCtx.Values.podOptions.defaultSpread }}
 - maxSkew: 1
   whenUnsatisfiable: ScheduleAnyway
-  topologyKey: "kubernetes.io/hostname"
+  topologyKey: {{ default "kubernetes.io/hostname" $rootCtx.Values.global.fallbackDefaults.topologyKey }}
   labelSelector:
     matchLabels:
       {{- include "tc.v1.common.lib.metadata.selectorLabels" (dict "rootCtx" $rootCtx "objectType" "pod" "objectName" $objectData.shortName) | indent 6 }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -57,6 +57,9 @@ global:
     # will be used for all CNPG objects
     # Can be overruled per CNPG objects
     pgVersion: 16
+    # -- Define a topologyKey for default topologySpreadConstraints
+    # Will be used when defaultSpread: true
+    topologyKey: kubernetes.io/hostname
   metallb:
     # -- Adds metalLB annotations to services
     addServiceAnnotations: true

--- a/website/src/content/docs/common/fallbackDefaults.md
+++ b/website/src/content/docs/common/fallbackDefaults.md
@@ -48,6 +48,7 @@ fallbackDefaults:
       timeoutSeconds: 2
       failureThreshold: 60
       successThreshold: 1
+  topologyKey: kubernetes.io/hostname
 ```
 
 ## `probeType`
@@ -781,6 +782,22 @@ fallbackDefaults:
 
 ---
 
+## `topologyKey`
+
+Define default topologyKey for topologySpreadConstraints in podOptions
+
+
+|            |                                |
+| ---------- | ------------------------------ |
+| Key        | `fallbackDefaults.topologyKey` |
+| Type       | `string`                          |
+| Required   | ❌                             |
+| Helm `tpl` | ❌                             |
+| Default    | `kubernetes.io/hostname`                            |
+
+
+---
+
 ## Full Examples
 
 ```yaml
@@ -808,4 +825,5 @@ fallbackDefaults:
       timeoutSeconds: 2
       failureThreshold: 60
       successThreshold: 1
+  topologyKey: truecharts.org/example
 ```


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This PR adds a global option to control the default topologyKey used for topologySpreadConstraints

⚒️ Fixes  #32457

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Ran the common library unit tests, added one to verify the usage of the field

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made changes to the documentation
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
