### PR TITLE
fix(common): Improve common resources limit ratios

### DIFF
--- a/archive/charts/premium/prometheus/values.yaml
+++ b/archive/charts/premium/prometheus/values.yaml
@@ -887,12 +887,12 @@ prometheus:
     resources:
       ## Example:
       ## limits:
-      ##    cpu: 100m
+      ##    cpu: 75m
       ##    memory: 128Mi
       limits: {}
       ## Examples:
       ## requests:
-      ##    cpu: 100m
+      ##    cpu: 75m
       ##    memory: 128Mi
       requests: {}
     ## Configure extra options for liveness probe

--- a/archive/charts/system/openebs/values.yaml
+++ b/archive/charts/system/openebs/values.yaml
@@ -56,10 +56,10 @@ localpv-provisioner:
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
     #  limits:
-    #    cpu: 100m
+    #    cpu: 75m
     #    memory: 128Mi
     #  requests:
-    #    cpu: 100m
+    #    cpu: 75m
     #    memory: 128Mi
     nodeSelector: {}
     tolerations: []

--- a/charts/library/common-test/tests/addons/autoperms_test.yaml
+++ b/charts/library/common-test/tests/addons/autoperms_test.yaml
@@ -176,7 +176,7 @@ tests:
             name: tmp
             emptyDir:
               medium: Memory
-              sizeLimit: 1500Mi
+              sizeLimit: 2400Mi
       - documentIndex: *jobDoc
         contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -367,19 +367,19 @@ tests:
           path: spec.template.spec.containers[0].resources
           value:
             requests:
-              cpu: 100m
-              memory: 250Mi
+              cpu: 75m
+              memory: 200Mi
             limits:
-              cpu: 1000m
-              memory: 1500Mi
+              cpu: 1500m
+              memory: 2400Mi
               nvidia.com/gpu: 1
       - documentIndex: *jobDoc
         equal:
           path: spec.template.spec.containers[0].resources
           value:
             requests:
-              cpu: 100m
-              memory: 250Mi
+              cpu: 75m
+              memory: 200Mi
             limits:
               cpu: 2000m
               memory: 2Gi

--- a/charts/library/common-test/tests/addons/codeserver_test.yaml
+++ b/charts/library/common-test/tests/addons/codeserver_test.yaml
@@ -99,11 +99,11 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
@@ -114,12 +114,12 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
                 nvidia.com/gpu: 1
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
       - documentIndex: *AddonServiceDocument
         equal:
           path: metadata.name
@@ -358,11 +358,11 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
 
   - it: should fail if more than 1 workload selected
     set:

--- a/charts/library/common-test/tests/addons/gluetun_test.yaml
+++ b/charts/library/common-test/tests/addons/gluetun_test.yaml
@@ -102,12 +102,12 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
                 nvidia.com/gpu: 1
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
@@ -118,11 +118,11 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
       - documentIndex: *ServiceDocument
         equal:
           path: metadata.name

--- a/charts/library/common-test/tests/addons/netshoot_test.yaml
+++ b/charts/library/common-test/tests/addons/netshoot_test.yaml
@@ -55,12 +55,12 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
                 nvidia.com/gpu: 1
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
@@ -71,11 +71,11 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
       - documentIndex: *ServiceDocument
         equal:
           path: metadata.name

--- a/charts/library/common-test/tests/addons/tailscale_test.yaml
+++ b/charts/library/common-test/tests/addons/tailscale_test.yaml
@@ -67,12 +67,12 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
                 nvidia.com/gpu: 1
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
@@ -83,11 +83,11 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.containers[1].env
@@ -174,12 +174,12 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
                 nvidia.com/gpu: 1
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
       - documentIndex: *DeploymentDocument
         equal:
           path: spec.template.spec.containers[1].name
@@ -190,11 +190,11 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
       - documentIndex: *DeploymentDocument
         contains:
           path: spec.template.spec.containers[1].env

--- a/charts/library/common-test/tests/cnpg/cluster_recovery_spec_test.yaml
+++ b/charts/library/common-test/tests/cnpg/cluster_recovery_spec_test.yaml
@@ -49,11 +49,11 @@ tests:
               inProgress: false
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
             storage:
               pvcTemplate:
                 accessModes:

--- a/charts/library/common-test/tests/cnpg/cluster_spec_test.yaml
+++ b/charts/library/common-test/tests/cnpg/cluster_spec_test.yaml
@@ -45,11 +45,11 @@ tests:
               inProgress: false
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
             storage:
               pvcTemplate:
                 accessModes:
@@ -114,11 +114,11 @@ tests:
               inProgress: false
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
             storage:
               pvcTemplate:
                 accessModes:

--- a/charts/library/common-test/tests/container/resources_test.yaml
+++ b/charts/library/common-test/tests/container/resources_test.yaml
@@ -648,7 +648,7 @@ tests:
                 probes: *probes
     asserts:
       - failedTemplate:
-          errorMessage: Container - Expected [resources.requests.cpu] to have one of the following formats [(Plain Integer - eg. 1), (Float - eg. 0.5), (Milicpu - eg. 500m)], but got [100MB]
+          errorMessage: Container - Expected [resources.requests.cpu] to have one of the following formats [(Plain Integer - eg. 1), (Float - eg. 0.5), (Milicpu - eg. 500m)], but got [75mB]
 
   - it: should fail with invalid format in limits.cpu
     set:
@@ -674,7 +674,7 @@ tests:
                 probes: *probes
     asserts:
       - failedTemplate:
-          errorMessage: Container - Expected [resources.limits.cpu] to have one of the following formats [(Plain Integer - eg. 1), (Float - eg. 0.5), (Milicpu - eg. 500m)], but got [100MB]
+          errorMessage: Container - Expected [resources.limits.cpu] to have one of the following formats [(Plain Integer - eg. 1), (Float - eg. 0.5), (Milicpu - eg. 500m)], but got [75mB]
 
   - it: should fail with invalid format in requests.memory
     set:

--- a/charts/library/common-test/tests/container/resources_test.yaml
+++ b/charts/library/common-test/tests/container/resources_test.yaml
@@ -42,11 +42,11 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
 
   - it: should override the default limits
     set:
@@ -89,8 +89,8 @@ tests:
                 nvidia.com/gpu: 1
                 some-resource: 1
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
 
   - it: should override the default limits from top level
     set:
@@ -134,8 +134,8 @@ tests:
                 memory: 4Gi
                 some-other-resource: 2
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
 
   - it: should override the default limits.cpu
     set:
@@ -169,10 +169,10 @@ tests:
             resources:
               limits:
                 cpu: 2000m
-                memory: 1500Mi
+                memory: 2400Mi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
 
   - it: should override the default limits.memory
     set:
@@ -205,11 +205,11 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
+                cpu: 1500m
                 memory: 4Gi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
 
   - it: should not render limits.cpu
     set:
@@ -242,10 +242,10 @@ tests:
           content:
             resources:
               limits:
-                memory: 1500Mi
+                memory: 2400Mi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
 
   - it: should not render limits.memory
     set:
@@ -278,10 +278,10 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
+                cpu: 1500m
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
 
   - it: should override the default requests
     set:
@@ -315,8 +315,8 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
                 cpu: 200m
                 memory: 1Gi
@@ -352,11 +352,11 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
                 cpu: 200m
-                memory: 250Mi
+                memory: 200Mi
 
   - it: should override the default requests.memory
     set:
@@ -389,10 +389,10 @@ tests:
           content:
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
-                cpu: 100m
+                cpu: 75m
                 memory: 1Gi
 
   - it: should not add extra resources on "wait" containers and on excluded containers
@@ -451,11 +451,11 @@ tests:
           path: spec.resources
           value:
             limits:
-              cpu: 1000m
-              memory: 1500Mi
+              cpu: 1500m
+              memory: 2400Mi
             requests:
-              cpu: 100m
-              memory: 250Mi
+              cpu: 75m
+              memory: 200Mi
       - documentIndex: &deploymentDoc 8
         isKind:
           of: Deployment
@@ -469,12 +469,12 @@ tests:
             name: test-release-name-common-test
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
                 nvidia.com/gpu: 1
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
       - documentIndex: *deploymentDoc
         isSubset:
           path: spec.template.spec.containers[1]
@@ -482,11 +482,11 @@ tests:
             name: test-release-name-common-test-my-container
             resources:
               limits:
-                cpu: 1000m
-                memory: 1500Mi
+                cpu: 1500m
+                memory: 2400Mi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 75m
+                memory: 200Mi
       - documentIndex: *deploymentDoc
         isSubset:
           path: spec.template.spec.initContainers[0]
@@ -609,7 +609,7 @@ tests:
       image: *image
       resources:
         requests:
-          cpu: 100m
+          cpu: 75m
           memory: ""
       workload:
         workload-name1:
@@ -632,8 +632,8 @@ tests:
       image: *image
       resources:
         requests:
-          cpu: 100MB
-          memory: 250Mi
+          cpu: 75mB
+          memory: 200Mi
       workload:
         workload-name1:
           enabled: true
@@ -655,11 +655,11 @@ tests:
       image: *image
       resources:
         requests:
-          cpu: 100m
-          memory: 250Mi
+          cpu: 75m
+          memory: 200Mi
         limits:
-          cpu: 100MB
-          memory: 1500Mi
+          cpu: 75mB
+          memory: 2400Mi
       workload:
         workload-name1:
           enabled: true
@@ -681,11 +681,11 @@ tests:
       image: *image
       resources:
         requests:
-          cpu: 100m
+          cpu: 75m
           memory: 50MB
         limits:
-          cpu: 1000m
-          memory: 1500Mi
+          cpu: 1500m
+          memory: 2400Mi
       workload:
         workload-name1:
           enabled: true
@@ -707,10 +707,10 @@ tests:
       image: *image
       resources:
         requests:
-          cpu: 100m
-          memory: 250Mi
+          cpu: 75m
+          memory: 200Mi
         limits:
-          cpu: 1000m
+          cpu: 1500m
           memory: 8GB
       workload:
         workload-name1:

--- a/charts/library/common-test/tests/container/volumeMounts_test.yaml
+++ b/charts/library/common-test/tests/container/volumeMounts_test.yaml
@@ -670,21 +670,21 @@ tests:
             - name: devshm
               emptyDir:
                 medium: Memory
-                sizeLimit: 1500Mi
+                sizeLimit: 2400Mi
             - name: shared
               emptyDir: {}
             - name: tmp
               emptyDir:
                 medium: Memory
-                sizeLimit: 1500Mi
+                sizeLimit: 2400Mi
             - name: varlogs
               emptyDir:
                 medium: Memory
-                sizeLimit: 1500Mi
+                sizeLimit: 2400Mi
             - name: varrun
               emptyDir:
                 medium: Memory
-                sizeLimit: 1500Mi
+                sizeLimit: 2400Mi
 
       - documentIndex: *deploymentDoc
         equal:

--- a/charts/library/common-test/tests/defaults/defaults-test.yaml
+++ b/charts/library/common-test/tests/defaults/defaults-test.yaml
@@ -90,21 +90,21 @@ tests:
               - name: devshm
                 emptyDir:
                   medium: Memory
-                  sizeLimit: 1500Mi
+                  sizeLimit: 2400Mi
               - name: shared
                 emptyDir: {}
               - name: tmp
                 emptyDir:
                   medium: Memory
-                  sizeLimit: 1500Mi
+                  sizeLimit: 2400Mi
               - name: varlogs
                 emptyDir:
                   medium: Memory
-                  sizeLimit: 1500Mi
+                  sizeLimit: 2400Mi
               - name: varrun
                 emptyDir:
                   medium: Memory
-                  sizeLimit: 1500Mi
+                  sizeLimit: 2400Mi
       - documentIndex: *deploymentDoc
         isSubset:
           path: spec.template.spec.containers[0]

--- a/charts/library/common-test/tests/pod/volume_emptyDIr_test.yaml
+++ b/charts/library/common-test/tests/pod/volume_emptyDIr_test.yaml
@@ -81,7 +81,7 @@ tests:
             name: emptyDir-vol
             emptyDir:
               medium: Memory
-              sizeLimit: 1500Mi
+              sizeLimit: 2400Mi
 
   - it: should pass with emptyDir volume with size set
     set:

--- a/charts/library/common-test/tests/vpa/spec_test.yaml
+++ b/charts/library/common-test/tests/vpa/spec_test.yaml
@@ -91,10 +91,10 @@ tests:
                 controlledResources: ["cpu", "memory"]
                 controlledValues: RequestsAndLimits
                 minAllowed:
-                  cpu: 1000m
+                  cpu: 1500m
                   memory: 1000Mi
                 maxAllowed:
-                  cpu: 1000m
+                  cpu: 1500m
                   memory: 1000Mi
     asserts:
       - documentIndex: &vpaDoc 1
@@ -124,10 +124,10 @@ tests:
                 controlledResources: ["cpu", "memory"]
                 controlledValues: RequestsAndLimits
                 minAllowed:
-                  cpu: 1000m
+                  cpu: 1500m
                   memory: 1000Mi
                 maxAllowed:
-                  cpu: 1000m
+                  cpu: 1500m
                   memory: 1000Mi
   - it: should create vpa with containerPolicies options ignored when mode is Off
     set:
@@ -149,10 +149,10 @@ tests:
                 controlledResources: ["cpu", "memory"]
                 controlledValues: RequestsAndLimits
                 minAllowed:
-                  cpu: 1000m
+                  cpu: 1500m
                   memory: 1000Mi
                 maxAllowed:
-                  cpu: 1000m
+                  cpu: 1500m
                   memory: 1000Mi
     asserts:
       - documentIndex: &vpaDoc 1

--- a/charts/library/common-test/tests/vpa/validation_test.yaml
+++ b/charts/library/common-test/tests/vpa/validation_test.yaml
@@ -332,7 +332,7 @@ tests:
               - containerName: "*"
                 mode: Auto
                 maxAllowed:
-                  cpu: 1000m
+                  cpu: 1500m
                   memory: invalid
     asserts:
       - failedTemplate:

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -123,11 +123,11 @@ securityContext:
 # Can be overruled per container
 resources:
   limits:
-    cpu: 1000m
-    memory: 1500Mi
+    cpu: 1500m
+    memory: 2400Mi
   requests:
-    cpu: 100m
-    memory: 250Mi
+    cpu: 75m
+    memory: 200Mi
 
 containerOptions:
   NVIDIA_CAPS:

--- a/clustertool/embed/generic/kubernetes/networking/nginx-external/app/helm-release.yaml
+++ b/clustertool/embed/generic/kubernetes/networking/nginx-external/app/helm-release.yaml
@@ -77,7 +77,7 @@ spec:
         enabled: false
       resources:
         requests:
-          cpu: 100m
+          cpu: 75m
         limits:
           memory: 500Mi
     defaultBackend:

--- a/clustertool/embed/generic/kubernetes/networking/nginx-internal/app/helm-release.yaml
+++ b/clustertool/embed/generic/kubernetes/networking/nginx-internal/app/helm-release.yaml
@@ -77,7 +77,7 @@ spec:
         enabled: false
       resources:
         requests:
-          cpu: 100m
+          cpu: 75m
         limits:
           memory: 500Mi
     defaultBackend:

--- a/clustertool/embed/generic/kubernetes/system/kube-prometheus-stack/app/helm-release.yaml
+++ b/clustertool/embed/generic/kubernetes/system/kube-prometheus-stack/app/helm-release.yaml
@@ -69,7 +69,7 @@ spec:
         replicas: 1
         resources:
           requests:
-            cpu: 100m
+            cpu: 75m
             memory: 500Mi
           limits:
             memory: 2000Mi

--- a/website/src/content/docs/guides/index.md
+++ b/website/src/content/docs/guides/index.md
@@ -115,7 +115,7 @@ prometheus:
     retentionSize: 50GB
     resources:
       requests:
-        cpu: 100m
+        cpu: 75m
         memory: 500Mi
       limits:
         memory: 2000Mi

--- a/website/src/content/docs/guides/ingress/nginx.md
+++ b/website/src/content/docs/guides/ingress/nginx.md
@@ -58,7 +58,7 @@ controller:
     enabled: false
   resources:
     requests:
-      cpu: 100m
+      cpu: 75m
     limits:
       memory: 500Mi
 defaultBackend:
@@ -110,7 +110,7 @@ controller:
     enabled: false
   resources:
     requests:
-      cpu: 100m
+      cpu: 75m
     limits:
       memory: 500Mi
 defaultBackend:


### PR DESCRIPTION
**Description**
Some users report that the current  ratios between requests and limits where a bit too strict.
This increases the ratio to 20x on CPU and 12x on ram, lowing requests and increasing limits slightly.

Its important to note that CPU is easier to share among containers, so has the higher ratio on purpose.
The new ratio allows more room for multithreading on a container

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
