### PR TITLE
fix(docs): Fix typo in README.md.tpl for issue link

### DIFF
--- a/templates/README.md.tpl
+++ b/templates/README.md.tpl
@@ -38,7 +38,7 @@ For information about the common chart and all defaults included with it, please
 
 - See the [Website](https://trueforge.org)
 - Check our [Discord](https://discord.gg/tVsPTHWTtr)
-- Open a [issue](https://github.com/trueforge-org/truecharts/issues/new/choose)
+- Open an [issue](https://github.com/trueforge-org/truecharts/issues/new/choose)
 
 ---
 


### PR DESCRIPTION
This PR fixes a small grammar issue in the README.

Changed "Open a issue" to "Open an issue".
No functional changes.

