### PR TITLE
feat(minecraft-bedrock): use tagged version instead of latest

### DIFF
--- a/charts/stable/minecraft-bedrock/Chart.yaml
+++ b/charts/stable/minecraft-bedrock/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   truecharts.org/min_helm_version: "3.11"
   truecharts.org/train: stable
 apiVersion: v2
-appVersion: latest
+appVersion: 2025.4.0
 dependencies:
   - name: common
     version: 25.4.10
@@ -32,4 +32,4 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/minecraft-bedrock
   - https://hub.docker.com/r/itzg/minecraft-bedrock-server
 type: application
-version: 10.5.2
+version: 11.0.0

--- a/charts/stable/minecraft-bedrock/values.yaml
+++ b/charts/stable/minecraft-bedrock/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/itzg/minecraft-bedrock-server
-  tag: latest@sha256:fdbdb03d45593d9d5f26d524b0f59af605020e9f5da0c97a9062cdfa7360596f
+  tag: 2025.4.0@sha256:0672bfd88a42c4dea1640f0e7daded8283e1a6829f63916b05c1db7b7f5625ba
   pullPolicy: Always
 service:
   main:


### PR DESCRIPTION
**Description**

Specifies container version instead of 'latest'. At the same time update version to newest 2025.4.0 as new major version.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
Not tested on local. [Release notes for 2025.4.0](https://github.com/itzg/docker-minecraft-bedrock-server/releases/tag/2025.4.0) do not indicate breaking change in release.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
