### PR TITLE
fix(common): Use gateway.networking.k8s.io/v1 for httpRoute

### DIFF
--- a/.github/workflows/common-tests.yaml
+++ b/.github/workflows/common-tests.yaml
@@ -144,7 +144,7 @@ jobs:
       matrix:
         # We test the latest k3s version and the lowest supported
         k3s-version:
-          - v1.27
+          - v1.28
           - v1.35
           - latest
         # We test the latest helm version and the lowest supported

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -50,5 +50,4 @@ sources:
   - https://github.com/trueforge-org/truecharts/tree/master/charts/library/common
   - https://hub.docker.com/_/
 type: library
-version: 28.33.2
-
+version: 28.33.3

--- a/charts/library/common/templates/class/_route.tpl
+++ b/charts/library/common/templates/class/_route.tpl
@@ -31,7 +31,7 @@ within the common library.
 {{- $defaultServicePort := get $primaryService.ports (include "tc.v1.common.lib.util.service.ports.primary" (dict "svcValues" $primaryService "rootCtx" $)) }}
 
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 {{- if and (ne $routeKind "GRPCRoute") (ne $routeKind "HTTPRoute") (ne $routeKind "TCPRoute") (ne $routeKind "TLSRoute") (ne $routeKind "UDPRoute") -}}
   {{- fail (printf "Not a valid route kind (%s)" $routeKind) -}}
 {{- end }}


### PR DESCRIPTION

**Description**

Deploying a httpRoute with the current common chart results in an error:

    no matches for kind "HTTPRoute" in version "gateway.networking.k8s.io/v1alpha2"

This PR changes the version used for httpRoutes to `gateway.networking.k8s.io/v1`

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**

I'm using httpRoutes with `gateway.networking.k8s.io/v1` already on my cluster.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

* HTTPRoute v1 is GA since [gateway-api v1.0.0](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.0.0) (released 2023-10-31). 
* `v1alpha2` is removed already in [gateway-api v0.8.0](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.8.0) (released 2023-08).
* Tested on a k3s cluster `v1.35.0+k3s1`

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`


