### PR TITLE
fix(Authelia) Authelia password_policy

### DIFF
--- a/charts/premium/authelia/Chart.yaml
+++ b/charts/premium/authelia/Chart.yaml
@@ -50,4 +50,4 @@ sources:
   - https://github.com/authelia/chartrepo
   - https://github.com/truecharts/charts/tree/master/charts/premium/authelia
 type: application
-version: 26.4.7
+version: 26.4.8

--- a/charts/premium/authelia/values.yaml
+++ b/charts/premium/authelia/values.yaml
@@ -107,6 +107,7 @@ totp:
 ##
 ## Parameters used for Password Policies
 password_policy:
+  enabled: false
   ## See: https://www.authelia.com/configuration/security/password-policy/
   standard:
     enabled: false


### PR DESCRIPTION
**Description**
<!--
When changes the settings for password policy it was not set in the config map.
According the template line 65 
https://github.com/truecharts/public/blob/f37a966cdbcaa6477626149a2bf431f67a1ce5fd/charts/premium/authelia/templates/_configmap.tpl#L65

Values.password_policy.enabled had to be true, which was not existing in the values.
Did add now as false, so when needed people can set to true.

-->
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Tested on my own cluster by added Values.password_policy.enabled=true,
This activated the password check.
Values.password_policy.enabled=false did indeed remove all from the configmap.
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [x ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
