### PR TITLE
fix(clustertool and docs): nginx deprecated annotation

### DIFF
--- a/clustertool/embed/generic/kubernetes/networking/nginx-external/app/helm-release.yaml
+++ b/clustertool/embed/generic/kubernetes/networking/nginx-external/app/helm-release.yaml
@@ -38,7 +38,6 @@ spec:
           # internal-dns.alpha.kubernetes.io/hostname: external.${DOMAIN_0}
           metallb.io/ip-allocated-from-pool: main
           metallb.io/loadBalancerIPs: ${NGINX_EXTERNAL_IP}
-          lbipam.cilium.io/ips: ${NGINX_EXTERNAL_IP}
       ingressClassByName: true
       watchIngressWithoutClass: false
       ingressClassResource:

--- a/clustertool/embed/generic/kubernetes/networking/nginx-external/app/helm-release.yaml
+++ b/clustertool/embed/generic/kubernetes/networking/nginx-external/app/helm-release.yaml
@@ -38,8 +38,7 @@ spec:
           # internal-dns.alpha.kubernetes.io/hostname: external.${DOMAIN_0}
           metallb.io/ip-allocated-from-pool: main
           metallb.io/loadBalancerIPs: ${NGINX_EXTERNAL_IP}
-          metallb.universe.tf/ip-allocated-from-pool: main
-          "lbipam.cilium.io/ips": ${NGINX_EXTERNAL_IP}
+          lbipam.cilium.io/ips: ${NGINX_EXTERNAL_IP}
       ingressClassByName: true
       watchIngressWithoutClass: false
       ingressClassResource:

--- a/clustertool/embed/generic/kubernetes/networking/nginx-internal/app/helm-release.yaml
+++ b/clustertool/embed/generic/kubernetes/networking/nginx-internal/app/helm-release.yaml
@@ -38,7 +38,6 @@ spec:
           # internal-dns.alpha.kubernetes.io/hostname: internal.${DOMAIN_0}
           metallb.io/ip-allocated-from-pool: main
           metallb.io/loadBalancerIPs: ${NGINX_INTERNAL_IP}
-          lbipam.cilium.io/ips: ${NGINX_INTERNAL_IP}
       ingressClassByName: true
       watchIngressWithoutClass: true
       ingressClassResource:

--- a/clustertool/embed/generic/kubernetes/networking/nginx-internal/app/helm-release.yaml
+++ b/clustertool/embed/generic/kubernetes/networking/nginx-internal/app/helm-release.yaml
@@ -38,8 +38,7 @@ spec:
           # internal-dns.alpha.kubernetes.io/hostname: internal.${DOMAIN_0}
           metallb.io/ip-allocated-from-pool: main
           metallb.io/loadBalancerIPs: ${NGINX_INTERNAL_IP}
-          metallb.universe.tf/ip-allocated-from-pool: main
-          "lbipam.cilium.io/ips": ${NGINX_INTERNAL_IP}
+          lbipam.cilium.io/ips: ${NGINX_INTERNAL_IP}
       ingressClassByName: true
       watchIngressWithoutClass: true
       ingressClassResource:

--- a/website/src/content/docs/guides/ingress/nginx.md
+++ b/website/src/content/docs/guides/ingress/nginx.md
@@ -23,7 +23,6 @@ Please note the IP variables that need to be set to your specific configuration 
         annotations:
           metallb.io/ip-allocated-from-pool: main
           metallb.io/loadBalancerIPs: ${NGINX_INTERNAL_IP}
-          metallb.universe.tf/ip-allocated-from-pool: main
       ingressClassByName: true
       watchIngressWithoutClass: true
       ingressClassResource:
@@ -77,7 +76,6 @@ Please note the IP variables that need to be set to your specific configuration 
         annotations:
           metallb.io/ip-allocated-from-pool: main
           metallb.io/loadBalancerIPs: ${NGINX_EXTERNAL_IP}
-          metallb.universe.tf/ip-allocated-from-pool: main
       ingressClassByName: true
       watchIngressWithoutClass: false
       ingressClassResource:

--- a/website/src/content/docs/guides/ingress/traefik.md
+++ b/website/src/content/docs/guides/ingress/traefik.md
@@ -21,7 +21,6 @@ service:
   annotations:
     metallb.io/ip-allocated-from-pool: main
     metallb.io/loadBalancerIPs: ${TRAEFIK_IP}
-    metallb.universe.tf/ip-allocated-from-pool: main
   spec:
     externalTrafficPolicy: Local
 logs:


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

`metallb.universe.tf/ip-allocated-from-pool: main` is deprecated, only `metallb.io/ip-allocated-from-pool: main` should be ok.
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [x] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
