### PR TITLE
feat(peanut): add persistence following upstream change

### DIFF
--- a/charts/stable/peanut/Chart.yaml
+++ b/charts/stable/peanut/Chart.yaml
@@ -33,4 +33,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/peanut
   - https://hub.docker.com/r/brandawg93/peanut
 type: application
-version: 6.7.0
+version: 7.0.0

--- a/charts/stable/peanut/Chart.yaml
+++ b/charts/stable/peanut/Chart.yaml
@@ -33,4 +33,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/peanut
   - https://hub.docker.com/r/brandawg93/peanut
 type: application
-version: 6.6.1
+version: 6.7.0

--- a/charts/stable/peanut/values.yaml
+++ b/charts/stable/peanut/values.yaml
@@ -15,14 +15,14 @@ service:
 portal:
   open:
     enabled: true
+persistence:
+  config:
+    enabled: true
+    mountPath: "/config"
 workload:
   main:
     podSpec:
       containers:
         main:
           env:
-            NUT_HOST: "localhost"
-            NUT_PORT: 3493
-            USERNAME: ""
-            PASSWORD: ""
             WEB_PORT: "{{ .Values.service.main.ports.main.port }}"


### PR DESCRIPTION
**Description**

As of [PeaNUT 3.0.0](https://github.com/Brandawg93/PeaNUT/releases/tag/v3.0.0), environment variables (i.e. to provide NUT configs) are no longer used to change settings directly (except on first run). Settings, including NUT host information, are now set by the UI and stored in [/config/settings.yml](https://github.com/Brandawg93/PeaNUT/wiki/YAML-Configuration) (this also allows for multiple host devices to be set up).

This change adds a 'config' persistence, which can then of course also be backed up via volsync for backup/restore of the settings.

The environment variables which were included in this chart to set NUT host are no longer [documented in the upstream](https://github.com/Brandawg93/PeaNUT#environment-variables) and I have therefore removed them from the chart.

I have not set as major chart version change as I do not believe it is "breaking" as such; anyone with the chart already will have a persistence volume added into which their settings will now be saved, but I am happy to be corrected on this!

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
Tested on local cluster by adding persistence to chart, confirmed settings remain after pod delete and recreation.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
