### PR TITLE
fix(authentik): Reduce authentik wait-server requests and limits

### DIFF
--- a/charts/stable/authentik/Chart.yaml
+++ b/charts/stable/authentik/Chart.yaml
@@ -39,5 +39,4 @@ sources:
   - https://github.com/trueforge-org/truecharts/tree/master/charts/stable/authentik
   - https://goauthentik.io/docs/
 type: application
-version: 40.0.1
-
+version: 40.0.2

--- a/charts/stable/authentik/Chart.yaml
+++ b/charts/stable/authentik/Chart.yaml
@@ -46,5 +46,4 @@ sources:
   - https://github.com/trueforge-org/truecharts/tree/master/charts/stable/authentik
   - https://goauthentik.io/docs/
 type: application
-version: 40.0.0
-
+version: 40.0.1

--- a/charts/stable/authentik/templates/_waitAuthentik.tpl
+++ b/charts/stable/authentik/templates/_waitAuthentik.tpl
@@ -17,4 +17,11 @@ args:
 
     echo "Authentik [{{ $serverUrl }}] is ready..."
     echo "Starting Outpost..."
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 10m
+    memory: 50Mi
 {{- end -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

Authentik's 'wait-server' init container has no `resources` section specified and this inherits the default common resource requests and limits. These are needlessly large for what the container is - a bash script.

This PR adds more conservative limits - matched to the limits specified for the `cnpg-wait` init container in common. 

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

CI

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
