### PR TITLE
fix(kavita): correct PVC mount point

### DIFF
--- a/charts/stable/kavita/Chart.yaml
+++ b/charts/stable/kavita/Chart.yaml
@@ -39,5 +39,5 @@ sources:
   - https://github.com/trueforge-org/truecharts/tree/master/charts/stable/kavita
   - https://www.kavitareader.com
 type: application
-version: 12.15.4
+version: 12.15.5
 

--- a/charts/stable/kavita/values.yaml
+++ b/charts/stable/kavita/values.yaml
@@ -17,7 +17,7 @@ service:
 persistence:
   config:
     enabled: true
-    mountPath: "/kavita/config"
+    mountPath: "/config"
   manga:
     enabled: true
     mountPath: "/manga"


### PR DESCRIPTION
**Description**

Kavita appears to have been updated to use the /config mount point rather than /kavita/config. It appears that the [linuxserver version](https://hub.docker.com/r/linuxserver/kavita#application-setup) uses the `/config` mapping while [most others](https://wiki.kavitareader.com/installation/docker/dockerhub/) use the `/kavita/config` mapping.

⚒️ Fixes https://discord.com/channels/830763548678291466/1451414257219666042

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**

I overrode the value in my personal deployment and the PVC mapping worked again, and the app started with the old data from when I first set up the application.

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

---
