### PR TITLE
fix(clustertool) memory request kube-prometheus-stack 

### DIFF
--- a/clustertool/embed/generic/kubernetes/system/kube-prometheus-stack/app/helm-release.yaml
+++ b/clustertool/embed/generic/kubernetes/system/kube-prometheus-stack/app/helm-release.yaml
@@ -70,6 +70,7 @@ spec:
         resources:
           requests:
             cpu: 100m
+            memory: 100Mi
           limits:
             memory: 2000Mi
         # storageSpec:

--- a/clustertool/embed/generic/kubernetes/system/kube-prometheus-stack/app/helm-release.yaml
+++ b/clustertool/embed/generic/kubernetes/system/kube-prometheus-stack/app/helm-release.yaml
@@ -58,7 +58,7 @@ spec:
         enableFeatures:
           - memory-snapshot-on-shutdown
         # Prometheus metrics retention time in PV
-        retention: 24h
+        retention: 14d
         retentionSize: 50GB
         # External labels to add to any time series or
         # alerts when communicating with external systems

--- a/clustertool/embed/generic/kubernetes/system/kube-prometheus-stack/app/helm-release.yaml
+++ b/clustertool/embed/generic/kubernetes/system/kube-prometheus-stack/app/helm-release.yaml
@@ -70,7 +70,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 100Mi
+            memory: 500Mi
           limits:
             memory: 2000Mi
         # storageSpec:

--- a/clustertool/embed/generic/kubernetes/system/kube-prometheus-stack/app/helm-release.yaml
+++ b/clustertool/embed/generic/kubernetes/system/kube-prometheus-stack/app/helm-release.yaml
@@ -66,7 +66,7 @@ spec:
           cluster: cluster_main
           env: prod
         # High availability
-        replicas: 2
+        replicas: 1
         resources:
           requests:
             cpu: 100m

--- a/website/src/content/docs/guides/index.md
+++ b/website/src/content/docs/guides/index.md
@@ -115,6 +115,7 @@ prometheus:
     resources:
       requests:
         cpu: 100m
+        memory: 100Mi
       limits:
         memory: 2000Mi
 ```

--- a/website/src/content/docs/guides/index.md
+++ b/website/src/content/docs/guides/index.md
@@ -115,7 +115,7 @@ prometheus:
     resources:
       requests:
         cpu: 100m
-        memory: 100Mi
+        memory: 500Mi
       limits:
         memory: 2000Mi
 ```


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
With new Clustertool Beta 2, upstream `kube-prometheus-stack` takes a  memory request of: 2000Mi.
It would like to deploy 2x a POD so a total of 4000Mi.
My test cluster have memory of 8Gb. It cannot deploy this 2nd pod as the request of a standard clustertool without this second pod is already 98.2%.
Will also block all other deployments.

Also the webpage manual changed.

Hopefully this is a good fix?

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [x] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Own cluster

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
