### PR TITLE
feat(common): Prevent update with old VPN addons set

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -48,4 +48,4 @@ sources:
   - https://hub.docker.com/_/
   - https://hub.docker.com/r/mikefarah/yq
 type: library
-version: 28.0.0
+version: 28.1.0

--- a/charts/library/common/templates/values/_validate.tpl
+++ b/charts/library/common/templates/values/_validate.tpl
@@ -22,4 +22,9 @@
     ) -}}
   {{- end -}}
 
+  {{/* Catch update related issues */}}
+  {{- if .Values.addons.vpn -}}
+    {{- fail (printf "Your current Common-Chart version does not support [.Values.addons.vpn] please use [.Values.addons.tailscale] or [.Values.addons.gluetun] instead" }}
+  {{- end -}}
+
 {{- end -}}

--- a/charts/library/common/templates/values/_validate.tpl
+++ b/charts/library/common/templates/values/_validate.tpl
@@ -23,8 +23,8 @@
   {{- end -}}
 
   {{/* Catch update related issues */}}
-    {{- if $allValues.addons -}}
-  {{- if $allValues.addons.vpn -}}
+    {{- if .addons -}}
+  {{- if .addons.vpn -}}
     {{- fail (printf "Your current Common-Chart version does not support [.Values.addons.vpn] please use [.Values.addons.tailscale] or [.Values.addons.gluetun] instead") }}
   {{- end -}}
   {{- end -}}

--- a/charts/library/common/templates/values/_validate.tpl
+++ b/charts/library/common/templates/values/_validate.tpl
@@ -23,8 +23,10 @@
   {{- end -}}
 
   {{/* Catch update related issues */}}
+    {{- if .Values.addons -}}
   {{- if .Values.addons.vpn -}}
     {{- fail (printf "Your current Common-Chart version does not support [.Values.addons.vpn] please use [.Values.addons.tailscale] or [.Values.addons.gluetun] instead") }}
+  {{- end -}}
   {{- end -}}
 
 {{- end -}}

--- a/charts/library/common/templates/values/_validate.tpl
+++ b/charts/library/common/templates/values/_validate.tpl
@@ -23,8 +23,8 @@
   {{- end -}}
 
   {{/* Catch update related issues */}}
-    {{- if .Values.addons -}}
-  {{- if .Values.addons.vpn -}}
+    {{- if $allValues.addons -}}
+  {{- if $allValues.addons.vpn -}}
     {{- fail (printf "Your current Common-Chart version does not support [.Values.addons.vpn] please use [.Values.addons.tailscale] or [.Values.addons.gluetun] instead") }}
   {{- end -}}
   {{- end -}}

--- a/charts/library/common/templates/values/_validate.tpl
+++ b/charts/library/common/templates/values/_validate.tpl
@@ -24,7 +24,7 @@
 
   {{/* Catch update related issues */}}
   {{- if .Values.addons.vpn -}}
-    {{- fail (printf "Your current Common-Chart version does not support [.Values.addons.vpn] please use [.Values.addons.tailscale] or [.Values.addons.gluetun] instead" }}
+    {{- fail (printf "Your current Common-Chart version does not support [.Values.addons.vpn] please use [.Values.addons.tailscale] or [.Values.addons.gluetun] instead") }}
   {{- end -}}
 
 {{- end -}}


### PR DESCRIPTION
**Description**
We want to ensure users dont accidentally update with old  vpn addon structure set.
This update fails any helm attempts using the old vpn addons

⚒️ Fixes  #33005

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
