### PR TITLE
fix(common): volsync render error access modes string

### DIFF
--- a/charts/library/common-test/tests/volsync/replication_dest_spec_test.yaml
+++ b/charts/library/common-test/tests/volsync/replication_dest_spec_test.yaml
@@ -82,6 +82,147 @@ tests:
                 runAsUser: 568
                 runAsGroup: 568
 
+  - it: should generate correct spec with accessModes as a list
+    set:
+      persistence:
+        destbackup:
+          enabled: true
+          type: pvc
+          mountPath: /backedup
+          accessModes:
+            - ReadWriteOncePod
+            - ReadWriteOnce
+          volsync:
+            - name: mybackup1
+              type: restic
+              credentials: mys3
+              dest:
+                enabled: true
+              src:
+                enabled: false
+      credentials:
+        mys3:
+          type: s3
+          url: https://s3.some-url
+          bucket: some-bucket
+          encrKey: some-key
+          accessKey: some-access-key
+          secretKey: some-secret-key
+    asserts:
+      - documentIndex: *secretDoc
+        isKind:
+          of: Secret
+      - documentIndex: *secretDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-destbackup-volsync-mybackup1
+      - documentIndex: *secretDoc
+        equal:
+          path: stringData
+          value:
+            AWS_ACCESS_KEY_ID: some-access-key
+            AWS_SECRET_ACCESS_KEY: some-secret-key
+            RESTIC_PASSWORD: some-key
+            RESTIC_REPOSITORY: s3:s3.some-url/some-bucket/test-release-name/volsync/destbackup-volsync-mybackup1
+      - documentIndex: *replicationDestDoc
+        isKind:
+          of: ReplicationDestination
+      - documentIndex: *replicationDestDoc
+        isAPIVersion:
+          of: volsync.backube/v1alpha1
+      - documentIndex: *replicationDestDoc
+        equal:
+          path: spec
+          value:
+            trigger:
+              manual: restore-once
+            restic:
+              repository: test-release-name-common-test-destbackup-volsync-mybackup1
+              copyMethod: Snapshot
+              cleanupTempPVC: false
+              cleanupCachePVC: false
+              cacheCapacity: 10Gi
+              capacity: 100Gi
+              accessModes:
+                - ReadWriteOncePod
+                - ReadWriteOnce
+              moverSecurityContext:
+                fsGroup: 568
+                runAsUser: 568
+                runAsGroup: 568
+
+  - it: should generate correct spec with accessModes as a string
+    set:
+      persistence:
+        destbackup:
+          enabled: true
+          type: pvc
+          mountPath: /backedup
+          accessModes: ReadWriteOncePod
+          volsync:
+            - name: mybackup1
+              type: restic
+              credentials: mys3
+              dest:
+                enabled: true
+              src:
+                enabled: false
+      credentials:
+        mys3:
+          type: s3
+          url: https://s3.some-url
+          bucket: some-bucket
+          encrKey: some-key
+          accessKey: some-access-key
+          secretKey: some-secret-key
+    asserts:
+      - documentIndex: *secretDoc
+        isKind:
+          of: Secret
+      - documentIndex: *secretDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretDoc
+        equal:
+          path: metadata.name
+          value: test-release-name-common-test-destbackup-volsync-mybackup1
+      - documentIndex: *secretDoc
+        equal:
+          path: stringData
+          value:
+            AWS_ACCESS_KEY_ID: some-access-key
+            AWS_SECRET_ACCESS_KEY: some-secret-key
+            RESTIC_PASSWORD: some-key
+            RESTIC_REPOSITORY: s3:s3.some-url/some-bucket/test-release-name/volsync/destbackup-volsync-mybackup1
+      - documentIndex: *replicationDestDoc
+        isKind:
+          of: ReplicationDestination
+      - documentIndex: *replicationDestDoc
+        isAPIVersion:
+          of: volsync.backube/v1alpha1
+      - documentIndex: *replicationDestDoc
+        equal:
+          path: spec
+          value:
+            trigger:
+              manual: restore-once
+            restic:
+              repository: test-release-name-common-test-destbackup-volsync-mybackup1
+              copyMethod: Snapshot
+              cleanupTempPVC: false
+              cleanupCachePVC: false
+              cacheCapacity: 10Gi
+              capacity: 100Gi
+              accessModes:
+                - ReadWriteOncePod
+              moverSecurityContext:
+                fsGroup: 568
+                runAsUser: 568
+                runAsGroup: 568
+
   - it: should generate correct spec with overridden region
     set:
       persistence:

--- a/charts/library/common-test/tests/volsync/replication_dest_spec_test.yaml
+++ b/charts/library/common-test/tests/volsync/replication_dest_spec_test.yaml
@@ -149,6 +149,13 @@ tests:
               accessModes:
                 - ReadWriteOncePod
                 - ReadWriteOnce
+              moverResources:
+                limits:
+                  cpu: 1500m
+                  memory: 2400Mi
+                requests:
+                  cpu: 75m
+                  memory: 200Mi
               moverSecurityContext:
                 fsGroup: 568
                 runAsUser: 568
@@ -218,6 +225,13 @@ tests:
               capacity: 100Gi
               accessModes:
                 - ReadWriteOncePod
+              moverResources:
+                limits:
+                  cpu: 1500m
+                  memory: 2400Mi
+                requests:
+                  cpu: 75m
+                  memory: 200Mi
               moverSecurityContext:
                 fsGroup: 568
                 runAsUser: 568

--- a/charts/library/common-test/tests/volsync/replication_src_spec_test.yaml
+++ b/charts/library/common-test/tests/volsync/replication_src_spec_test.yaml
@@ -89,6 +89,161 @@ tests:
           path: spec.restic.unlock
           pattern: "^[0-9]{14}$"
 
+  - it: should generate correct spec with accessModes as a list
+    set:
+      persistence:
+        srcbackup:
+          enabled: true
+          type: pvc
+          mountPath: /backedup
+          accessModes:
+            - ReadWriteOncePod
+            - ReadWriteOnce
+          volsync:
+            - name: mybackup1
+              type: restic
+              credentials: mys3
+              dest:
+                enabled: false
+              src:
+                enabled: true
+      credentials:
+        mys3:
+          type: s3
+          url: http://some-url
+          bucket: some-bucket
+          encrKey: some-key
+          accessKey: some-access-key
+          secretKey: some-secret-key
+    asserts:
+      - documentIndex: *secretDoc
+        isKind:
+          of: Secret
+      - documentIndex: *secretDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretDoc
+        equal:
+          path: stringData
+          value:
+            AWS_ACCESS_KEY_ID: some-access-key
+            AWS_SECRET_ACCESS_KEY: some-secret-key
+            RESTIC_PASSWORD: some-key
+            RESTIC_REPOSITORY: s3:http://some-url/some-bucket/test-release-name/volsync/srcbackup-volsync-mybackup1
+      - documentIndex: *replicationDestDoc
+        isKind:
+          of: ReplicationSource
+      - documentIndex: *replicationDestDoc
+        isAPIVersion:
+          of: volsync.backube/v1alpha1
+      - documentIndex: *replicationDestDoc
+        isSubset:
+          path: spec
+          content:
+            sourcePVC: test-release-name-common-test-srcbackup
+            trigger:
+              schedule: "0 0 * * *"
+      - documentIndex: *replicationDestDoc
+        isSubset:
+          path: spec.restic
+          content:
+            repository: test-release-name-common-test-srcbackup-volsync-mybackup1
+            copyMethod: Snapshot
+            pruneIntervalDays: 7
+            retain:
+              hourly: 6
+              daily: 5
+              weekly: 4
+              monthly: 3
+              yearly: 1
+            accessModes:
+              - ReadWriteOncePod
+              - ReadWriteOnce
+            moverSecurityContext:
+              fsGroup: 568
+              runAsUser: 568
+              runAsGroup: 568
+      - documentIndex: *replicationDestDoc
+        matchRegex:
+          path: spec.restic.unlock
+          pattern: "^[0-9]{14}$"
+
+  - it: should generate correct spec with accessModes as a string
+    set:
+      persistence:
+        srcbackup:
+          enabled: true
+          type: pvc
+          mountPath: /backedup
+          accessModes: ReadWriteOncePod
+          volsync:
+            - name: mybackup1
+              type: restic
+              credentials: mys3
+              dest:
+                enabled: false
+              src:
+                enabled: true
+      credentials:
+        mys3:
+          type: s3
+          url: http://some-url
+          bucket: some-bucket
+          encrKey: some-key
+          accessKey: some-access-key
+          secretKey: some-secret-key
+    asserts:
+      - documentIndex: *secretDoc
+        isKind:
+          of: Secret
+      - documentIndex: *secretDoc
+        isAPIVersion:
+          of: v1
+      - documentIndex: *secretDoc
+        equal:
+          path: stringData
+          value:
+            AWS_ACCESS_KEY_ID: some-access-key
+            AWS_SECRET_ACCESS_KEY: some-secret-key
+            RESTIC_PASSWORD: some-key
+            RESTIC_REPOSITORY: s3:http://some-url/some-bucket/test-release-name/volsync/srcbackup-volsync-mybackup1
+      - documentIndex: *replicationDestDoc
+        isKind:
+          of: ReplicationSource
+      - documentIndex: *replicationDestDoc
+        isAPIVersion:
+          of: volsync.backube/v1alpha1
+      - documentIndex: *replicationDestDoc
+        isSubset:
+          path: spec
+          content:
+            sourcePVC: test-release-name-common-test-srcbackup
+            trigger:
+              schedule: "0 0 * * *"
+      - documentIndex: *replicationDestDoc
+        isSubset:
+          path: spec.restic
+          content:
+            repository: test-release-name-common-test-srcbackup-volsync-mybackup1
+            copyMethod: Snapshot
+            pruneIntervalDays: 7
+            retain:
+              hourly: 6
+              daily: 5
+              weekly: 4
+              monthly: 3
+              yearly: 1
+            accessModes:
+              - ReadWriteOncePod
+            moverSecurityContext:
+              fsGroup: 568
+              runAsUser: 568
+              runAsGroup: 568
+      - documentIndex: *replicationDestDoc
+        matchRegex:
+          path: spec.restic.unlock
+          pattern: "^[0-9]{14}$"
+
   - it: should generate correct spec with overridden region
     set:
       persistence:

--- a/charts/library/common-test/tests/volsync/replication_src_spec_test.yaml
+++ b/charts/library/common-test/tests/volsync/replication_src_spec_test.yaml
@@ -159,6 +159,13 @@ tests:
             accessModes:
               - ReadWriteOncePod
               - ReadWriteOnce
+            moverResources:
+              limits:
+                cpu: 1500m
+                memory: 2400Mi
+              requests:
+                cpu: 75m
+                memory: 200Mi
             moverSecurityContext:
               fsGroup: 568
               runAsUser: 568
@@ -235,6 +242,13 @@ tests:
               yearly: 1
             accessModes:
               - ReadWriteOncePod
+            moverResources:
+              limits:
+                cpu: 1500m
+                memory: 2400Mi
+              requests:
+                cpu: 75m
+                memory: 200Mi
             moverSecurityContext:
               fsGroup: 568
               runAsUser: 568

--- a/charts/library/common/templates/lib/volsync/_storage.tpl
+++ b/charts/library/common/templates/lib/volsync/_storage.tpl
@@ -13,6 +13,9 @@
   {{- if $target.accessModes }}
     {{- $accessModes = $target.accessModes }}
   {{- end }}
+  {{- if kindIs "string" $accessModes -}}
+    {{- $accessModes = (list $accessModes) -}}
+  {{- end -}}
 
   {{- $storageClassName := $rootCtx.Values.global.fallbackDefaults.storageClass -}}
   {{- if $objectData.storageClass }}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes volsync resources when the `accessModes` on the persistence object is set to a string. ` executing "tc.v1.common.lib.volsync.storage" at <$accessModes>: range can't iterate over ReadWriteOncePod`

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Added tests to cover `accessModes` being set to both a string and an array.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
