### PR TITLE
fix(authelia): remove notifier and auth. backend

### DIFF
--- a/charts/stable/authelia/Chart.yaml
+++ b/charts/stable/authelia/Chart.yaml
@@ -50,4 +50,4 @@ sources:
   - https://github.com/authelia/chartrepo
   - https://github.com/truecharts/charts/tree/master/charts/stable/authelia
 type: application
-version: 27.1.0
+version: 27.1.1

--- a/charts/stable/authelia/ci/basic-values.yaml
+++ b/charts/stable/authelia/ci/basic-values.yaml
@@ -6,3 +6,10 @@ ingress:
         paths:
           - path: /
             pathType: Prefix
+authelia:
+  authentication_backend:
+    file:
+      path: /config/users.yaml
+  notifier:
+    filesystem:
+      filename: /config/notification.txt

--- a/charts/stable/authelia/docs/Setup-Guide.md
+++ b/charts/stable/authelia/docs/Setup-Guide.md
@@ -12,7 +12,7 @@ LLDAP is a `stable` train chart and therefore isn't supported at the same level 
 
 :::
 
-- Follow the easy steps included in the [Installation Notes](/charts/stable/lldap/installation-notes) for [LLDAP](/charts/stable/lldap/). Change `dc=example,dc=com` to your domain, i.e. `dc=MYDOMAIN,dc=net` and then change your password.
+- Follow the easy steps included in the [Installation Notes](/charts/stable/lldap/installation-notes) for [LLDAP](/charts/stable/lldap/). Change `dc=example,dc=com` to your domain, e.g. `dc=MYDOMAIN,dc=net` and then change your password.
 
 - Once in `LLDAP`, create a user inside the `lldap_password_manager` group and change your default `admin` password. That `lldap_password_manager` user will be used to bind to `Authelia`. Here I've created a user called `manager`, but you can use anything
 
@@ -26,47 +26,36 @@ LLDAP is a `stable` train chart and therefore isn't supported at the same level 
 // values.yaml
 # All configuration options should be put under this. Supports all upstream options
 authelia:
-  # your domain
-  domain: example.com
-  # autehlia ingress url
-  default_redirection_url: https://auth.example.com
+  session:
+    # Be sure to change this to your domain. You can also define multiple domains
+    cookies:
+      - domain: example.com
+        authelia_url: https://auth.example.com
   authentication_backend:
     # lldap setup
+    # https://github.com/lldap/lldap/blob/main/example_configs/authelia_config.yml
     ldap:
-      enabled: true
-      implementation: custom
-      # if name is not lldap update as needed
-      url: ldap://lldap-ldap.lldap.svc.cluster.local:3890
-      # replace with your domain
-      base_dn: DC=example,DC=com
-      username_attribute: uid
-      additional_users_dn: ou=people
-      users_filter: (&(|({username_attribute}={input})({mail_attribute}={input}))(objectClass=person))
-      additional_groups_dn: ou=groups
-      groups_filter: (member={dn})
-      group_name_attribute: cn
-      mail_attribute: mail
-      display_name_attribute: displayName
-      # user with lldap_password_manager group
+      implementation: lldap
+      address: ldap://lldap-ldap.lldap.svc.cluster.local:3890
+      base_dn: dc=example,dc=com
       user: uid=manager,ou=people,dc=example,dc=com
+      # user with lldap_password_manager group
       # above user password in plain text
-      plain_password: somepassword
-    file:
-      enabled: false
+      password: somepassword
   notifier:
     # smtp setup (example is gmail)
     smtp:
-      enabled: true
-      host: smtp.gmail.com
-      port: 587
+      address: submission://smtp.gmail.com:587
       # gmail email address (username)
       username: email@gmail.com
       # use a google app password if using gmail
-      plain_password: somepassword
+      password: somepassword
       # email address to show as sender
       sender: no-reply@example.com
-    filesystem:
-      enabled: false
+      tls:
+        server_name: smtp.gmail.com
+        minimum_version: TLS1.2
+        skip_verify: false
   access_control:
     rules:
       # basic rule for one factor (username/password) login for users in the admin group

--- a/charts/stable/authelia/values.yaml
+++ b/charts/stable/authelia/values.yaml
@@ -5,13 +5,8 @@ image:
 
 # Raw Authelia configuration
 # Replace it with your configuration
+# https://www.authelia.com/configuration/prologue/introduction/
 authelia:
-  authentication_backend:
-    file:
-      path: /config/users.yaml
-  notifier:
-    filesystem:
-      filename: /config/notification.txt
   access_control:
     default_policy: one_factor
   session:


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ The default `file` authentication_backend and the default `filesystem` notifier create problem when a user want to define different ones in their own values (e.g., `ldap` authentication_backend and the `smtp` notifier). This PR removes the default values for these settings to prevent such conflict.

It also removes unneeded configuration from the setup-guide (`implementation: lldap` is now available instead of `implementation: custom`) and invalid or deprecated keys (e.g., `enabled`, `default_redirection_url`, etc.).

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [x] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
