### PR TITLE
clustertool(feat): etcd metrics

### DIFF
--- a/clustertool/embed/generic/patches/controlplane.yaml
+++ b/clustertool/embed/generic/patches/controlplane.yaml
@@ -10,6 +10,9 @@ cluster:
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
+  etcd:
+    extraArgs:
+      listen-metrics-urls: http://0.0.0.0:2381
   proxy:
     extraArgs:
       metrics-bind-address: 0.0.0.0:10249


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
In the kube-prometheus-stack included in clustertool, `etcd dashboard` is added automatically to the grafana dashboard.
To get this dashboard working you need to scrape correctly the metrics. This can be done with multiple possibilities. I tested two.

1. The easiest option, which is this PR. It exposes the metrics on the standard port used by the kube-prometheus-stack: 2381.
   Disadvantage you can see the metrics via each computer on the same network as it is just plain http page.

2. A more difficult option. You need to add to the kube-prometheus-stack the certificates via a `secret` and set the correct ports.
 If you are interested, that can be seen with this PR on my own cluster. https://github.com/Boemeltrein/TalosCluster/commit/a923e4c0e4e12b4aefd2ced26a7d48ee44e136fb

Option 2 seems not to be implemented for me in clustertool, so therefore a PR for option 1.
Up to here if it something OK to include like this.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Made a new TEST Cluster bootstrap with this patch added. That went OK.  Happy to test again when a new clustertool version will be released.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
