### PR TITLE
feat(blocky): k8sgateway add HTTPRoute resource to watch

### DIFF
--- a/charts/stable/blocky/Chart.yaml
+++ b/charts/stable/blocky/Chart.yaml
@@ -51,5 +51,4 @@ sources:
   - https://github.com/Mozart409/blocky-frontend
   - https://github.com/trueforge-org/truecharts/tree/master/charts/stable/blocky
 type: application
-version: 19.15.2
-
+version: 19.16.0

--- a/charts/stable/blocky/Chart.yaml
+++ b/charts/stable/blocky/Chart.yaml
@@ -51,5 +51,5 @@ sources:
   - https://github.com/Mozart409/blocky-frontend
   - https://github.com/trueforge-org/truecharts/tree/master/charts/stable/blocky
 type: application
-version: 19.15.1
+version: 19.15.2
 

--- a/charts/stable/blocky/values.yaml
+++ b/charts/stable/blocky/values.yaml
@@ -283,7 +283,7 @@ serviceAccount:
     primary: true
 
 # -- Create a ClusterRole and ClusterRoleBinding
-# @default -- See below
+# used by k8sgateway
 rbac:
   main:
     # -- Enables or disables the ClusterRole and ClusterRoleBinding
@@ -292,14 +292,16 @@ rbac:
     clusterWide: true
     # -- Set Rules on the ClusterRole
     rules:
+      # General CRDs
       - apiGroups:
-          - ""
+          - apiextensions.k8s.io
         resources:
-          - services
-          - namespaces
+          - customresourcedefinitions
         verbs:
+          - get
           - list
           - watch
+      # Ingress
       - apiGroups:
           - extensions
           - networking.k8s.io
@@ -308,13 +310,48 @@ rbac:
         verbs:
           - list
           - watch
+      # Service    
+      - apiGroups:
+          - ""
+        resources:
+          - services
+          - namespaces
+        verbs:
+          - list
+          - watch
+      # HTTPRoute, TLSRoute, GRPCRoute
+      - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - "*"
+        verbs:
+          - watch
+          - list
+      # DNSEndpoint
+      - apiGroups:
+          - externaldns.k8s.io
+        resources:
+          - dnsendpoints
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - externaldns.k8s.io
+        resources:
+          - dnsendpoints/status
+        verbs:
+          - "*"      
 
 k8sgateway:
   enabled: true
   # -- TTL for non-apex responses (in seconds)
   ttl: 300
-  # -- Limit what kind of resources to watch, e.g. watchedResources: ["Ingress"]
-  watchedResources: []
+  # -- Limit what kind of resources to watch, e.g. watchedResources: [ Ingress | Service | HTTPRoute | TLSRoute | GRPCRoute | DNSEndpoint ]
+  watchedResources:
+    - Ingress
+    - Service
+    - HTTPRoute
   # -- Service name of a secondary DNS server (should be `serviceName.namespace`)
   secondary: ""
   # -- Override the default `serviceName.namespace` domain apex
@@ -402,7 +439,7 @@ metrics:
 
 redis:
   enabled: true
-# CANNOT be defined in above yaml section
+
 queryLog:
   # optional one of: mysql, postgresql, csv, csv-client. If empty, log to console
   type: "postgresql"


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Change rbac and recources to watch, so also HTTPRoute are now added automatically.
Rbac according to:
https://github.com/k8s-gateway/k8s_gateway/pkgs/container/k8s_gateway

Resources is now specifically set, as if no resources are specified only Ingress and Service will be monitored

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
on own cluster

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
