### PR TITLE
fix(grafana): Reduce default Grafana k8s-sidecar resources

### DIFF
--- a/charts/stable/grafana/Chart.yaml
+++ b/charts/stable/grafana/Chart.yaml
@@ -39,5 +39,4 @@ sources:
   - https://grafana.com/
   - https://hub.docker.com/r/grafana/grafana
 type: application
-version: 22.0.0
-
+version: 22.0.1

--- a/charts/stable/grafana/values.yaml
+++ b/charts/stable/grafana/values.yaml
@@ -216,8 +216,8 @@ workload:
               cpu: 10m
               memory: 128Mi
             limits:
-              cpu: 50m
-              memory: 512Mi
+              cpu: 1000m
+              memory: 1536Mi
         datasources:
           enabled: true
           imageSelector: sidecarImage
@@ -253,8 +253,8 @@ workload:
               cpu: 10m
               memory: 128Mi
             limits:
-              cpu: 50m
-              memory: 512Mi
+              cpu: 1000m
+              memory: 1536Mi
         alerts:
           enabled: true
           imageSelector: sidecarImage
@@ -290,8 +290,8 @@ workload:
               cpu: 10m
               memory: 128Mi
             limits:
-              cpu: 50m
-              memory: 512Mi
+              cpu: 1000m
+              memory: 1536Mi
         plugins:
           enabled: true
           imageSelector: sidecarImage
@@ -327,8 +327,8 @@ workload:
               cpu: 10m
               memory: 128Mi
             limits:
-              cpu: 50m
-              memory: 512Mi
+              cpu: 1000m
+              memory: 1536Mi
         notifiers:
           enabled: true
           imageSelector: sidecarImage
@@ -364,8 +364,8 @@ workload:
               cpu: 10m
               memory: 128Mi
             limits:
-              cpu: 50m
-              memory: 512Mi
+              cpu: 1000m
+              memory: 1536Mi
 
 configmap:
   dashboard-provider:

--- a/charts/stable/grafana/values.yaml
+++ b/charts/stable/grafana/values.yaml
@@ -214,7 +214,7 @@ workload:
           resources:
             requests:
               cpu: 10m
-              memory: 256Mi
+              memory: 128Mi
             limits:
               cpu: 50m
               memory: 512Mi
@@ -251,7 +251,7 @@ workload:
           resources:
             requests:
               cpu: 10m
-              memory: 256Mi
+              memory: 128Mi
             limits:
               cpu: 50m
               memory: 512Mi
@@ -288,7 +288,7 @@ workload:
           resources:
             requests:
               cpu: 10m
-              memory: 256Mi
+              memory: 128Mi
             limits:
               cpu: 50m
               memory: 512Mi
@@ -325,7 +325,7 @@ workload:
           resources:
             requests:
               cpu: 10m
-              memory: 256Mi
+              memory: 128Mi
             limits:
               cpu: 50m
               memory: 512Mi
@@ -362,7 +362,7 @@ workload:
           resources:
             requests:
               cpu: 10m
-              memory: 256Mi
+              memory: 128Mi
             limits:
               cpu: 50m
               memory: 512Mi

--- a/charts/stable/grafana/values.yaml
+++ b/charts/stable/grafana/values.yaml
@@ -211,6 +211,13 @@ workload:
               enabled: false
             startup:
               enabled: false
+          resources:
+            requests:
+              cpu: 10m
+              memory: 256Mi
+            limits:
+              cpu: 50m
+              memory: 512Mi
         datasources:
           enabled: true
           imageSelector: sidecarImage
@@ -241,6 +248,13 @@ workload:
               enabled: false
             startup:
               enabled: false
+          resources:
+            requests:
+              cpu: 10m
+              memory: 256Mi
+            limits:
+              cpu: 50m
+              memory: 512Mi
         alerts:
           enabled: true
           imageSelector: sidecarImage
@@ -271,6 +285,13 @@ workload:
               enabled: false
             startup:
               enabled: false
+          resources:
+            requests:
+              cpu: 10m
+              memory: 256Mi
+            limits:
+              cpu: 50m
+              memory: 512Mi
         plugins:
           enabled: true
           imageSelector: sidecarImage
@@ -301,6 +322,13 @@ workload:
               enabled: false
             startup:
               enabled: false
+          resources:
+            requests:
+              cpu: 10m
+              memory: 256Mi
+            limits:
+              cpu: 50m
+              memory: 512Mi
         notifiers:
           enabled: true
           imageSelector: sidecarImage
@@ -331,6 +359,13 @@ workload:
               enabled: false
             startup:
               enabled: false
+          resources:
+            requests:
+              cpu: 10m
+              memory: 256Mi
+            limits:
+              cpu: 50m
+              memory: 512Mi
 
 configmap:
   dashboard-provider:

--- a/charts/stable/grafana/values.yaml
+++ b/charts/stable/grafana/values.yaml
@@ -216,7 +216,7 @@ workload:
               cpu: 10m
               memory: 128Mi
             limits:
-              cpu: 1000m
+              cpu: 200m
               memory: 1536Mi
         datasources:
           enabled: true
@@ -253,7 +253,7 @@ workload:
               cpu: 10m
               memory: 128Mi
             limits:
-              cpu: 1000m
+              cpu: 200m
               memory: 1536Mi
         alerts:
           enabled: true
@@ -290,7 +290,7 @@ workload:
               cpu: 10m
               memory: 128Mi
             limits:
-              cpu: 1000m
+              cpu: 200m
               memory: 1536Mi
         plugins:
           enabled: true
@@ -327,7 +327,7 @@ workload:
               cpu: 10m
               memory: 128Mi
             limits:
-              cpu: 1000m
+              cpu: 200m
               memory: 1536Mi
         notifiers:
           enabled: true
@@ -364,7 +364,7 @@ workload:
               cpu: 10m
               memory: 128Mi
             limits:
-              cpu: 1000m
+              cpu: 200m
               memory: 1536Mi
 
 configmap:


### PR DESCRIPTION
**Description**

The default Grafana chart requests and limits for the `k8s-sidecar` containers are a bit over the top:

```bash
kubectl resource-capacity --namespace grafana --pods -uc 
NODE            POD                       CONTAINER             CPU REQUESTS   CPU LIMITS     CPU UTIL   MEMORY REQUESTS   MEMORY LIMITS   MEMORY UTIL

...                                                                                                                                         
k8s-control-1   grafana-9554bbdd8-ph6vq   grafana-alerts        75m (0%)       1500m (10%)    2m (0%)    200Mi (0%)        2400Mi (2%)     272Mi (0%)
k8s-control-1   grafana-9554bbdd8-ph6vq   grafana-dashboards    75m (0%)       1500m (10%)    1m (0%)    200Mi (0%)        2400Mi (2%)     275Mi (0%)
k8s-control-1   grafana-9554bbdd8-ph6vq   grafana-datasources   75m (0%)       1500m (10%)    1m (0%)    200Mi (0%)        2400Mi (2%)     272Mi (0%)
k8s-control-1   grafana-9554bbdd8-ph6vq   grafana-notifiers     75m (0%)       1500m (10%)    1m (0%)    200Mi (0%)        2400Mi (2%)     272Mi (0%)
k8s-control-1   grafana-9554bbdd8-ph6vq   grafana-plugins       75m (0%)       1500m (10%)    1m (0%)    200Mi (0%)        2400Mi (2%)     272Mi (0%)
...
```

I have never seen them use more than 10m CPU or go over 300Mi of memory. 

So I think it makes sense to assign lower default resources than what the `common` defaults are.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [X] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
