### PR TITLE
feat(common): force recreate on single-replica with RWO storage

### DIFF
--- a/charts/library/common-test/Chart.yaml
+++ b/charts/library/common-test/Chart.yaml
@@ -35,4 +35,3 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/library/common-test
 type: application
 version: 1.0.0
-

--- a/charts/library/common-test/tests/persistence/pvc_stategy_type_test.yaml
+++ b/charts/library/common-test/tests/persistence/pvc_stategy_type_test.yaml
@@ -1,0 +1,153 @@
+suite: pvc strategy type test
+templates:
+  - common.yaml
+release:
+  name: test-release-name
+  namespace: test-release-namespace
+tests:
+  - it: should leave strategy as defined with non RWO accessModes and single replica
+    set:
+      workload:
+        some-workload:
+          enabled: true
+          primary: true
+          type: Deployment
+          strategy: RollingUpdate
+          podSpec: {}
+      persistence:
+        my-volume1:
+          enabled: true
+          type: pvc
+          accessModes:
+            - ReadWriteMany
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - documentIndex: &pvcDoc 1
+        isKind:
+          of: PersistentVolumeClaim
+      - documentIndex: *pvcDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-my-volume1
+      - documentIndex: *pvcDoc
+        equal:
+          path: spec.accessModes
+          value:
+            - ReadWriteMany
+  - it: should set strategy to Recreate with RWO accessModes and single replica
+    set:
+      workload:
+        some-workload:
+          enabled: true
+          primary: true
+          type: Deployment
+          strategy: RollingUpdate
+          podSpec: {}
+      persistence:
+        my-volume1:
+          enabled: true
+          type: pvc
+          accessModes:
+            - ReadWriteMany
+            - ReadWriteOnce
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        equal:
+          path: spec.strategy.type
+          value: Recreate
+      - documentIndex: &pvcDoc 1
+        isKind:
+          of: PersistentVolumeClaim
+      - documentIndex: *pvcDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-my-volume1
+      - documentIndex: *pvcDoc
+        equal:
+          path: spec.accessModes
+          value:
+            - ReadWriteMany
+            - ReadWriteOnce
+  - it: should leave strategy as defined with non RWO accessModes and multiple replica
+    set:
+      workload:
+        some-workload:
+          enabled: true
+          primary: true
+          type: Deployment
+          replicas: 2
+          strategy: RollingUpdate
+          podSpec: {}
+      persistence:
+        my-volume1:
+          enabled: true
+          type: pvc
+          accessModes:
+            - ReadWriteMany
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - documentIndex: &pvcDoc 1
+        isKind:
+          of: PersistentVolumeClaim
+      - documentIndex: *pvcDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-my-volume1
+      - documentIndex: *pvcDoc
+        equal:
+          path: spec.accessModes
+          value:
+            - ReadWriteMany
+  - it: should leave strategy as defined with RWO accessModes and multiple replica
+    set:
+      workload:
+        some-workload:
+          enabled: true
+          primary: true
+          type: Deployment
+          replicas: 2
+          strategy: RollingUpdate
+          podSpec: {}
+      persistence:
+        my-volume1:
+          enabled: true
+          type: pvc
+          accessModes:
+            - ReadWriteMany
+            - ReadWriteOnce
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - documentIndex: &pvcDoc 1
+        isKind:
+          of: PersistentVolumeClaim
+      - documentIndex: *pvcDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-my-volume1
+      - documentIndex: *pvcDoc
+        equal:
+          path: spec.accessModes
+          value:
+            - ReadWriteMany
+            - ReadWriteOnce

--- a/charts/library/common/templates/lib/pod/_volumes.tpl
+++ b/charts/library/common/templates/lib/pod/_volumes.tpl
@@ -96,9 +96,9 @@ objectData: The object data to be used to render the Pod.
         "objectData" $persistence "caller" "Volumes") | fromYamlArray
     -}}
 
-    {{- $hasRWO := include "tc.v1.common.lib.pod.volumes.hasRWO" (dict "modes" $modes) | toBool -}}
+    {{- $hasRWO := include "tc.v1.common.lib.pod.volumes.hasRWO" (dict "modes" $modes) -}}
 
-    {{- if $hasRWO -}}
+    {{- if eq $hasRWO "true" -}}
       {{- if eq $objectData.type "DaemonSet" -}}
         {{- fail "Expected [accessMode] to not be [ReadWriteOnce] when used on a [DaemonSet]" -}}
 

--- a/charts/library/common/templates/lib/pod/_volumes.tpl
+++ b/charts/library/common/templates/lib/pod/_volumes.tpl
@@ -96,13 +96,8 @@ objectData: The object data to be used to render the Pod.
         "objectData" $persistence "caller" "Volumes") | fromYamlArray
     -}}
 
-    {{- $hasRWO := false -}}
-    {{- range $m := $modes -}}
-      {{- if eq $m "ReadWriteOnce" -}}
-        {{- $hasRWO = true -}}
-        {{- break -}}
-      {{- end -}}
-    {{- end -}}
+    {{- $hasRWO := include "tc.v1.common.lib.pod.volumes.hasRWO" (dict "modes" $modes) | toBool -}}
+
 
     {{- if $hasRWO -}}
       {{- if eq $objectData.type "DaemonSet" -}}
@@ -112,8 +107,21 @@ objectData: The object data to be used to render the Pod.
         {{- include "add.warning" (dict "rootCtx" $rootCtx
             "warn" (printf "WARNING: The [accessModes] on volume [%s] is set to [ReadWriteOnce] when on a [Deployment] with more than 1 replica" $name))
         -}}
+
       {{- end -}}
     {{- end -}}
 
   {{- end -}}
+{{- end -}}
+
+{{- define "tc.v1.common.lib.pod.volumes.hasRWO" -}}
+  {{- $modes := .modes -}}
+  {{- $hasRWO := false -}}
+  {{- range $m := $modes -}}
+    {{- if eq $m "ReadWriteOnce" -}}
+      {{- $hasRWO = true -}}
+      {{- break -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $hasRWO -}}
 {{- end -}}

--- a/charts/library/common/templates/lib/pod/_volumes.tpl
+++ b/charts/library/common/templates/lib/pod/_volumes.tpl
@@ -98,7 +98,6 @@ objectData: The object data to be used to render the Pod.
 
     {{- $hasRWO := include "tc.v1.common.lib.pod.volumes.hasRWO" (dict "modes" $modes) | toBool -}}
 
-
     {{- if $hasRWO -}}
       {{- if eq $objectData.type "DaemonSet" -}}
         {{- fail "Expected [accessMode] to not be [ReadWriteOnce] when used on a [DaemonSet]" -}}
@@ -107,7 +106,6 @@ objectData: The object data to be used to render the Pod.
         {{- include "add.warning" (dict "rootCtx" $rootCtx
             "warn" (printf "WARNING: The [accessModes] on volume [%s] is set to [ReadWriteOnce] when on a [Deployment] with more than 1 replica" $name))
         -}}
-
       {{- end -}}
     {{- end -}}
 

--- a/charts/library/common/templates/lib/workload/_daemonsetSpec.tpl
+++ b/charts/library/common/templates/lib/workload/_daemonsetSpec.tpl
@@ -9,8 +9,8 @@ objectData:
 {{- define "tc.v1.common.lib.workload.daemonsetSpec" -}}
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
-  {{ include "tc.v1.common.lib.workload.components.strategyType" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
-  {{- $strategy := $objectData.strategy }}
+  {{- include "tc.v1.common.lib.workload.components.strategyType" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
+  {{- $strategy := $objectData.strategy -}}
 revisionHistoryLimit: {{ $objectData.revisionHistoryLimit | default 3 }}
 updateStrategy:
   type: {{ $strategy }}

--- a/charts/library/common/templates/lib/workload/_daemonsetSpec.tpl
+++ b/charts/library/common/templates/lib/workload/_daemonsetSpec.tpl
@@ -9,11 +9,13 @@ objectData:
 {{- define "tc.v1.common.lib.workload.daemonsetSpec" -}}
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
-  {{- include "tc.v1.common.lib.workload.components.strategyType" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
-  {{- $strategy := $objectData.strategy -}}
+  {{- include "tc.v1.common.lib.workload.components.strategyType" (dict
+    "rootCtx" $rootCtx "objectData" $objectData
+    "defaultStrategy" "RollingUpdate" "resource" "DaemonSet"
+  ) }}
 revisionHistoryLimit: {{ $objectData.revisionHistoryLimit | default 3 }}
 updateStrategy:
-  type: {{ $strategy }}
+  type: {{ $objectData.strategy }}
   {{- if and (eq $objectData.strategy "RollingUpdate") $objectData.rollingUpdate -}}
     {{ if (or (hasKey $objectData.rollingUpdate "maxUnavailable") (hasKey $objectData.rollingUpdate "maxSurge")) }}
   rollingUpdate:

--- a/charts/library/common/templates/lib/workload/_daemonsetSpec.tpl
+++ b/charts/library/common/templates/lib/workload/_daemonsetSpec.tpl
@@ -9,7 +9,8 @@ objectData:
 {{- define "tc.v1.common.lib.workload.daemonsetSpec" -}}
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
-  {{- $strategy := $objectData.strategy | default "RollingUpdate" }}
+  {{ include "tc.v1.common.lib.workload.components.strategyType" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
+  {{- $strategy := $objectData.strategy }}
 revisionHistoryLimit: {{ $objectData.revisionHistoryLimit | default 3 }}
 updateStrategy:
   type: {{ $strategy }}

--- a/charts/library/common/templates/lib/workload/_deploymentSpec.tpl
+++ b/charts/library/common/templates/lib/workload/_deploymentSpec.tpl
@@ -10,7 +10,7 @@ objectData:
 {{- define "tc.v1.common.lib.workload.deploymentSpec" -}}
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
-  {{ include "tc.v1.common.lib.workload.components.strategyType" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
+  {{- include "tc.v1.common.lib.workload.components.strategyType" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
   {{- $strategy := $objectData.strategy -}}
   {{- $replicas := 1 -}}
   {{- if hasKey $objectData "replicas" -}}

--- a/charts/library/common/templates/lib/workload/_deploymentSpec.tpl
+++ b/charts/library/common/templates/lib/workload/_deploymentSpec.tpl
@@ -10,7 +10,8 @@ objectData:
 {{- define "tc.v1.common.lib.workload.deploymentSpec" -}}
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
-  {{- $strategy := $objectData.strategy | default "Recreate" -}}
+  {{ include "tc.v1.common.lib.workload.components.strategyType" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
+  {{- $strategy := $objectData.strategy -}}
   {{- $replicas := 1 -}}
   {{- if hasKey $objectData "replicas" -}}
     {{- $replicas = $objectData.replicas -}}

--- a/charts/library/common/templates/lib/workload/_deploymentSpec.tpl
+++ b/charts/library/common/templates/lib/workload/_deploymentSpec.tpl
@@ -10,8 +10,10 @@ objectData:
 {{- define "tc.v1.common.lib.workload.deploymentSpec" -}}
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
-  {{- include "tc.v1.common.lib.workload.components.strategyType" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
-  {{- $strategy := $objectData.strategy -}}
+  {{- include "tc.v1.common.lib.workload.components.strategyType" (dict
+    "rootCtx" $rootCtx "objectData" $objectData
+    "defaultStrategy" "Recreate" "resource" "Deployment"
+  ) -}}
   {{- $replicas := 1 -}}
   {{- if hasKey $objectData "replicas" -}}
     {{- $replicas = $objectData.replicas -}}
@@ -22,7 +24,7 @@ objectData:
 replicas: {{ $replicas }}
 revisionHistoryLimit: {{ $objectData.revisionHistoryLimit | default 3 }}
 strategy:
-  type: {{ $strategy }}
+  type: {{ $objectData.strategy }}
   {{- if and (eq $objectData.strategy "RollingUpdate") $objectData.rollingUpdate -}}
     {{ if (or (hasKey $objectData.rollingUpdate "maxUnavailable") (hasKey $objectData.rollingUpdate "maxSurge")) }}
   rollingUpdate:

--- a/charts/library/common/templates/lib/workload/_statefulsetSpec.tpl
+++ b/charts/library/common/templates/lib/workload/_statefulsetSpec.tpl
@@ -10,8 +10,10 @@ objectData:
 {{- define "tc.v1.common.lib.workload.statefulsetSpec" -}}
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
-  {{ include "tc.v1.common.lib.workload.components.strategyType" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
-  {{- $strategy := $objectData.strategy -}}
+  {{- include "tc.v1.common.lib.workload.components.strategyType" (dict
+    "rootCtx" $rootCtx "objectData" $objectData
+    "defaultStrategy" "RollingUpdate" "resource" "StatefulSet"
+  ) -}}
   {{- $replicas := 1 -}}
   {{- if hasKey $objectData "replicas" -}}
     {{- $replicas = $objectData.replicas -}}
@@ -23,7 +25,7 @@ replicas: {{ $replicas }}
 revisionHistoryLimit: {{ $objectData.revisionHistoryLimit | default 3 }}
 serviceName: {{ $objectData.name }}
 updateStrategy:
-  type: {{ $strategy }}
+  type: {{ $objectData.strategy }}
   {{- if and (eq $objectData.strategy "RollingUpdate") $objectData.rollingUpdate -}}
     {{- if (or (hasKey $objectData.rollingUpdate "maxUnavailable") (hasKey $objectData.rollingUpdate "partition")) }}
   rollingUpdate:

--- a/charts/library/common/templates/lib/workload/_statefulsetSpec.tpl
+++ b/charts/library/common/templates/lib/workload/_statefulsetSpec.tpl
@@ -10,7 +10,8 @@ objectData:
 {{- define "tc.v1.common.lib.workload.statefulsetSpec" -}}
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
-  {{- $strategy := $objectData.strategy | default "RollingUpdate" -}}
+  {{ include "tc.v1.common.lib.workload.components.strategyType" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
+  {{- $strategy := $objectData.strategy }}
   {{- $replicas := 1 -}}
   {{- if hasKey $objectData "replicas" -}}
     {{- $replicas = $objectData.replicas -}}

--- a/charts/library/common/templates/lib/workload/_statefulsetSpec.tpl
+++ b/charts/library/common/templates/lib/workload/_statefulsetSpec.tpl
@@ -11,7 +11,7 @@ objectData:
   {{- $objectData := .objectData -}}
   {{- $rootCtx := .rootCtx -}}
   {{ include "tc.v1.common.lib.workload.components.strategyType" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
-  {{- $strategy := $objectData.strategy }}
+  {{- $strategy := $objectData.strategy -}}
   {{- $replicas := 1 -}}
   {{- if hasKey $objectData "replicas" -}}
     {{- $replicas = $objectData.replicas -}}

--- a/charts/library/common/templates/lib/workload/components/_strategyType.tpl
+++ b/charts/library/common/templates/lib/workload/components/_strategyType.tpl
@@ -14,11 +14,7 @@ objectData:
     {{- $replicas = $objectData.replicas -}}
   {{- end -}}
 
-  {{- set $objectData.strategy $strategy }}
-
-  {{- if gt $replicas 1 -}}
-    {{- set $objectData.strategy $strategy }}
-  {{- else -}}
+  {{- if eq $replicas 1 -}}
     {{- range $name, $persistence := .Values.persistence }}
       {{- $enabled := (include "tc.v1.common.lib.util.enabled" (dict
                   "rootCtx" $rootCtx "objectData" $persistenceValues
@@ -38,7 +34,7 @@ objectData:
         {{- $hasRWO := include "tc.v1.common.lib.pod.volumes.hasRWO" (dict "modes" $modes) | toBool -}}
 
         {{- if $hasRWO -}}
-          {{- set $objectData.strategy "Recreate" }}
+          {{- $strategy = "Recreate" -}}
           {{- include "add.warning" (dict "rootCtx" $rootCtx "warn" (printf
             "WARNING: The [accessModes] on volume [%s] is set to [ReadWriteOnce] with a single replica and an strategy of [%s]. This is not stable, defaulting to [Recreate] strategy" $name $strategy))
           -}}
@@ -46,4 +42,6 @@ objectData:
       {{- end -}}
     {{- end -}}
   {{- end -}}
+
+  {{- set $objectData.strategy $strategy -}}
 {{- end -}}

--- a/charts/library/common/templates/lib/workload/components/_strategyType.tpl
+++ b/charts/library/common/templates/lib/workload/components/_strategyType.tpl
@@ -1,0 +1,51 @@
+{{/* Deployment Spec */}}
+{{/* Call this template:
+{{ include "tc.v1.common.lib.workload.components.strategyType" (dict "rootCtx" $rootCtx "objectData" $objectData) -}}
+rootCtx: The root context of the chart.
+objectData:
+  replicas: The number of replicas.
+  strategy: The deployment strategy to use to replace existing pods with new ones.
+*/}}
+{{- define "tc.v1.common.lib.workload.components.strategyType" -}}
+  {{- $objectData := .objectData -}}
+  {{- $rootCtx := .rootCtx -}}
+  {{- $strategy := $objectData.strategy | default "Recreate" -}}
+  {{- $replicas := 1 -}}
+  {{- if hasKey $objectData "replicas" -}}
+    {{- $replicas = $objectData.replicas -}}
+  {{- end -}}
+    {{- set $objectData.strategy $strategy }}
+  {{- if gt $replicas 1 -}}
+    {{- set $objectData.strategy $strategy }}
+  {{- else -}}
+    {{- range $name, $persistence := .Values.persistence }}
+      {{- $enabled := (include "tc.v1.common.lib.util.enabled" (dict
+                  "rootCtx" $rootCtx "objectData" $persistenceValues
+                  "name" $name "caller" "Volumes"
+                  "key" "persistence")) -}}
+      {{- if (eq $enabled "true") -}}
+        {{- $type := ($persistence.type | default $rootCtx.Values.global.fallbackDefaults.persistenceType) -}}
+
+        {{- $typesWithAccessMode := (list "pvc") -}}
+        {{- if (mustHas $type $typesWithAccessMode) -}}
+          {{- $modes := include "tc.v1.common.lib.pvc.accessModes" (dict "rootCtx" $rootCtx
+             "objectData" $persistence "caller" "Volumes") | fromYamlArray
+          -}}
+
+          {{- $hasRWO := include "tc.v1.common.lib.pod.volumes.hasRWO" (dict "modes" $modes) | toBool -}}
+
+          {{- if $hasRWO -}}
+            {{- set $objectData.strategy "Recreate" }}
+            {{- include "add.warning" (dict "rootCtx" $rootCtx
+                "warn" (printf "WARNING: The [accessModes] on volume [%s] is set to [ReadWriteOnce] with a single replica and an strategy of [%s]. This is not stable, defaulting to [Recreate] strategy" $name $strategy))
+            -}}
+          {{- end }}
+        {{- end }}
+
+      {{- end }}
+    {{- end }}
+
+  {{- end -}}
+
+
+{{- end -}}

--- a/charts/library/common/templates/lib/workload/components/_strategyType.tpl
+++ b/charts/library/common/templates/lib/workload/components/_strategyType.tpl
@@ -16,6 +16,7 @@ objectData:
   {{- if hasKey $objectData "replicas" -}}
     {{- $replicas = $objectData.replicas -}}
   {{- end -}}
+  {{- $replicas = $replicas | int -}}
 
   {{- $volsRWO := list -}}
   {{- range $name, $persistence := $rootCtx.Values.persistence }}

--- a/charts/library/common/templates/lib/workload/components/_strategyType.tpl
+++ b/charts/library/common/templates/lib/workload/components/_strategyType.tpl
@@ -44,8 +44,9 @@ objectData:
   {{- if gt (len $volsRWO) 0 -}}
     {{/* RWO + replicas > 1 is a no-no */}}
     {{- if gt $replicas 1 -}}
-      {{/* Should we hard fail or just warn here? */}}
-      {{- fail (printf "Following volumes [%s] are set to [ReadWriteOnce] but there are more 1 replica. This is not allowed" (join "," $volsRWO)) -}}
+      {{- include "add.warning" (dict "rootCtx" $rootCtx "warn" (printf
+          "WARNING: The [accessModes] on volume(s) [%s] is set to [ReadWriteOnce] with a more than 1 replica. This is not stables" (join "," $volsRWO)
+        )) -}}
     {{- else -}}
       {{/* DaemonSets and StatefulSets can have RWO with 1 replica under their supported strategies (OnDelete, RollingUpdate) */}}
 

--- a/charts/library/common/templates/lib/workload/components/_strategyType.tpl
+++ b/charts/library/common/templates/lib/workload/components/_strategyType.tpl
@@ -18,9 +18,9 @@ objectData:
   {{- end -}}
 
   {{- $volsRWO := list -}}
-  {{- range $name, $persistence := .Values.persistence }}
+  {{- range $name, $persistence := $rootCtx.Values.persistence }}
     {{- $enabled := (include "tc.v1.common.lib.util.enabled" (dict
-                "rootCtx" $rootCtx "objectData" $persistenceValues
+                "rootCtx" $rootCtx "objectData" $persistence
                 "name" $name "caller" "Volumes"
                 "key" "persistence")) -}}
 
@@ -34,8 +34,8 @@ objectData:
           "objectData" $persistence "caller" "Volumes") | fromYamlArray
       -}}
 
-      {{- $hasRWO := include "tc.v1.common.lib.pod.volumes.hasRWO" (dict "modes" $modes) | toBool -}}
-      {{- if not $hasRWO -}}{{- continue -}}{{- end -}}
+      {{- $hasRWO := include "tc.v1.common.lib.pod.volumes.hasRWO" (dict "modes" $modes) -}}
+      {{- if ne $hasRWO "true" -}}{{- continue -}}{{- end -}}
       {{- $volsRWO = mustAppend $volsRWO $name -}}
     {{- end -}}
   {{- end -}}
@@ -66,5 +66,5 @@ objectData:
   {{- end -}}
 
   {{/* Update strategy */}}
-  {{- set $objectData.strategy $strategy -}}
+  {{- $_ := set $objectData "strategy" $strategy -}}
 {{- end -}}


### PR DESCRIPTION
**Description**
This should ensure users cannot set "rolling update" when using RWO storage and a single-replica, as this would inherently brick pod updates, as storage would, inherently, stay locked with the previous pod instance

⚒️ Fixes  #33097

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
