### PR TITLE
fix(longhorn): Convert default values from int to string

### DIFF
--- a/clustertool/embed/generic/kubernetes/system/longhorn/app/helm-release.yaml
+++ b/clustertool/embed/generic/kubernetes/system/longhorn/app/helm-release.yaml
@@ -26,9 +26,9 @@ spec:
   values:
     defaultSettings:
       # Increase to 3 for a multi-node cluster
-      defaultReplicaCount: 1
+      defaultReplicaCount: "1"
       # Overprovisioning might be needed when using volsync
-      storageOverProvisioningPercentage: 100000
+      storageOverProvisioningPercentage: "100000"
       # v2DataEngine: true
     persistence:
       # Set to false to pick another CSI as default


### PR DESCRIPTION
**Description**

Flux seems to complain for default values provided as int:

```
Helm install failed for release longhorn-system/longhorn with chart longhorn@1.10.0: execution error at
(longhorn/templates/default-setting.yaml:67:8): defaultSettings.* must be a string
```

for both `defaultReplicaCount` and `storageoverProvisioningPercentage` in the longhorn chart embedded into clustertool
**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
`clustertool init` yielded the `helm-release.yaml` with `int`s, and I had to manually convert them to strings in order to get longhorn to deploy.

Versions: `clustertool==2.0.6` and `talos==1.11.1`

**📃 Notes:**
Might be worth adding a test that covers this, though I'm not sure where to start. 

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
