### PR TITLE
fix(wyoming-whisper): change persistence and securitycontext to remove root

### DIFF
--- a/charts/stable/wyoming-whisper/Chart.yaml
+++ b/charts/stable/wyoming-whisper/Chart.yaml
@@ -37,4 +37,4 @@ sources:
   - https://github.com/trueforge-org/truecharts/tree/master/charts/stable/wyoming-whisper
   - https://hub.docker.com/r/rhasspy/wyoming-whisper
 type: application
-version: 9.2.5
+version: 10.0.0

--- a/charts/stable/wyoming-whisper/Chart.yaml
+++ b/charts/stable/wyoming-whisper/Chart.yaml
@@ -26,7 +26,7 @@ home: https://truecharts.org/charts/stable/wyoming-whisper
 icon: https://truecharts.org/img/hotlink-ok/chart-icons/wyoming-whisper.webp
 keywords:
   - wyoming-whisper
-kubeVersion: '>=1.24.0-0'
+kubeVersion: ">=1.24.0-0"
 maintainers:
   - name: TrueCharts
     email: info@truecharts.org
@@ -37,5 +37,4 @@ sources:
   - https://github.com/trueforge-org/truecharts/tree/master/charts/stable/wyoming-whisper
   - https://hub.docker.com/r/rhasspy/wyoming-whisper
 type: application
-version: 9.2.4
-
+version: 9.2.5

--- a/charts/stable/wyoming-whisper/values.yaml
+++ b/charts/stable/wyoming-whisper/values.yaml
@@ -2,13 +2,7 @@ image:
   repository: docker.io/rhasspy/wyoming-whisper
   pullPolicy: IfNotPresent
   tag: 3.0.2@sha256:995b37523bc422f4f7649e50ccded97a5b9bf6d1d0420591183a778dd5d7d3f2
-securityContext:
-  container:
-    readOnlyRootFilesystem: false
-    runAsNonRoot: false
-    runAsUser: 0
-    runAsGroup: 0
-    
+
 service:
   main:
     ports:
@@ -46,4 +40,4 @@ persistence:
     mountPath: /data
   cache:
     enabled: true
-    mountPath: /.cache/huggingface/hub
+    mountPath: /.cache/huggingface


### PR DESCRIPTION
**Description**
Removes need for root privileges by expanding the persistence a bit
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
It works on my cluster: [helmrelease.yaml](https://github.com/mgale456/ClusterTesting/blob/main/clusters/main/kubernetes/apps/whisper/app/helm-release.yaml)

**📃 Notes:**
huggingface has descriptions of their environment variables [here](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hfhome). There are more subdirectories under .cache/huggingface than just hub/, so that's why I'm making this change (see HF_XET_CACHE or HF_TOKEN_PATH as examples).

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
