### PR TITLE
chore(minecraft-proxy) fix supported java variants

### DIFF
--- a/charts/stable/minecraft-proxy/Chart.yaml
+++ b/charts/stable/minecraft-proxy/Chart.yaml
@@ -14,7 +14,7 @@ annotations:
   trueforge.org/min_helm_version: "3.14"
   trueforge.org/train: stable
 apiVersion: v2
-appVersion: 2025.1.0
+appVersion: 2025.10.0
 dependencies:
   - name: common
     version: 28.31.19
@@ -43,5 +43,4 @@ sources:
   - https://github.com/itzg/docker-mc-proxy
   - https://github.com/trueforge-org/truecharts/tree/master/charts/stable/minecraft-proxy
 type: application
-version: 2.15.0
-
+version: 2.16.0

--- a/charts/stable/minecraft-proxy/ci/j11-values.yaml
+++ b/charts/stable/minecraft-proxy/ci/j11-values.yaml
@@ -1,1 +1,0 @@
-imageSelector: j11Image

--- a/charts/stable/minecraft-proxy/ci/j17-values.yaml
+++ b/charts/stable/minecraft-proxy/ci/j17-values.yaml
@@ -1,0 +1,1 @@
+imageSelector: j17Image

--- a/charts/stable/minecraft-proxy/ci/j25-values.yaml
+++ b/charts/stable/minecraft-proxy/ci/j25-values.yaml
@@ -1,0 +1,1 @@
+imageSelector: j25Image

--- a/charts/stable/minecraft-proxy/values.yaml
+++ b/charts/stable/minecraft-proxy/values.yaml
@@ -1,15 +1,19 @@
 # yaml-language-server: $schema=./values.schema.json
 image:
   repository: ghcr.io/itzg/mc-proxy
-  tag: java21-2025.1.0@sha256:f47b506dcd5f841f24e7352b26cc50a335f2c6bff6bea44093c5684d3a22f05b
-  pullPolicy: Always
-j11Image:
-  repository: ghcr.io/itzg/mc-proxy
-  tag: java11-2025.1.0@sha256:67fece141aa6f8c8d7b8c04e9cb04d53964de1f14667452fb454f674f141d42c
+  tag: 2025.10.0-java21@sha256:28a4f84f538cee00099cee8370b075594b258f93c5feeaefb0fde736aa9636ab
   pullPolicy: Always
 j8Image:
   repository: ghcr.io/itzg/mc-proxy
-  tag: java8-2025.1.0@sha256:b4f65bb8e38744298877bcc3010b069143436f0db2736edbe630dbdf9004dd7f
+  tag: 2025.10.0-java8@sha256:4d4639ec1e3f74723e6a4174dcb9d861b08ec07635b9e891c4660c5baa952dfa
+  pullPolicy: Always
+j17Image:
+  repository: ghcr.io/itzg/mc-proxy
+  tag: 2025.10.0-java17@sha256:7043620f1ac866e86fee922c1c22a035800db95c2fe511778de4f22ac19e9f19
+  pullPolicy: Always
+j25Image:
+  repository: ghcr.io/itzg/mc-proxy
+  tag: 2025.10.0-java25@sha256:0737c64aac9a090a37c282ef1c2dba90b202fa3f2c9ffc0157df3b61fa2d0334
   pullPolicy: Always
 service:
   main:


### PR DESCRIPTION
**Description**
minecraft-proxy dropped support for java11 and added support for other java variants.
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
- [X] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
