### PR TITLE
fix(flexo): remove emptyDir and use default persistentVolumeClaim

### DIFF
--- a/charts/stable/flexo/Chart.yaml
+++ b/charts/stable/flexo/Chart.yaml
@@ -33,4 +33,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/flexo
   - https://hub.docker.com/r/nroi/flexo
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/charts/stable/flexo/values.yaml
+++ b/charts/stable/flexo/values.yaml
@@ -12,8 +12,6 @@ service:
 persistence:
   data:
     enabled: true
-    type: "emptyDir"
-    size: 10Gi
     mountPath: "/var/cache/flexo"
 workload:
   main:


### PR DESCRIPTION
**Description**

Change behavior of data to volume to persistentVolumeClaim. Even though it is only cached data, still better to keep it on redeployment. 

⚒️ Fixes 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
Yes

**📃 Notes:**


**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

---