### PR TITLE
fix(renovate): default config configmap

### DIFF
--- a/charts/stable/renovate/Chart.yaml
+++ b/charts/stable/renovate/Chart.yaml
@@ -32,5 +32,5 @@ sources:
   - https://github.com/truecharts/charts/tree/master/charts/stable/renovate
   - https://github.com/trueforge-org/truecharts/tree/master/charts/stable/renovate
 type: application
-version: 2.4.1
+version: 2.4.2
 

--- a/charts/stable/renovate/values.yaml
+++ b/charts/stable/renovate/values.yaml
@@ -29,7 +29,7 @@ workload:
             # You can set RENOVATE_AUTODISCOVER to true to run Renovate on all repos you have push access to
             RENOVATE_AUTODISCOVER: 'false'
             RENOVATE_TOKEN: '${GITHUB_PAT}'
-            RENOVATE_CONFIG_FILE: /config/renovate-config.js
+            RENOVATE_CONFIG_FILE: /config/renovate-config.json
             LOG_LEVEL: debug
             RENOVATE_CACHE_DIR: /tmp/renovate/cache
 
@@ -37,7 +37,7 @@ configmap:
   config:
     enabled: true
     data:
-      renovate-config.js: |-
+      renovate-config.json: |-
         {
           "repositories": ["trueforge-org/truecharts"],
           "dryRun" : "full"
@@ -67,5 +67,5 @@ persistence:
     defaultMode: "0777"
     mountPath: /config/
     items:
-      - key: renovate-config.js
-        path: renovate-config.js
+      - key: renovate-config.json
+        path: renovate-config.json


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
I changed the configmap default file name for renovate because the default use json syntax but format .js trigger a javascript parser (because the configuration can be provided as js file), so the image creation was failing

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Changing the file extension to .json create correctly the pods and doesn't fail anymore

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
