### PR TITLE
fix(common): have the ready condition to true on manually managed endpointslices

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -48,5 +48,4 @@ sources:
   - https://hub.docker.com/_/
   - https://hub.docker.com/r/mikefarah/yq
 type: library
-version: 28.12.3
-
+version: 28.12.4

--- a/charts/library/common/templates/class/_endpointSlice.tpl
+++ b/charts/library/common/templates/class/_endpointSlice.tpl
@@ -28,6 +28,7 @@ metadata:
   namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Endpoint Slice") }}
   {{- $labels := (mustMerge ($objectData.labels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $rootCtx | fromYaml)) -}}
   {{- $_ := set $labels "kubernetes.io/service-name" $objectData.name -}}
+  {{- $_ := set $labels "endpointslice.kubernetes.io/managed-by" "Helm" -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $rootCtx "labels" $labels) | trim) }}
   labels:
     {{- . | nindent 4 }}

--- a/charts/library/common/templates/lib/endpointSlice/_endpoints.tpl
+++ b/charts/library/common/templates/lib/endpointSlice/_endpoints.tpl
@@ -18,4 +18,6 @@ objectData: The object data of the service
   {{- end }}
 - addresses:
   - {{ tpl $objectData.externalIP $rootCtx }}
+    conditions:
+      ready: true
 {{- end -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

I added the "condition ready" to the endpoint slice manifest so that traffic flows to it.
https://kubernetes.io/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1/
https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/
https://kubernetes.io/docs/concepts/services-networking/service/#endpointslices

Also set the label `endpointslice.kubernetes.io/managed-by` to Helm, so it is not managed by a default manager.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Deployed in my cluster


**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
