### PR TITLE
fix(navidrome): Update Scanner.Schedule configuration option for Navidrome >=v0.55.0

### DIFF
--- a/charts/stable/navidrome/Chart.yaml
+++ b/charts/stable/navidrome/Chart.yaml
@@ -37,5 +37,5 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/navidrome
   - https://hub.docker.com/r/deluan/navidrome
 type: application
-version: 21.8.2
+version: 21.8.3
 

--- a/charts/stable/navidrome/values.yaml
+++ b/charts/stable/navidrome/values.yaml
@@ -9,7 +9,7 @@ workload:
         main:
           env:
             ND_MUSICFOLDER: /music
-            ND_SCANSCHEDULE: "@every 15m"
+            ND_SCANNER_SCHEDULE: "@every 15m"
             ND_LOGLEVEL: info
             ND_SESSIONTIMEOUT: 24h
             ND_ENABLETRANSCODINGCONFIG: false


### PR DESCRIPTION
As documented in their v0.55.0 release here
https://github.com/navidrome/navidrome/releases/tag/v0.55.0

**Description**
Navidrome v0.55.0 changed the configuration option from `ScanSchedule` to `Scanner.Schedule`, which also affects the corresponding environment variables of `ND_SCANSCHEDULE` to `ND_SCANNER_SCHEDULE`. Navidrome documentation for v0.55.0 can be seen [here](https://github.com/navidrome/navidrome/releases/tag/v0.55.0).

`ND_SCANSCHEDULE` no longer works and on startup, Navidrome will ignore the environment variable and disable scanning. E.g.
```
time="2025-05-02T08:29:47Z" level=info msg="Periodic scan is DISABLED"
```

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
After adding `ND_SCANNER_SCHEDULE` environment variable, Navidrome reports that scanning has been enabled in its logs:
```
time="2025-05-11T14:32:52Z" level=info msg="Starting scheduler"
time="2025-05-11T14:32:52Z" level=info msg="Scheduling periodic scan" schedule="@every 15m"
```

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
