### PR TITLE
fix(esphome): Update persistence for correct cache directories

### DIFF
--- a/charts/stable/esphome/Chart.yaml
+++ b/charts/stable/esphome/Chart.yaml
@@ -32,4 +32,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/esphome
   - https://hub.docker.com/r/esphome/esphome
 type: application
-version: 22.1.0
+version: 22.0.2

--- a/charts/stable/esphome/Chart.yaml
+++ b/charts/stable/esphome/Chart.yaml
@@ -32,4 +32,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/esphome
   - https://hub.docker.com/r/esphome/esphome
 type: application
-version: 22.0.1
+version: 22.1.0

--- a/charts/stable/esphome/values.yaml
+++ b/charts/stable/esphome/values.yaml
@@ -43,9 +43,12 @@ persistence:
   config:
     enabled: true
     mountPath: /config
-  platformio:
+  cache: #caches platformio packages to prevent excess downloads
     enabled: true
-    mountPath: /.platformio
+    mountPath: /cache
+  build: #caches compiled code to not require rebuilds
+    enabled: true
+    mountPath: /build
 portal:
   open:
     enabled: true

--- a/charts/stable/esphome/values.yaml
+++ b/charts/stable/esphome/values.yaml
@@ -43,10 +43,12 @@ persistence:
   config:
     enabled: true
     mountPath: /config
-  cache:  # caches platformio packages to prevent excess downloads
+  # caches platformio packages to prevent excess downloads
+  cache:
     enabled: true
     mountPath: /cache
-  build:  # caches compiled code to not require rebuilds
+  # caches compiled code to not require rebuilds
+  build:
     enabled: true
     mountPath: /build
 portal:

--- a/charts/stable/esphome/values.yaml
+++ b/charts/stable/esphome/values.yaml
@@ -43,10 +43,10 @@ persistence:
   config:
     enabled: true
     mountPath: /config
-  cache: # caches platformio packages to prevent excess downloads
+  cache:  # caches platformio packages to prevent excess downloads
     enabled: true
     mountPath: /cache
-  build: # caches compiled code to not require rebuilds
+  build:  # caches compiled code to not require rebuilds
     enabled: true
     mountPath: /build
 portal:

--- a/charts/stable/esphome/values.yaml
+++ b/charts/stable/esphome/values.yaml
@@ -43,10 +43,10 @@ persistence:
   config:
     enabled: true
     mountPath: /config
-  cache: #caches platformio packages to prevent excess downloads
+  cache: # caches platformio packages to prevent excess downloads
     enabled: true
     mountPath: /cache
-  build: #caches compiled code to not require rebuilds
+  build: # caches compiled code to not require rebuilds
     enabled: true
     mountPath: /build
 portal:


### PR DESCRIPTION
**Description**
I figured this out when looking for why my volsync backup was so large for what should be just a couple yaml files. This saves me 1.3GB of S3 storage, but that quantity will vary.

Now we're mounting the cache directories that esphome is expecting. If they don't see these directories existing, then they change the location to be inside the config directory so that these things are cached.

It looks like we used to have this working, but upstream probably changed the directories at some point. They don't seem to have clear documentation that I could find. I found these directories [in their github](https://github.com/esphome/esphome/blob/dev/docker/docker_entrypoint.sh).

⚒️ Fixes  # N/A

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
Deployed locally and then updated my devices. It'll have to redownload the packages, but there's no breaking change from what I found.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
