### PR TITLE
fix(devcontainer): Export KREW_PATH to fish shell

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -22,7 +22,10 @@ fisher install PatrickF1/fzf.fish
   ./"${KREW}" install krew
 )
 
-export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
+KREW_PATH="${KREW_ROOT:-$HOME/.krew}/bin"
+export PATH="$KREW_PATH:$PATH"
+# add KREW_PATH to fish shell path
+/usr/bin/fish -c "fish_add_path $KREW_PATH"
 
 kubectl krew install pv-mounter
 kubectl krew install cnpg

--- a/clustertool/embed/generic/root/DOTREPLACEdevcontainer/postCreateCommand.sh
+++ b/clustertool/embed/generic/root/DOTREPLACEdevcontainer/postCreateCommand.sh
@@ -22,7 +22,10 @@ fisher install PatrickF1/fzf.fish
   ./"${KREW}" install krew
 )
 
-export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
+KREW_PATH="${KREW_ROOT:-$HOME/.krew}/bin"
+export PATH="$KREW_PATH:$PATH"
+# add KREW_PATH to fish shell path
+/usr/bin/fish -c "fish_add_path $KREW_PATH"
 
 kubectl krew install pv-mounter
 kubectl krew install cnpg


### PR DESCRIPTION
**Description**

This allow us to actually use krew and installed plugins from fish shells inside our devcontainer

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**

On local vs-code install, I was hitting
```
talos_clustertool on  main [$] 
⬢ [Docker] ❯ kubectl krew
error: unknown command "krew" for "kubectl"

talos_clustertool on  main [$] 
⬢ [Docker] ❯ kubectl pv-mounter
error: unknown command "pv-mounter" for "kubectl"
```
before fix inside a devcontainer. After exporting the krew path to fish, we can find the installed plugins.

```
talos_clustertool on  main [!] 
⬢ [Docker] ❯ kubectl pv-mounter
pv-mounter is a kubectl plugin that allows you to easily mount and unmount
Kubernetes PersistentVolumeClaims (PVCs) locally via SSHFS.

It transparently manages proxy pods, ephemeral containers, port-forwarding,
and SSHFS connections.
...
``` 

**📃 Notes:**
Not sure if relevant, but I used:
```
(base) ➜  truecharts git:(orippler/export_krew_path_to_fish) code --version
1.104.1
0f0d87fa9e96c856c5212fc86db137ac0d783365
x64
```
on Ubuntu 22.04
**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
