### PR TITLE
fix(clustertool): Revert 35820 apiVersion: source.toolkit.fluxcd.io

### DIFF
--- a/clustertool/embed/generic/root/repositories/oci/flux-manifests.yaml
+++ b/clustertool/embed/generic/root/repositories/oci/flux-manifests.yaml
@@ -1,6 +1,6 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: OCIRepository
 metadata:
   name: flux-manifests

--- a/website/src/content/docs/guides/fluxcd/capacitor.md
+++ b/website/src/content/docs/guides/fluxcd/capacitor.md
@@ -31,8 +31,8 @@ If you face issues feel free to open a thread in the appropiate Channel in our D
 - Next we will need 3 files inside the capacitor folder:
 
 
-capacitor.yaml
 ```yaml
+//capacitor.yaml
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -51,8 +51,8 @@ spec:
     name: capacitor
 ```
 
-ingress.yaml
 ```yaml
+//ingress.yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/website/src/content/docs/guides/fluxcd/capacitor.md
+++ b/website/src/content/docs/guides/fluxcd/capacitor.md
@@ -33,6 +33,7 @@ If you face issues feel free to open a thread in the appropiate Channel in our D
 
 ```yaml
 //capacitor.yaml
+
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -53,6 +54,7 @@ spec:
 
 ```yaml
 //ingress.yaml
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -80,8 +82,9 @@ spec:
       secretName: capacitor-tls-0 # use what you have configured for your ingress
 ```
 
-kustomization.yaml
 ``` yaml
+//kustomization.yaml
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -93,8 +96,9 @@ resources:
 
 Go to your `Reponsitories/oci` directory and create this file.
 
-capacitor-manifests.yaml
 ``` yaml
+//capacitor-manifests.yaml
+
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: OCIRepository
 metadata:

--- a/website/src/content/docs/guides/fluxcd/capacitor.md
+++ b/website/src/content/docs/guides/fluxcd/capacitor.md
@@ -31,9 +31,8 @@ If you face issues feel free to open a thread in the appropiate Channel in our D
 - Next we will need 3 files inside the capacitor folder:
 
 
+capacitor.yaml
 ```yaml
-//capacitor.yaml
-
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -52,9 +51,8 @@ spec:
     name: capacitor
 ```
 
+ingress.yaml
 ```yaml
-//ingress.yaml
-
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -82,9 +80,8 @@ spec:
       secretName: capacitor-tls-0 # use what you have configured for your ingress
 ```
 
+kustomization.yaml
 ``` yaml
-//kustomization.yaml
-
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -96,10 +93,9 @@ resources:
 
 Go to your `Reponsitories/oci` directory and create this file.
 
+capacitor-manifests.yaml
 ``` yaml
-//capacitor-manifests.yaml
-
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: OCIRepository
 metadata:
   name: capacitor


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->
With this previous PR it seems a fresh clustertool bootstrap isn't possible.
This needs to be `apiVersion: source.toolkit.fluxcd.io/v1beta2`

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Just bootstrapped my cluster and `apiVersion: source.toolkit.fluxcd.io/v1` will not work

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
