### PR TITLE
fix(common): correct skipEmptyWalArchiveCheck template syntax in cluster

### DIFF
--- a/charts/library/common-test/tests/cnpg/cluster_metadata_test.yaml
+++ b/charts/library/common-test/tests/cnpg/cluster_metadata_test.yaml
@@ -165,5 +165,5 @@ tests:
     asserts:
       - documentIndex: *clusterDoc
         equal:
-          path: metadata.annotations."cnpg.io/skipEmptyWalArchiveCheck"
+          path: metadata.annotations["cnpg.io/skipEmptyWalArchiveCheck"]
           value: true

--- a/charts/library/common-test/tests/cnpg/cluster_metadata_test.yaml
+++ b/charts/library/common-test/tests/cnpg/cluster_metadata_test.yaml
@@ -153,3 +153,17 @@ tests:
         equal:
           path: metadata.namespace
           value: local-namespace
+
+  - it: should pass with cnpg with skipEmptyWalArchiveCheck annotation
+    set:
+      cnpg:
+        my-pg:
+          enabled: true
+          user: test-user
+          database: test-db
+          password: test-password
+    asserts:
+      - documentIndex: *clusterDoc
+        equal:
+          path: metadata.annotations."cnpg.io/skipEmptyWalArchiveCheck"
+          value: true

--- a/charts/library/common-test/tests/cnpg/cluster_metadata_test.yaml
+++ b/charts/library/common-test/tests/cnpg/cluster_metadata_test.yaml
@@ -166,4 +166,4 @@ tests:
       - documentIndex: *clusterDoc
         equal:
           path: metadata.annotations["cnpg.io/skipEmptyWalArchiveCheck"]
-          value: true
+          value: "enabled"

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -48,5 +48,5 @@ sources:
   - https://hub.docker.com/_/
   - https://hub.docker.com/r/mikefarah/yq
 type: library
-version: 28.12.8
+version: 28.12.9
 

--- a/charts/library/common/templates/class/cnpg/_cluster.tpl
+++ b/charts/library/common/templates/class/cnpg/_cluster.tpl
@@ -176,7 +176,9 @@ metadata:
   annotations:
     cnpg.io/hibernation: {{ $hibernation | quote }}
     checksum/secrets: {{ toJson $rootCtx.Values.secret | sha256sum }}
-    cnpg.io/skipEmptyWalArchiveCheck: {{ $skipEmptyWalArchiveCheck }}
+    {{- if $skipEmptyWalArchiveCheck }}
+    cnpg.io/skipEmptyWalArchiveCheck: "enabled"
+    {{- end }}
   {{- $annotations := (mustMerge $clusterAnnotations (include "tc.v1.common.lib.metadata.allAnnotations" $rootCtx | fromYaml)) -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $rootCtx "annotations" $annotations) | trim) }}
     {{- . | nindent 4 }}

--- a/charts/library/common/templates/class/cnpg/_cluster.tpl
+++ b/charts/library/common/templates/class/cnpg/_cluster.tpl
@@ -176,7 +176,7 @@ metadata:
   annotations:
     cnpg.io/hibernation: {{ $hibernation | quote }}
     checksum/secrets: {{ toJson $rootCtx.Values.secret | sha256sum }}
-    cnpg.io/skipEmptyWalArchiveCheck: $skipEmptyWalArchiveCheck
+    cnpg.io/skipEmptyWalArchiveCheck: {{ $skipEmptyWalArchiveCheck }}
   {{- $annotations := (mustMerge $clusterAnnotations (include "tc.v1.common.lib.metadata.allAnnotations" $rootCtx | fromYaml)) -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $rootCtx "annotations" $annotations) | trim) }}
     {{- . | nindent 4 }}


### PR DESCRIPTION
Updated the _cluster.tpl file to ensure the skipEmptyWalArchiveCheck annotation is properly rendered. Added a new test case in cluster_metadata_test.yaml to verify the correct behavior of the annotation.

**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Added unit tests to verify the annotation

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
