### PR TITLE
fix(common): Improve Endpointslices

### DIFF
--- a/charts/library/common-test/tests/service/external_ip_test.yaml
+++ b/charts/library/common-test/tests/service/external_ip_test.yaml
@@ -122,14 +122,15 @@ tests:
         equal:
           path: metadata.labels
           value:
-            kubernetes.io/service-name: test-release-name-common-test
-            app.kubernetes.io/name: common-test
+            app: common-test-1.0.0
             app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: common-test
             app.kubernetes.io/version: *appVer
-            helm.sh/chart: common-test-1.0.0
+            endpointslice.kubernetes.io/managed-by: helm
             helm-revision: "0"
-            app: common-test-1.0.0
+            helm.sh/chart: common-test-1.0.0
+            kubernetes.io/service-name: test-release-name-common-test
             release: test-release-name
       - documentIndex: *endpointSliceDoc
         equal:
@@ -152,6 +153,8 @@ tests:
           value:
             - addresses:
                 - 1.1.1.1
+              conditions:
+                ready: true
 
   - it: should pass with type ExternalIP and https and useSlice explicitly set to true
     set:
@@ -201,9 +204,25 @@ tests:
           value:
             - addresses:
                 - 1.1.1.1
+              conditions:
+                ready: true
       - documentIndex: &serviceDoc 0
         isKind:
           of: Service
+      - documentIndex: *endpointSliceDoc
+        equal:
+          path: metadata.labels
+          value:
+            app: common-test-1.0.0
+            app.kubernetes.io/instance: test-release-name
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: common-test
+            app.kubernetes.io/version: *appVer
+            endpointslice.kubernetes.io/managed-by: helm
+            helm-revision: "0"
+            helm.sh/chart: common-test-1.0.0
+            kubernetes.io/service-name: test-release-name-common-test
+            release: test-release-name
 
   - it: should pass with type ExternalIP and useSlice set to false
     set:

--- a/charts/library/common-test/tests/service/external_ip_test.yaml
+++ b/charts/library/common-test/tests/service/external_ip_test.yaml
@@ -122,14 +122,15 @@ tests:
         equal:
           path: metadata.labels
           value:
-            kubernetes.io/service-name: test-release-name-common-test
-            app.kubernetes.io/name: common-test
+            app: common-test-1.0.0
             app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: common-test
             app.kubernetes.io/version: *appVer
-            helm.sh/chart: common-test-1.0.0
+            endpointslice.kubernetes.io/managed-by: helm
             helm-revision: "0"
-            app: common-test-1.0.0
+            helm.sh/chart: common-test-1.0.0
+            kubernetes.io/service-name: test-release-name-common-test
             release: test-release-name
       - documentIndex: *endpointSliceDoc
         equal:
@@ -208,6 +209,20 @@ tests:
       - documentIndex: &serviceDoc 0
         isKind:
           of: Service
+      - documentIndex: *endpointSliceDoc
+        equal:
+          path: metadata.labels
+          value:
+            app: common-test-1.0.0
+            app.kubernetes.io/instance: test-release-name
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: common-test
+            app.kubernetes.io/version: *appVer
+            endpointslice.kubernetes.io/managed-by: helm
+            helm-revision: "0"
+            helm.sh/chart: common-test-1.0.0
+            kubernetes.io/service-name: test-release-name-common-test
+            release: test-release-name
 
   - it: should pass with type ExternalIP and useSlice set to false
     set:

--- a/charts/library/common-test/tests/service/external_ip_test.yaml
+++ b/charts/library/common-test/tests/service/external_ip_test.yaml
@@ -122,15 +122,14 @@ tests:
         equal:
           path: metadata.labels
           value:
-            app: common-test-1.0.0
+            kubernetes.io/service-name: test-release-name-common-test
+            app.kubernetes.io/name: common-test
             app.kubernetes.io/instance: test-release-name
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: common-test
             app.kubernetes.io/version: *appVer
-            endpointslice.kubernetes.io/managed-by: helm
-            helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
-            kubernetes.io/service-name: test-release-name-common-test
+            helm-revision: "0"
+            app: common-test-1.0.0
             release: test-release-name
       - documentIndex: *endpointSliceDoc
         equal:
@@ -209,20 +208,6 @@ tests:
       - documentIndex: &serviceDoc 0
         isKind:
           of: Service
-      - documentIndex: *endpointSliceDoc
-        equal:
-          path: metadata.labels
-          value:
-            app: common-test-1.0.0
-            app.kubernetes.io/instance: test-release-name
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: common-test
-            app.kubernetes.io/version: *appVer
-            endpointslice.kubernetes.io/managed-by: helm
-            helm-revision: "0"
-            helm.sh/chart: common-test-1.0.0
-            kubernetes.io/service-name: test-release-name-common-test
-            release: test-release-name
 
   - it: should pass with type ExternalIP and useSlice set to false
     set:

--- a/charts/library/common-test/tests/service/external_ip_test.yaml
+++ b/charts/library/common-test/tests/service/external_ip_test.yaml
@@ -127,7 +127,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: common-test
             app.kubernetes.io/version: *appVer
-            endpointslice.kubernetes.io/managed-by: helm
+            endpointslice.kubernetes.io/managed-by: Helm
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             kubernetes.io/service-name: test-release-name-common-test
@@ -218,7 +218,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: common-test
             app.kubernetes.io/version: *appVer
-            endpointslice.kubernetes.io/managed-by: helm
+            endpointslice.kubernetes.io/managed-by: Helm
             helm-revision: "0"
             helm.sh/chart: common-test-1.0.0
             kubernetes.io/service-name: test-release-name-common-test

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -37,4 +37,4 @@ sources:
   - https://hub.docker.com/_/
   - https://hub.docker.com/r/mikefarah/yq
 type: library
-version: 28.26.2
+version: 28.26.3

--- a/charts/library/common/templates/class/_endpointSlice.tpl
+++ b/charts/library/common/templates/class/_endpointSlice.tpl
@@ -28,6 +28,7 @@ metadata:
   namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Endpoint Slice") }}
   {{- $labels := (mustMerge ($objectData.labels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $rootCtx | fromYaml)) -}}
   {{- $_ := set $labels "kubernetes.io/service-name" $objectData.name -}}
+  {{- $_ := set $labels "endpointslice.kubernetes.io/managed-by" "Helm" -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $rootCtx "labels" $labels) | trim) }}
   labels:
     {{- . | nindent 4 }}

--- a/charts/library/common/templates/class/_endpointSlice.tpl
+++ b/charts/library/common/templates/class/_endpointSlice.tpl
@@ -28,6 +28,7 @@ metadata:
   namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Endpoint Slice") }}
   {{- $labels := (mustMerge ($objectData.labels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $rootCtx | fromYaml)) -}}
   {{- $_ := set $labels "kubernetes.io/service-name" $objectData.name -}}
+  {{- $_ := set $labels "endpointslice.kubernetes.io/managed-by" "helm" -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $rootCtx "labels" $labels) | trim) }}
   labels:
     {{- . | nindent 4 }}

--- a/charts/library/common/templates/class/_endpointSlice.tpl
+++ b/charts/library/common/templates/class/_endpointSlice.tpl
@@ -28,7 +28,7 @@ metadata:
   namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Endpoint Slice") }}
   {{- $labels := (mustMerge ($objectData.labels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $rootCtx | fromYaml)) -}}
   {{- $_ := set $labels "kubernetes.io/service-name" $objectData.name -}}
-  {{- $_ := set $labels "endpointslice.kubernetes.io/managed-by" "helm" -}}
+  {{- $_ := set $labels "endpointslice.kubernetes.io/managed-by" "Helm" -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $rootCtx "labels" $labels) | trim) }}
   labels:
     {{- . | nindent 4 }}

--- a/charts/library/common/templates/class/_endpointSlice.tpl
+++ b/charts/library/common/templates/class/_endpointSlice.tpl
@@ -28,7 +28,7 @@ metadata:
   namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Endpoint Slice") }}
   {{- $labels := (mustMerge ($objectData.labels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $rootCtx | fromYaml)) -}}
   {{- $_ := set $labels "kubernetes.io/service-name" $objectData.name -}}
-  {{- $_ := set $labels "endpointslice.kubernetes.io/managed-by" "Helm" -}}
+  {{- $_ := set $labels "endpointslice.kubernetes.io/managed-by" "helm" -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $rootCtx "labels" $labels) | trim) }}
   labels:
     {{- . | nindent 4 }}

--- a/charts/library/common/templates/class/_endpointSlice.tpl
+++ b/charts/library/common/templates/class/_endpointSlice.tpl
@@ -28,7 +28,6 @@ metadata:
   namespace: {{ include "tc.v1.common.lib.metadata.namespace" (dict "rootCtx" $rootCtx "objectData" $objectData "caller" "Endpoint Slice") }}
   {{- $labels := (mustMerge ($objectData.labels | default dict) (include "tc.v1.common.lib.metadata.allLabels" $rootCtx | fromYaml)) -}}
   {{- $_ := set $labels "kubernetes.io/service-name" $objectData.name -}}
-  {{- $_ := set $labels "endpointslice.kubernetes.io/managed-by" "helm" -}}
   {{- with (include "tc.v1.common.lib.metadata.render" (dict "rootCtx" $rootCtx "labels" $labels) | trim) }}
   labels:
     {{- . | nindent 4 }}

--- a/charts/library/common/templates/lib/endpointSlice/_endpoints.tpl
+++ b/charts/library/common/templates/lib/endpointSlice/_endpoints.tpl
@@ -18,4 +18,7 @@ objectData: The object data of the service
   {{- end }}
 - addresses:
   - {{ tpl $objectData.externalIP $rootCtx }}
+    conditions:
+      ready: true
+      serving: true
 {{- end -}}

--- a/charts/library/common/templates/lib/endpointSlice/_endpoints.tpl
+++ b/charts/library/common/templates/lib/endpointSlice/_endpoints.tpl
@@ -18,7 +18,6 @@ objectData: The object data of the service
   {{- end }}
 - addresses:
   - {{ tpl $objectData.externalIP $rootCtx }}
-    conditions:
-      ready: true
-      serving: true
+  conditions:
+    ready: true
 {{- end -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Continuation of https://github.com/trueforge-org/truecharts/pull/37019

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Common tests added

**📃 Notes:**
<!-- Please enter any other relevant information here -->
Information:
https://kubernetes.io/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1/
https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/
https://kubernetes.io/docs/concepts/services-networking/service/#endpointslices

Regarding the added `conditions. ready` , nil value should be interpreted as "true", but I think it is good to set t explicity to "true".
Let me know when we want to do that as well for `serving`
```
endpoints.conditions (EndpointConditions)

conditions contains information about the current status of the endpoint.

EndpointConditions represents the current condition of an endpoint.

endpoints.conditions.ready (boolean)

ready indicates that this endpoint is ready to receive traffic, according to whatever system is managing the endpoint. A nil value should be interpreted as "true". In general, an endpoint should be marked ready if it is serving and not terminating, though this can be overridden in some cases, such as when the associated Service has set the publishNotReadyAddresses flag.

endpoints.conditions.serving (boolean)

serving indicates that this endpoint is able to receive traffic, according to whatever system is managing the endpoint. For endpoints backed by pods, the EndpointSlice controller will mark the endpoint as serving if the pod's Ready condition is True. A nil value should be interpreted as "true".

endpoints.conditions.terminating (boolean)

terminating indicates that this endpoint is terminating. A nil value should be interpreted as "false".
```

Ragarding the added `Label`. This one is not handled by the default labels of TrueCharts already and therefore good to add.
Upstream information:
```
For an EndpointSlice that you create yourself, or in your own code, you should also pick a value to use for the label [endpointslice.kubernetes.io/managed-by](https://kubernetes.io/docs/reference/labels-annotations-taints/#endpointslicekubernetesiomanaged-by). If you create your own controller code to manage EndpointSlices, consider using a value similar to "my-domain.example/name-of-controller". If you are using a third party tool, use the name of the tool in all-lowercase and change spaces and other punctuation to dashes (-). If people are directly using a tool such as kubectl to manage EndpointSlices, use a name that describes this manual management, such as "staff" or "cluster-admins". You should avoid using the reserved value "controller", which identifies EndpointSlices managed by Kubernetes' own control plane.
``` 

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
