### PR TITLE
feat(common): Add `customCA` and `customCASecretRef` support for CNPG

### DIFF
--- a/charts/library/common-test/Chart.yaml
+++ b/charts/library/common-test/Chart.yaml
@@ -37,4 +37,3 @@ sources:
   - https://github.com/trueforge-org/truecharts/tree/master/charts/library/common-test
 type: application
 version: 1.0.0
-

--- a/charts/library/common-test/tests/cnpg/backup_provider_secret_spec_test.yaml
+++ b/charts/library/common-test/tests/cnpg/backup_provider_secret_spec_test.yaml
@@ -76,23 +76,23 @@ tests:
             manualBackups:
               - name: today
     asserts:
-      - documentIndex: *secretDoc
+      - documentIndex: &secretCredDoc 3
         isKind:
           of: Secret
-      - documentIndex: *secretDoc
+      - documentIndex: *secretCredDoc
         isAPIVersion:
           of: v1
-      - documentIndex: *secretDoc
+      - documentIndex: *secretCredDoc
         equal:
           path: metadata.name
           value: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
-      - documentIndex: *secretDoc
+      - documentIndex: *secretCredDoc
         equal:
           path: stringData
           value:
             ACCESS_SECRET_KEY: some-secret-key
             ACCESS_KEY_ID: some-access-key
-      - documentIndex: &secretCADoc 3
+      - documentIndex: &secretCADoc 2
         isKind:
           of: Secret
       - documentIndex: *secretCADoc

--- a/charts/library/common-test/tests/cnpg/backup_provider_secret_spec_test.yaml
+++ b/charts/library/common-test/tests/cnpg/backup_provider_secret_spec_test.yaml
@@ -46,3 +46,67 @@ tests:
           value:
             ACCESS_SECRET_KEY: some-secret-key
             ACCESS_KEY_ID: some-access-key
+
+  - it: should create secrets for s3 provider with customCA
+    set:
+      credentials:
+        test:
+          type: s3
+          url: http://some-url
+          encrKey: some-encr-key
+          bucket: some-bucket
+          secretKey: some-secret-key
+          accessKey: some-access-key
+          customCA: |-
+            -----BEGIN CERTIFICATE-----
+            ...
+            -----END CERTIFICATE-----
+      cnpg:
+        my-pg:
+          enabled: true
+          user: test-user
+          database: test-db
+          password: test-password
+          backups:
+            enabled: true
+            target: primary
+            retentionPolicy: 10d
+            credentials: test
+            destinationPath: some-path
+            manualBackups:
+              - name: today
+    asserts:
+      - documentIndex: *secretDoc
+        isKind:
+          of: Secret
+      - documentIndex: *secretDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
+      - documentIndex: *secretDoc
+        equal:
+          path: stringData
+          value:
+            ACCESS_SECRET_KEY: some-secret-key
+            ACCESS_KEY_ID: some-access-key
+      - documentIndex: &secretCADoc 3
+        isKind:
+          of: Secret
+      - documentIndex: *secretCADoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretCADoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-ca
+      - documentIndex: *secretCADoc
+        equal:
+          path: stringData
+          value:
+            ca.crt: |-
+              -----BEGIN CERTIFICATE-----
+              ...
+              -----END CERTIFICATE-----

--- a/charts/library/common-test/tests/cnpg/backup_validation_test.yaml
+++ b/charts/library/common-test/tests/cnpg/backup_validation_test.yaml
@@ -65,3 +65,43 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: CNPG Backup - Expected [url] in [credentials.test] to start with [http://] or [https://]. It was observed that sometimes can cause issues if it does not. Got [some-url]
+
+  - it: should fail with both customCA and customCASecretRef specified in s3 credentials
+    set:
+      secret:
+        my-secret:
+          enabled: true
+          data:
+            my-key: |-
+              -----BEGIN CERTIFICATE-----
+              ...
+              -----END CERTIFICATE-----
+      credentials:
+        test:
+          type: s3
+          url: some-url
+          bucket: some-bucket
+          encrKey: some-encr-key
+          accessKey: some-access-key
+          secretKey: some-secret-key
+          customCA: |-
+            -----BEGIN CERTIFICATE-----
+            ...
+            -----END CERTIFICATE-----
+          customCASecretRef:
+            name: my-secret
+            key: my-key
+      cnpg:
+        my-pg:
+          enabled: true
+          user: test-user
+          database: test-db
+          password: test-password
+          backups:
+            enabled: true
+            credentials: test
+            manualBackups:
+              - name: today
+    asserts:
+      - failedTemplate:
+          errorMessage: CNPG Backup - Both [customCA] and [customCASecretRef] defined in [credentials.test]. Choose one

--- a/charts/library/common-test/tests/cnpg/backup_validation_test.yaml
+++ b/charts/library/common-test/tests/cnpg/backup_validation_test.yaml
@@ -79,7 +79,7 @@ tests:
       credentials:
         test:
           type: s3
-          url: some-url
+          url: https://valid-url.com
           bucket: some-bucket
           encrKey: some-encr-key
           accessKey: some-access-key

--- a/charts/library/common-test/tests/cnpg/cluster_backup_spec_test.yaml
+++ b/charts/library/common-test/tests/cnpg/cluster_backup_spec_test.yaml
@@ -78,6 +78,209 @@ tests:
               retentionPolicy: 10d
               target: primary
 
+  - it: should generate correct spec with backups using customCA (s3)
+    set:
+      credentials:
+        test:
+          type: s3
+          accessKey: some-access-key
+          secretKey: some-secret-key
+          bucket: some-bucket
+          encrKey: some-encr-key
+          url: http://some-url
+          customCA: |-
+            -----BEGIN CERTIFICATE-----
+            ...
+            -----END CERTIFICATE-----
+      cnpg:
+        my-pg:
+          enabled: true
+          user: test-user
+          database: test-db
+          password: test-password
+          backups:
+            enabled: true
+            target: primary
+            retentionPolicy: 10d
+            credentials: test
+            destinationPath: some-path
+    asserts:
+      - documentIndex: *secretDoc
+        isKind:
+          of: Secret
+      - documentIndex: *secretDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
+      - documentIndex: *secretDoc
+        equal:
+          path: stringData
+          value:
+            ACCESS_KEY_ID: some-access-key
+            ACCESS_SECRET_KEY: some-secret-key
+      - documentIndex: &secretCADoc 2
+        isKind:
+          of: Secret
+      - documentIndex: *secretCADoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretCADoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-ca
+      - documentIndex: *secretCADoc
+        equal:
+          path: stringData
+          value:
+            ca.crt: |-
+              -----BEGIN CERTIFICATE-----
+              ...
+              -----END CERTIFICATE-----
+      - documentIndex: *clusterDoc
+        isKind:
+          of: Cluster
+      - documentIndex: *clusterDoc
+        isAPIVersion:
+          of: postgresql.cnpg.io/v1
+      - documentIndex: *clusterDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg
+      - documentIndex: *clusterDoc
+        isSubset:
+          path: spec
+          content:
+            backup:
+              barmanObjectStore:
+                data:
+                  compression: bzip2
+                  jobs: 2
+                destinationPath: some-path
+                endpointURL: http://some-url
+                endpointCA:
+                  name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-ca
+                  key: ca.crt
+                s3Credentials:
+                  accessKeyId:
+                    key: ACCESS_KEY_ID
+                    name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
+                  secretAccessKey:
+                    key: ACCESS_SECRET_KEY
+                    name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
+                serverName: test-release-name-common-test-cnpg-my-pg
+                wal:
+                  compression: bzip2
+              retentionPolicy: 10d
+              target: primary
+
+  - it: should generate correct spec with backups using customCASecretRef (s3)
+    set:
+      secret:
+        my-secret:
+          enabled: true
+          data:
+            my-key: |-
+              -----BEGIN CERTIFICATE-----
+              ...
+              -----END CERTIFICATE-----
+      credentials:
+        test:
+          type: s3
+          accessKey: some-access-key
+          secretKey: some-secret-key
+          bucket: some-bucket
+          encrKey: some-encr-key
+          url: http://some-url
+          customCASecretRef:
+            name: my-secret
+            key: my-key
+      cnpg:
+        my-pg:
+          enabled: true
+          user: test-user
+          database: test-db
+          password: test-password
+          backups:
+            enabled: true
+            target: primary
+            retentionPolicy: 10d
+            credentials: test
+            destinationPath: some-path
+    asserts:
+      - documentIndex: *secretDoc
+        isKind:
+          of: Secret
+      - documentIndex: *secretDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
+      - documentIndex: *secretDoc
+        equal:
+          path: stringData
+          value:
+            ACCESS_KEY_ID: some-access-key
+            ACCESS_SECRET_KEY: some-secret-key
+      - documentIndex: *secretCADoc
+        isKind:
+          of: Secret
+      - documentIndex: *secretCADoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretCADoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-my-secret
+      - documentIndex: *secretCADoc
+        equal:
+          path: stringData
+          value:
+            my-key: |-
+              -----BEGIN CERTIFICATE-----
+              ...
+              -----END CERTIFICATE-----
+      - documentIndex: *clusterDoc
+        isKind:
+          of: Cluster
+      - documentIndex: *clusterDoc
+        isAPIVersion:
+          of: postgresql.cnpg.io/v1
+      - documentIndex: *clusterDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg
+      - documentIndex: *clusterDoc
+        isSubset:
+          path: spec
+          content:
+            backup:
+              barmanObjectStore:
+                data:
+                  compression: bzip2
+                  jobs: 2
+                destinationPath: some-path
+                endpointURL: http://some-url
+                endpointCA:
+                  name: test-release-name-common-test-my-secret
+                  key: my-key
+                s3Credentials:
+                  accessKeyId:
+                    key: ACCESS_KEY_ID
+                    name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
+                  secretAccessKey:
+                    key: ACCESS_SECRET_KEY
+                    name: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
+                serverName: test-release-name-common-test-cnpg-my-pg
+                wal:
+                  compression: bzip2
+              retentionPolicy: 10d
+              target: primary
+
   - it: should use the revision when set in server name
     set:
       credentials:

--- a/charts/library/common-test/tests/cnpg/cluster_backup_spec_test.yaml
+++ b/charts/library/common-test/tests/cnpg/cluster_backup_spec_test.yaml
@@ -226,7 +226,7 @@ tests:
           value:
             ACCESS_KEY_ID: some-access-key
             ACCESS_SECRET_KEY: some-secret-key
-      - documentIndex: &secretCustomCASecretRefCADoc 3
+      - documentIndex: &secretCustomCASecretRefCADoc 4
         isKind:
           of: Secret
       - documentIndex: *secretCustomCASecretRefCADoc

--- a/charts/library/common-test/tests/cnpg/cluster_backup_spec_test.yaml
+++ b/charts/library/common-test/tests/cnpg/cluster_backup_spec_test.yaml
@@ -105,17 +105,17 @@ tests:
             credentials: test
             destinationPath: some-path
     asserts:
-      - documentIndex: &secretCredDoc 2
+      - documentIndex: &secretCustomCACredDoc 2
         isKind:
           of: Secret
-      - documentIndex: *secretCredDoc
+      - documentIndex: *secretCustomCACredDoc
         isAPIVersion:
           of: v1
-      - documentIndex: *secretCredDoc
+      - documentIndex: *secretCustomCACredDoc
         equal:
           path: metadata.name
           value: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
-      - documentIndex: *secretCredDoc
+      - documentIndex: *secretCustomCACredDoc
         equal:
           path: stringData
           value:
@@ -210,17 +210,17 @@ tests:
             credentials: test
             destinationPath: some-path
     asserts:
-      - documentIndex: *secretCredDoc
+      - documentIndex: *secretDoc
         isKind:
           of: Secret
-      - documentIndex: *secretCredDoc
+      - documentIndex: *secretDoc
         isAPIVersion:
           of: v1
-      - documentIndex: *secretCredDoc
+      - documentIndex: *secretDoc
         equal:
           path: metadata.name
           value: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
-      - documentIndex: *secretCredDoc
+      - documentIndex: *secretDoc
         equal:
           path: stringData
           value:

--- a/charts/library/common-test/tests/cnpg/cluster_backup_spec_test.yaml
+++ b/charts/library/common-test/tests/cnpg/cluster_backup_spec_test.yaml
@@ -105,33 +105,33 @@ tests:
             credentials: test
             destinationPath: some-path
     asserts:
-      - documentIndex: *secretDoc
+      - documentIndex: &secretCredDoc 2
         isKind:
           of: Secret
-      - documentIndex: *secretDoc
+      - documentIndex: *secretCredDoc
         isAPIVersion:
           of: v1
-      - documentIndex: *secretDoc
+      - documentIndex: *secretCredDoc
         equal:
           path: metadata.name
           value: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
-      - documentIndex: *secretDoc
+      - documentIndex: *secretCredDoc
         equal:
           path: stringData
           value:
             ACCESS_KEY_ID: some-access-key
             ACCESS_SECRET_KEY: some-secret-key
-      - documentIndex: &secretCADoc 2
+      - documentIndex: &secretCustomCACADoc 1
         isKind:
           of: Secret
-      - documentIndex: *secretCADoc
+      - documentIndex: *secretCustomCACADoc
         isAPIVersion:
           of: v1
-      - documentIndex: *secretCADoc
+      - documentIndex: *secretCustomCACADoc
         equal:
           path: metadata.name
           value: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-ca
-      - documentIndex: *secretCADoc
+      - documentIndex: *secretCustomCACADoc
         equal:
           path: stringData
           value:
@@ -210,33 +210,33 @@ tests:
             credentials: test
             destinationPath: some-path
     asserts:
-      - documentIndex: *secretDoc
+      - documentIndex: *secretCredDoc
         isKind:
           of: Secret
-      - documentIndex: *secretDoc
+      - documentIndex: *secretCredDoc
         isAPIVersion:
           of: v1
-      - documentIndex: *secretDoc
+      - documentIndex: *secretCredDoc
         equal:
           path: metadata.name
           value: test-release-name-common-test-cnpg-my-pg-provider-backup-s3-creds
-      - documentIndex: *secretDoc
+      - documentIndex: *secretCredDoc
         equal:
           path: stringData
           value:
             ACCESS_KEY_ID: some-access-key
             ACCESS_SECRET_KEY: some-secret-key
-      - documentIndex: *secretCADoc
+      - documentIndex: &secretCustomCASecretRefCADoc 3
         isKind:
           of: Secret
-      - documentIndex: *secretCADoc
+      - documentIndex: *secretCustomCASecretRefCADoc
         isAPIVersion:
           of: v1
-      - documentIndex: *secretCADoc
+      - documentIndex: *secretCustomCASecretRefCADoc
         equal:
           path: metadata.name
           value: test-release-name-common-test-my-secret
-      - documentIndex: *secretCADoc
+      - documentIndex: *secretCustomCASecretRefCADoc
         equal:
           path: stringData
           value:

--- a/charts/library/common-test/tests/cnpg/cluster_recovery_spec_test.yaml
+++ b/charts/library/common-test/tests/cnpg/cluster_recovery_spec_test.yaml
@@ -154,6 +154,216 @@ tests:
                       key: ACCESS_SECRET_KEY
                       name: test-release-name-common-test-cnpg-my-pg-provider-recovery-s3-creds
 
+  - it: should generate correct spec with recovery/objectStore using customCA (s3)
+    set:
+      credentials:
+        test:
+          type: s3
+          accessKey: some-access-key
+          secretKey: some-secret-key
+          bucket: some-bucket
+          encrKey: some-encr-key
+          url: https://s3.some-region.amazonaws.com
+          path: some-path
+          customCA: |-
+            -----BEGIN CERTIFICATE-----
+            ...
+            -----END CERTIFICATE-----
+      cnpg:
+        my-pg:
+          enabled: true
+          user: test-user
+          database: test-db
+          password: test-password
+          mode: recovery
+          recovery:
+            method: object_store
+            credentials: test
+    asserts:
+      - documentIndex: &secretCustomCACredDoc 2
+        isKind:
+          of: Secret
+      - documentIndex: *secretCustomCACredDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretCustomCACredDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg-provider-recovery-s3-creds
+      - documentIndex: *secretCustomCACredDoc
+        equal:
+          path: stringData
+          value:
+            ACCESS_KEY_ID: some-access-key
+            ACCESS_SECRET_KEY: some-secret-key
+      - documentIndex: &secretCustomCACADoc 1
+        isKind:
+          of: Secret
+      - documentIndex: *secretCustomCACADoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretCustomCACADoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg-provider-recovery-s3-ca
+      - documentIndex: *secretCustomCACADoc
+        equal:
+          path: stringData
+          value:
+            ca.crt: |-
+              -----BEGIN CERTIFICATE-----
+              ...
+              -----END CERTIFICATE-----
+      - documentIndex: *clusterDoc
+        isKind:
+          of: Cluster
+      - documentIndex: *clusterDoc
+        isAPIVersion:
+          of: postgresql.cnpg.io/v1
+      - documentIndex: *clusterDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg
+      - documentIndex: *clusterDoc
+        isSubset:
+          path: spec
+          content:
+            bootstrap:
+              recovery:
+                secret:
+                  name: test-release-name-common-test-cnpg-my-pg-user
+                owner: test-user
+                database: test-db
+                source: test-release-name-common-test-cnpg-my-pg
+      - documentIndex: *clusterDoc
+        isSubset:
+          path: spec
+          content:
+            externalClusters:
+              - name: test-release-name-common-test-cnpg-my-pg
+                barmanObjectStore:
+                  serverName: test-release-name-common-test-cnpg-my-pg
+                  destinationPath: s3://some-bucket/some-path/test-release-name/cnpg
+                  endpointURL: https://s3.some-region.amazonaws.com
+                  endpointCA:
+                    name: test-release-name-common-test-cnpg-my-pg-provider-recovery-s3-ca
+                    key: ca.crt
+                  s3Credentials:
+                    accessKeyId:
+                      key: ACCESS_KEY_ID
+                      name: test-release-name-common-test-cnpg-my-pg-provider-recovery-s3-creds
+                    secretAccessKey:
+                      key: ACCESS_SECRET_KEY
+                      name: test-release-name-common-test-cnpg-my-pg-provider-recovery-s3-creds
+
+  - it: should generate correct spec with recovery/objectStore using customCASecretRef (s3)
+    set:
+      my-secret:
+        enabled: true
+        data:
+          my-key: |-
+            -----BEGIN CERTIFICATE-----
+            ...
+            -----END CERTIFICATE-----
+      credentials:
+        test:
+          type: s3
+          accessKey: some-access-key
+          secretKey: some-secret-key
+          bucket: some-bucket
+          encrKey: some-encr-key
+          url: https://s3.some-region.amazonaws.com
+          path: some-path
+          customCASecretRef:
+            name: my-secret
+            key: my-key
+      cnpg:
+        my-pg:
+          enabled: true
+          user: test-user
+          database: test-db
+          password: test-password
+          mode: recovery
+          recovery:
+            method: object_store
+            credentials: test
+    asserts:
+      - documentIndex: *secretDoc
+        isKind:
+          of: Secret
+      - documentIndex: *secretDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg-provider-recovery-s3-creds
+      - documentIndex: *secretDoc
+        equal:
+          path: stringData
+          value:
+            ACCESS_KEY_ID: some-access-key
+            ACCESS_SECRET_KEY: some-secret-key
+      - documentIndex: &secretCustomCASecretRefCADoc 4
+        isKind:
+          of: Secret
+      - documentIndex: *secretCustomCASecretRefCADoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretCustomCASecretRefCADoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-my-secret
+      - documentIndex: *secretCustomCASecretRefCADoc
+        equal:
+          path: stringData
+          value:
+            my-key: |-
+              -----BEGIN CERTIFICATE-----
+              ...
+              -----END CERTIFICATE-----
+      - documentIndex: *clusterDoc
+        isKind:
+          of: Cluster
+      - documentIndex: *clusterDoc
+        isAPIVersion:
+          of: postgresql.cnpg.io/v1
+      - documentIndex: *clusterDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-cnpg-my-pg
+      - documentIndex: *clusterDoc
+        isSubset:
+          path: spec
+          content:
+            bootstrap:
+              recovery:
+                secret:
+                  name: test-release-name-common-test-cnpg-my-pg-user
+                owner: test-user
+                database: test-db
+                source: test-release-name-common-test-cnpg-my-pg
+      - documentIndex: *clusterDoc
+        isSubset:
+          path: spec
+          content:
+            externalClusters:
+              - name: test-release-name-common-test-cnpg-my-pg
+                barmanObjectStore:
+                  serverName: test-release-name-common-test-cnpg-my-pg
+                  destinationPath: s3://some-bucket/some-path/test-release-name/cnpg
+                  endpointURL: https://s3.some-region.amazonaws.com
+                  endpointCA:
+                    name: test-release-name-common-test-my-secret
+                    key: my-key
+                  s3Credentials:
+                    accessKeyId:
+                      key: ACCESS_KEY_ID
+                      name: test-release-name-common-test-cnpg-my-pg-provider-recovery-s3-creds
+                    secretAccessKey:
+                      key: ACCESS_SECRET_KEY
+                      name: test-release-name-common-test-cnpg-my-pg-provider-recovery-s3-creds
+
   - it: should generate correct spec with recovery/objectStore (s3 - destinationPath/endpointURL)
     set:
       credentials:

--- a/charts/library/common-test/tests/cnpg/cluster_recovery_spec_test.yaml
+++ b/charts/library/common-test/tests/cnpg/cluster_recovery_spec_test.yaml
@@ -258,13 +258,14 @@ tests:
 
   - it: should generate correct spec with recovery/objectStore using customCASecretRef (s3)
     set:
-      my-secret:
-        enabled: true
-        data:
-          my-key: |-
-            -----BEGIN CERTIFICATE-----
-            ...
-            -----END CERTIFICATE-----
+      secret:
+        my-secret:
+          enabled: true
+          data:
+            my-key: |-
+              -----BEGIN CERTIFICATE-----
+              ...
+              -----END CERTIFICATE-----
       credentials:
         test:
           type: s3

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -50,5 +50,4 @@ sources:
   - https://hub.docker.com/_/
   - https://hub.docker.com/r/mikefarah/yq
 type: library
-version: 28.23.0
-
+version: 28.24.0

--- a/charts/library/common/templates/lib/cnpg/providers/_customCA.tpl
+++ b/charts/library/common/templates/lib/cnpg/providers/_customCA.tpl
@@ -1,0 +1,7 @@
+{{- define "tc.v1.common.lib.cnpg.provider.s3.customCA.secret" -}}
+{{- $creds := .creds }}
+enabled: true
+data:
+  ca.crt: |-
+{{ $creds.customCA | indent 4 }}
+{{- end -}}

--- a/charts/library/common/templates/lib/cnpg/providers/_providerSecretSpawner.tpl
+++ b/charts/library/common/templates/lib/cnpg/providers/_providerSecretSpawner.tpl
@@ -30,4 +30,10 @@
   {{- with (include (printf "tc.v1.common.lib.cnpg.provider.%s.secret" $provider) (dict "creds" $creds) | fromYaml) -}}
     {{- $_ := set $rootCtx.Values.secret (printf "cnpg-%s-provider-%s-%s-creds" $objectData.shortName $type $provider) . -}}
   {{- end -}}
+
+  {{- if $creds.customCA -}}
+    {{- with (include (printf "tc.v1.common.lib.cnpg.provider.%s.customCA.secret" $provider) (dict "creds" $creds) | fromYaml) -}}
+      {{- $_ := set $rootCtx.Values.secret (printf "cnpg-%s-provider-%s-%s-ca" $objectData.shortName $type $provider) . -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -297,7 +297,6 @@ credentials:
   #   url: ""
   #   ## Provide a custom certificate authority in cases where the URL endpoint
   #   ## uses a self-signed certificate
-  #   ## NOTE: DEPRECATED, use customCASecretRef instead
   #   customCA: ""
   #   customCASecretRef:
   #     name: my-secret


### PR DESCRIPTION
**Description**

As a continuation of #40385 and #40000 I am now extending customCA and customCASecretRef support to work with CNPG backup/restore

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**

- Tested generation using `helm template` and inspecting the results
-  CI tests


**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [X] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
- [X] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
